### PR TITLE
fix checkouts of standing data for tests on Windows, enable vcpkg on macOS and Linux

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.log   eol=lf
+*.out   eol=lf
+*.fot   eol=lf
+*.tex   eol=lf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,7 +797,7 @@ dependencies = [
  "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1296,7 +1296,7 @@ dependencies = [
  "tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "zip 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1596,7 +1596,7 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1869,7 +1869,7 @@ dependencies = [
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum utf8-ranges 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9d50aa7650df78abf942826607c62468ce18d9019673d4a2ebe1865dbb96ffde"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
-"checksum vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d"
+"checksum vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "797464475f30ddb8830cc529aaaae648d581f99e2036a928877dfde027ddf6b3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,9 +37,9 @@ cc = "^1.0"
 pkg-config = "^0.3"  # note: sync dist/docker/*/pkg-config-rs.sh with the version in Cargo.lock
 regex = "^1.1"
 sha2 = "^0.8"
+vcpkg = "0.2.7"
 
 [target.'cfg(target_env = "msvc")'.build-dependencies]
-vcpkg = "0.2.6"
 
 [dependencies]
 aho-corasick = "^0.7"

--- a/build.rs
+++ b/build.rs
@@ -6,7 +6,6 @@
 
 use cc;
 use pkg_config;
-#[cfg(target_env = "msvc")]
 use vcpkg;
 
 use std::env;
@@ -16,41 +15,43 @@ use std::path::PathBuf;
 #[cfg(target_os = "macos")]
 const LIBS: &'static str = "harfbuzz >= 1.4 harfbuzz-icu icu-uc freetype2 graphite2 libpng zlib";
 
+#[cfg(target_os = "macos")]
+const VCPKG_LIBS: &[&'static str] = &["harfbuzz", "freetype"];
+
 #[cfg(not(target_os = "macos"))]
 const LIBS: &'static str =
     "fontconfig harfbuzz >= 1.4 harfbuzz-icu icu-uc freetype2 graphite2 libpng zlib";
 
-#[cfg(target_os = "windows")]
-#[allow(dead_code)]
-const VCPKG_LIBS: &[&'static str] = &[
-    "fontconfig", "harfbuzz", "icu", "libpng", "zlib", "freetype", "graphite2"];
-//FIXME: it should actually be harfbuzz[graphite2,icu], but currently vcpkg-rs doesn't support features.
+#[cfg(not(target_os = "macos"))]
+const VCPKG_LIBS: &[&'static str] = &["fontconfig", "harfbuzz", "freetype"];
+// Need a way to check that the vcpkg harfbuzz port has graphite2 and icu options enabled.
 
-#[cfg(target_env = "msvc")]
-fn load_vcpkg_deps(include_paths: &mut Vec<PathBuf>) -> bool {
+fn load_vcpkg_deps(include_paths: &mut Vec<PathBuf>) {
     for dep in VCPKG_LIBS {
         let library = 
             vcpkg::find_package(dep).expect("failed to load package from vcpkg");
         include_paths.extend(library.include_paths.iter().cloned());
     }
-    true
-}
-
-#[cfg(not(target_env = "msvc"))]
-fn load_vcpkg_deps(_include_paths: &mut Vec<PathBuf>) -> bool {
-    false
 }
 
 fn main() {
-    // We (have to) rerun the search again below to emit the metadata at the right time.
+    let target = env::var("TARGET").unwrap();
+    let rustflags = env::var("RUSTFLAGS").unwrap_or(String::new());
 
     let use_vcpkg = env::var("TECTONIC_VCPKG").is_ok();
     let mut deps = None;
     let mut vcpkg_includes = vec![];
-    if cfg!(target_env = "msvc") && use_vcpkg {
+    if use_vcpkg {
         load_vcpkg_deps(&mut vcpkg_includes);
         eprintln!("{:?}", vcpkg_includes);
+
+        if target.contains("-linux-") {
+            // add icudata to the end of the list of libs as vcpkg-rs does not
+            // order individual libraries as a single pass linker requires
+            println!("cargo:rustc-link-lib=icudata");
+        }
     } else {
+        // We (have to) rerun the search again below to emit the metadata at the right time.
         let deps_library = pkg_config::Config::new()
             .cargo_metadata(false)
             .probe(LIBS)
@@ -284,9 +285,13 @@ fn main() {
         cppcfg.define("WORDS_BIGENDIAN", "1");
     }
 
-    if cfg!(target_env = "msvc") {
+    if target.contains("-msvc") {
         ccfg.flag("/EHsc");
         cppcfg.flag("/EHsc");
+        if rustflags.contains("+crt-static"){
+            ccfg.define("GRAPHITE2_STATIC", None);
+            cppcfg.define("GRAPHITE2_STATIC", None);
+        }
     }
 
     // OK, back to generic build rules.


### PR DESCRIPTION
This fixes the issue with the line endings in the test data getting changed to CRLF when it is checked out on Windows, by adding a `.gitattributes` file. This does not update an existing checkout so it is probably necessary to delete the `tests/` directory and check it out again to get the unchanged versions. (This is particularly painful if you clone the repo and `.gitattributes` is not on the master branch yet - git will not change the line endings as you change branches.)

vcpkg 0.2.7 adds support for Linux and macOS so I enabled it for them also. Windows (msvc) works for static and dynamic builds, and Linux and macOS work for static builds.

For a Windows static build I used:
```
.\vcpkg install --triplet x64-windows-static fontconfig freetype harfbuzz[icu,graphite2]
set VCPKG_ROOT=<wherever>
set TECTONIC_VCPKG=1
set RUSTFLAGS=-Ctarget-feature=+crt-static
```

For a Linux static build I used:
```
./vcpkg install fontconfig freetype harfbuzz\[icu,graphite2\]
set VCPKG_ROOT=<wherever>
set TECTONIC_VCPKG=1
```

For a macOS static build I used:
```
./vcpkg install freetype harfbuzz\[icu,graphite2\]
set VCPKG_ROOT=<wherever>
set TECTONIC_VCPKG=1
```

For a Windows dynamic build I used:
```
.\vcpkg install --triplet x64-windows fontconfig freetype harfbuzz[icu,graphite2]
set VCPKG_ROOT=<wherever>
set TECTONIC_VCPKG=1
set VCPKGRS_DYNAMIC=1
```
