### PR TITLE
Move some declarations to imports

### DIFF
--- a/engine/src/bibtex.rs
+++ b/engine/src/bibtex.rs
@@ -7,6 +7,7 @@
          unused_mut)]
 
 extern crate libc;
+use libc::free;
 extern "C" {
     /* tectonic/core-bridge.h: declarations of C/C++ => Rust bridge API
        Copyright 2016-2018 the Tectonic Project
@@ -49,8 +50,6 @@ extern "C" {
     fn strlen(_: *const i8) -> u64;
     #[no_mangle]
     fn strcpy(_: *mut i8, _: *const i8) -> *mut i8;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn xmalloc(size: size_t) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_agl.rs
+++ b/engine/src/dpx_agl.rs
@@ -6,13 +6,12 @@
          unused_assignments,
          unused_mut)]
 extern crate libc;
+use libc::free;
 extern "C" {
     #[no_mangle]
     fn __ctype_b_loc() -> *mut *const u16;
     #[no_mangle]
     fn strtol(_: *const i8, _: *mut *mut i8, _: i32) -> i64;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_bmpimage.rs
+++ b/engine/src/dpx_bmpimage.rs
@@ -7,9 +7,11 @@
          unused_mut)]
 
 extern crate libc;
+
+use crate::dpx_pdfobj::pdf_obj;
+
 extern "C" {
     /* A deeper object hierarchy will be considered as (illegal) loop. */
-    pub type pdf_obj;
     pub type pdf_ximage_;
     #[no_mangle]
     fn free(__ptr: *mut libc::c_void);

--- a/engine/src/dpx_bmpimage.rs
+++ b/engine/src/dpx_bmpimage.rs
@@ -9,12 +9,11 @@
 extern crate libc;
 
 use crate::dpx_pdfobj::pdf_obj;
+use libc::free;
 
 extern "C" {
     /* A deeper object hierarchy will be considered as (illegal) loop. */
     pub type pdf_ximage_;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memset(_: *mut libc::c_void, _: i32, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_cff.rs
+++ b/engine/src/dpx_cff.rs
@@ -6,9 +6,8 @@
          unused_assignments,
          unused_mut)]
 extern crate libc;
+use libc::free;
 extern "C" {
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_cff_dict.rs
+++ b/engine/src/dpx_cff_dict.rs
@@ -7,6 +7,7 @@
          unused_mut)]
 
 extern crate libc;
+use libc::free;
 extern "C" {
     #[no_mangle]
     fn __errno_location() -> *mut i32;
@@ -14,8 +15,6 @@ extern "C" {
     fn sprintf(_: *mut i8, _: *const i8, _: ...) -> i32;
     #[no_mangle]
     fn strtod(_: *const i8, _: *mut *mut i8) -> f64;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memset(_: *mut libc::c_void, _: i32, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_cid.rs
+++ b/engine/src/dpx_cid.rs
@@ -8,6 +8,7 @@
 
 extern crate libc;
 use crate::dpx_pdfobj::{pdf_obj, pdf_file};
+use libc::free;
 extern "C" {
     #[no_mangle]
     fn __ctype_b_loc() -> *mut *const u16;
@@ -55,8 +56,6 @@ extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: u64) -> *mut libc::c_void;
     #[no_mangle]
     fn strtoul(_: *const i8, _: *mut *mut i8, _: i32) -> u64;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn cff_release_charsets(charset: *mut cff_charsets);
     /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.

--- a/engine/src/dpx_cid.rs
+++ b/engine/src/dpx_cid.rs
@@ -7,9 +7,8 @@
          unused_mut)]
 
 extern crate libc;
+use crate::dpx_pdfobj::{pdf_obj, pdf_file};
 extern "C" {
-    pub type pdf_obj;
-    pub type pdf_file;
     #[no_mangle]
     fn __ctype_b_loc() -> *mut *const u16;
     #[no_mangle]

--- a/engine/src/dpx_cidtype0.rs
+++ b/engine/src/dpx_cidtype0.rs
@@ -7,8 +7,8 @@
          unused_mut)]
 
 extern crate libc;
+use crate::dpx_pdfobj::pdf_obj;
 extern "C" {
-    pub type pdf_obj;
     pub type Type0Font;
     /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 

--- a/engine/src/dpx_cidtype0.rs
+++ b/engine/src/dpx_cidtype0.rs
@@ -8,6 +8,7 @@
 
 extern crate libc;
 use crate::dpx_pdfobj::pdf_obj;
+use libc::free;
 extern "C" {
     pub type Type0Font;
     /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
@@ -31,8 +32,6 @@ extern "C" {
     */
     #[no_mangle]
     fn Type0Font_set_ToUnicode(font: *mut Type0Font, cmap_ref: *mut pdf_obj);
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memmove(_: *mut libc::c_void, _: *const libc::c_void, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_cidtype2.rs
+++ b/engine/src/dpx_cidtype2.rs
@@ -7,6 +7,7 @@
          unused_mut)]
 extern crate libc;
 use crate::dpx_pdfobj::pdf_obj;
+use libc::free;
 extern "C" {
     pub type Type0Font;
     pub type otl_gsub;
@@ -29,8 +30,6 @@ extern "C" {
      * these. */
     #[no_mangle]
     fn ttstub_input_close(handle: rust_input_handle_t) -> i32;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memmove(_: *mut libc::c_void, _: *const libc::c_void, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_cidtype2.rs
+++ b/engine/src/dpx_cidtype2.rs
@@ -6,8 +6,8 @@
          unused_assignments,
          unused_mut)]
 extern crate libc;
+use crate::dpx_pdfobj::pdf_obj;
 extern "C" {
-    pub type pdf_obj;
     pub type Type0Font;
     pub type otl_gsub;
     /* tectonic/core-bridge.h: declarations of C/C++ => Rust bridge API

--- a/engine/src/dpx_cmap.rs
+++ b/engine/src/dpx_cmap.rs
@@ -7,9 +7,8 @@
          unused_mut)]
 
 extern crate libc;
+use libc::free;
 extern "C" {
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_cmap_read.rs
+++ b/engine/src/dpx_cmap_read.rs
@@ -7,6 +7,7 @@
          unused_mut)]
 
 extern crate libc;
+use libc::free;
 extern "C" {
     pub type pst_obj;
     #[no_mangle]
@@ -67,8 +68,6 @@ extern "C" {
     fn CMap_set_type(cmap: *mut CMap, type_0: i32);
     #[no_mangle]
     fn CMap_set_name(cmap: *mut CMap, name: *const i8);
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_cmap_write.rs
+++ b/engine/src/dpx_cmap_write.rs
@@ -6,9 +6,9 @@
          unused_assignments,
          unused_mut)]
 extern crate libc;
+use crate::dpx_pdfobj::pdf_obj;
 extern "C" {
     /* A deeper object hierarchy will be considered as (illegal) loop. */
-    pub type pdf_obj;
     #[no_mangle]
     fn free(__ptr: *mut libc::c_void);
     #[no_mangle]

--- a/engine/src/dpx_cmap_write.rs
+++ b/engine/src/dpx_cmap_write.rs
@@ -7,10 +7,9 @@
          unused_mut)]
 extern crate libc;
 use crate::dpx_pdfobj::pdf_obj;
+use libc::free;
 extern "C" {
     /* A deeper object hierarchy will be considered as (illegal) loop. */
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memset(_: *mut libc::c_void, _: i32, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_dpxfile.rs
+++ b/engine/src/dpx_dpxfile.rs
@@ -6,11 +6,10 @@
          unused_assignments,
          unused_mut)]
 extern crate libc;
+use libc::free;
 extern "C" {
     #[no_mangle]
     fn strcat(_: *mut i8, _: *const i8) -> *mut i8;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn getenv(__name: *const i8) -> *mut i8;
     #[no_mangle]

--- a/engine/src/dpx_dpxutil.rs
+++ b/engine/src/dpx_dpxutil.rs
@@ -7,6 +7,7 @@
          unused_mut)]
 
 extern crate libc;
+use libc::free;
 extern "C" {
     #[no_mangle]
     fn __ctype_b_loc() -> *mut *const u16;
@@ -14,8 +15,6 @@ extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: u64) -> *mut libc::c_void;
     #[no_mangle]
     fn memcmp(_: *const libc::c_void, _: *const libc::c_void, _: u64) -> i32;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn dpx_warning(fmt: *const i8, _: ...);
     /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.

--- a/engine/src/dpx_dvi.rs
+++ b/engine/src/dpx_dvi.rs
@@ -8,6 +8,7 @@
 
 extern crate libc;
 use crate::dpx_pdfobj::pdf_obj;
+use libc::free;
 extern "C" {
     pub type _IO_wide_data;
     pub type _IO_codecvt;
@@ -46,8 +47,6 @@ extern "C" {
     fn atof(__nptr: *const i8) -> f64;
     #[no_mangle]
     fn strtol(_: *const i8, _: *mut *mut i8, _: i32) -> i64;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn strlen(_: *const i8) -> u64;
     /* The internal, C/C++ interface: */

--- a/engine/src/dpx_dvi.rs
+++ b/engine/src/dpx_dvi.rs
@@ -7,6 +7,7 @@
          unused_mut)]
 
 extern crate libc;
+use crate::dpx_pdfobj::pdf_obj;
 extern "C" {
     pub type _IO_wide_data;
     pub type _IO_codecvt;
@@ -33,8 +34,6 @@ extern "C" {
         Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
     */
     /* Here is the complete list of PDF object types */
-    /* A deeper object hierarchy will be considered as (illegal) loop. */
-    pub type pdf_obj;
     #[no_mangle]
     fn memset(_: *mut libc::c_void, _: i32, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_dvipdfmx.rs
+++ b/engine/src/dpx_dvipdfmx.rs
@@ -7,6 +7,7 @@
          unused_mut)]
 
 extern crate libc;
+use libc::free;
 extern "C" {
     #[no_mangle]
     fn atof(__nptr: *const i8) -> f64;
@@ -24,8 +25,6 @@ extern "C" {
     fn strcmp(_: *const i8, _: *const i8) -> i32;
     #[no_mangle]
     fn memcmp(_: *const libc::c_void, _: *const libc::c_void, _: u64) -> i32;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn pdf_obj_set_verbose(level: i32);
     #[no_mangle]

--- a/engine/src/dpx_epdf.rs
+++ b/engine/src/dpx_epdf.rs
@@ -7,13 +7,12 @@
          unused_mut)]
 
 extern crate libc;
+use crate::dpx_pdfobj::{pdf_obj, pdf_file};
 use super::dpx_pdfdraw::{pdf_dev_currentmatrix, pdf_dev_transform, pdf_invertmatrix};
 extern "C" {
     pub type _IO_wide_data;
     pub type _IO_codecvt;
     pub type _IO_marker;
-    pub type pdf_obj;
-    pub type pdf_file;
     pub type pdf_ximage_;
     #[no_mangle]
     fn strtod(_: *const i8, _: *mut *mut i8) -> f64;

--- a/engine/src/dpx_epdf.rs
+++ b/engine/src/dpx_epdf.rs
@@ -9,6 +9,7 @@
 extern crate libc;
 use crate::dpx_pdfobj::{pdf_obj, pdf_file};
 use super::dpx_pdfdraw::{pdf_dev_currentmatrix, pdf_dev_transform, pdf_invertmatrix};
+use libc::free;
 extern "C" {
     pub type _IO_wide_data;
     pub type _IO_codecvt;
@@ -66,8 +67,6 @@ extern "C" {
     fn pdf_new_array() -> *mut pdf_obj;
     #[no_mangle]
     fn pdf_number_value(number: *mut pdf_obj) -> f64;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn strncpy(_: *mut i8, _: *const i8, _: u64) -> *mut i8;
     #[no_mangle]

--- a/engine/src/dpx_fontmap.rs
+++ b/engine/src/dpx_fontmap.rs
@@ -6,6 +6,7 @@
          unused_assignments,
          unused_mut)]
 extern crate libc;
+use libc::free;
 extern "C" {
     #[no_mangle]
     fn __ctype_b_loc() -> *mut *const u16;
@@ -17,8 +18,6 @@ extern "C" {
     fn strtol(_: *const i8, _: *mut *mut i8, _: i32) -> i64;
     #[no_mangle]
     fn strtoul(_: *const i8, _: *mut *mut i8, _: i32) -> u64;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_jp2image.rs
+++ b/engine/src/dpx_jp2image.rs
@@ -7,6 +7,7 @@
          unused_mut)]
 
 extern crate libc;
+use crate::dpx_pdfobj::pdf_obj;
 extern "C" {
     pub type _IO_wide_data;
     pub type _IO_codecvt;
@@ -34,7 +35,6 @@ extern "C" {
     */
     /* Here is the complete list of PDF object types */
     /* A deeper object hierarchy will be considered as (illegal) loop. */
-    pub type pdf_obj;
     pub type pdf_ximage_;
     #[no_mangle]
     fn pow(_: f64, _: f64) -> f64;

--- a/engine/src/dpx_jpegimage.rs
+++ b/engine/src/dpx_jpegimage.rs
@@ -8,6 +8,7 @@
 
 extern crate libc;
 use crate::dpx_pdfobj::pdf_obj;
+use libc::free;
 extern "C" {
     pub type pdf_ximage_;
     #[no_mangle]
@@ -72,8 +73,6 @@ extern "C" {
     fn ttstub_input_seek(handle: rust_input_handle_t, offset: ssize_t, whence: i32) -> size_t;
     #[no_mangle]
     fn ttstub_input_get_size(handle: rust_input_handle_t) -> size_t;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memset(_: *mut libc::c_void, _: i32, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_jpegimage.rs
+++ b/engine/src/dpx_jpegimage.rs
@@ -7,8 +7,8 @@
          unused_mut)]
 
 extern crate libc;
+use crate::dpx_pdfobj::pdf_obj;
 extern "C" {
-    pub type pdf_obj;
     pub type pdf_ximage_;
     #[no_mangle]
     fn pdf_ximage_set_image(

--- a/engine/src/dpx_mem.rs
+++ b/engine/src/dpx_mem.rs
@@ -6,6 +6,7 @@
          unused_assignments,
          unused_mut)]
 extern crate libc;
+use libc::free;
 extern "C" {
     #[no_mangle]
     fn _tt_abort(format: *const i8, _: ...) -> !;
@@ -13,8 +14,6 @@ extern "C" {
     fn malloc(_: u64) -> *mut libc::c_void;
     #[no_mangle]
     fn realloc(_: *mut libc::c_void, _: u64) -> *mut libc::c_void;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
 }
 pub type size_t = u64;
 /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.

--- a/engine/src/dpx_mpost.rs
+++ b/engine/src/dpx_mpost.rs
@@ -7,6 +7,7 @@
          unused_mut)]
 
 extern crate libc;
+use crate::dpx_pdfobj::{pdf_obj, pdf_file};
 use super::dpx_pdfdraw::{
     pdf_dev_concat, pdf_dev_currentmatrix, pdf_dev_dtransform, pdf_dev_idtransform,
 };
@@ -36,9 +37,6 @@ extern "C" {
         Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
     */
     /* Here is the complete list of PDF object types */
-    /* A deeper object hierarchy will be considered as (illegal) loop. */
-    pub type pdf_obj;
-    pub type pdf_file;
     #[no_mangle]
     fn __ctype_b_loc() -> *mut *const u16;
     #[no_mangle]

--- a/engine/src/dpx_mpost.rs
+++ b/engine/src/dpx_mpost.rs
@@ -11,6 +11,7 @@ use crate::dpx_pdfobj::{pdf_obj, pdf_file};
 use super::dpx_pdfdraw::{
     pdf_dev_concat, pdf_dev_currentmatrix, pdf_dev_dtransform, pdf_dev_idtransform,
 };
+use libc::free;
 extern "C" {
     pub type _IO_wide_data;
     pub type _IO_codecvt;
@@ -43,8 +44,6 @@ extern "C" {
     fn atof(__nptr: *const i8) -> f64;
     #[no_mangle]
     fn strtod(_: *const i8, _: *mut *mut i8) -> f64;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn strcpy(_: *mut i8, _: *const i8) -> *mut i8;
     #[no_mangle]

--- a/engine/src/dpx_otl_conf.rs
+++ b/engine/src/dpx_otl_conf.rs
@@ -7,8 +7,8 @@
          unused_mut)]
 
 extern crate libc;
+use crate::dpx_pdfobj::pdf_obj;
 extern "C" {
-    pub type pdf_obj;
     #[no_mangle]
     fn __ctype_b_loc() -> *mut *const u16;
     #[no_mangle]

--- a/engine/src/dpx_otl_conf.rs
+++ b/engine/src/dpx_otl_conf.rs
@@ -8,11 +8,10 @@
 
 extern crate libc;
 use crate::dpx_pdfobj::pdf_obj;
+use libc::free;
 extern "C" {
     #[no_mangle]
     fn __ctype_b_loc() -> *mut *const u16;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memset(_: *mut libc::c_void, _: i32, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_otl_opt.rs
+++ b/engine/src/dpx_otl_opt.rs
@@ -7,11 +7,10 @@
          unused_mut)]
 
 extern crate libc;
+use libc::free;
 extern "C" {
     #[no_mangle]
     fn __ctype_b_loc() -> *mut *const u16;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_pdfcolor.rs
+++ b/engine/src/dpx_pdfcolor.rs
@@ -7,6 +7,7 @@
          unused_mut)]
 extern crate libc;
 use crate::dpx_pdfobj::pdf_obj;
+use libc::free;
 extern "C" {
     #[no_mangle]
     fn __ctype_b_loc() -> *mut *const u16;
@@ -42,8 +43,6 @@ extern "C" {
     fn sprintf(_: *mut i8, _: *const i8, _: ...) -> i32;
     #[no_mangle]
     fn strlen(_: *const i8) -> u64;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_pdfcolor.rs
+++ b/engine/src/dpx_pdfcolor.rs
@@ -6,8 +6,8 @@
          unused_assignments,
          unused_mut)]
 extern crate libc;
+use crate::dpx_pdfobj::pdf_obj;
 extern "C" {
-    pub type pdf_obj;
     #[no_mangle]
     fn __ctype_b_loc() -> *mut *const u16;
     #[no_mangle]

--- a/engine/src/dpx_pdfdev.rs
+++ b/engine/src/dpx_pdfdev.rs
@@ -6,9 +6,9 @@
          unused_assignments,
          unused_mut)]
 extern crate libc;
+use crate::dpx_pdfobj::pdf_obj;
 use super::dpx_pdfdraw::{pdf_dev_concat, pdf_dev_transform};
 extern "C" {
-    pub type pdf_obj;
     #[no_mangle]
     fn free(__ptr: *mut libc::c_void);
     #[no_mangle]

--- a/engine/src/dpx_pdfdev.rs
+++ b/engine/src/dpx_pdfdev.rs
@@ -8,9 +8,8 @@
 extern crate libc;
 use crate::dpx_pdfobj::pdf_obj;
 use super::dpx_pdfdraw::{pdf_dev_concat, pdf_dev_transform};
+use libc::free;
 extern "C" {
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn modf(_: f64, _: *mut f64) -> f64;
     #[no_mangle]

--- a/engine/src/dpx_pdfdoc.rs
+++ b/engine/src/dpx_pdfdoc.rs
@@ -9,6 +9,7 @@
 extern crate libc;
 use super::dpx_pdfdev::pdf_dev_bop;
 use crate::dpx_pdfobj::{pdf_obj, pdf_file};
+use libc::free;
 extern "C" {
     /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 
@@ -55,8 +56,6 @@ extern "C" {
     */
     #[no_mangle]
     fn pdf_color_set_verbose(level: i32);
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_pdfdoc.rs
+++ b/engine/src/dpx_pdfdoc.rs
@@ -8,6 +8,7 @@
 
 extern crate libc;
 use super::dpx_pdfdev::pdf_dev_bop;
+use crate::dpx_pdfobj::{pdf_obj, pdf_file};
 extern "C" {
     /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 
@@ -31,9 +32,6 @@ extern "C" {
         Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
     */
     /* Here is the complete list of PDF object types */
-    /* A deeper object hierarchy will be considered as (illegal) loop. */
-    pub type pdf_obj;
-    pub type pdf_file;
     /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 
         Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,

--- a/engine/src/dpx_pdfdraw.rs
+++ b/engine/src/dpx_pdfdraw.rs
@@ -8,6 +8,7 @@
 
 extern crate libc;
 use super::dpx_pdfdev::pdf_sprint_matrix;
+use libc::free;
 extern "C" {
     #[no_mangle]
     fn graphics_mode();
@@ -21,8 +22,6 @@ extern "C" {
     fn pdf_sprint_coord(buf: *mut i8, p: *const pdf_coord) -> i32;
     #[no_mangle]
     fn pdf_sprint_rect(buf: *mut i8, p: *const pdf_rect) -> i32;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memset(_: *mut libc::c_void, _: i32, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_pdfencoding.rs
+++ b/engine/src/dpx_pdfencoding.rs
@@ -7,9 +7,8 @@
          unused_mut)]
 
 extern crate libc;
+use crate::dpx_pdfobj::{pdf_obj, pdf_file};
 extern "C" {
-    pub type pdf_obj;
-    pub type pdf_file;
     #[no_mangle]
     fn pdf_add_dict(dict: *mut pdf_obj, key: *mut pdf_obj, value: *mut pdf_obj) -> i32;
     #[no_mangle]

--- a/engine/src/dpx_pdfencoding.rs
+++ b/engine/src/dpx_pdfencoding.rs
@@ -8,6 +8,7 @@
 
 extern crate libc;
 use crate::dpx_pdfobj::{pdf_obj, pdf_file};
+use libc::free;
 extern "C" {
     #[no_mangle]
     fn pdf_add_dict(dict: *mut pdf_obj, key: *mut pdf_obj, value: *mut pdf_obj) -> i32;
@@ -68,8 +69,6 @@ extern "C" {
     fn strlen(_: *const i8) -> u64;
     #[no_mangle]
     fn strcmp(_: *const i8, _: *const i8) -> i32;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memset(_: *mut libc::c_void, _: i32, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_pdfencrypt.rs
+++ b/engine/src/dpx_pdfencrypt.rs
@@ -8,6 +8,7 @@
 
 extern crate libc;
 use crate::dpx_pdfobj::pdf_obj;
+use libc::free;
 extern "C" {
     #[no_mangle]
     fn sprintf(_: *mut i8, _: *const i8, _: ...) -> i32;
@@ -15,8 +16,6 @@ extern "C" {
     fn rand() -> i32;
     #[no_mangle]
     fn srand(__seed: u32);
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn strlen(_: *const i8) -> u64;
     #[no_mangle]

--- a/engine/src/dpx_pdfencrypt.rs
+++ b/engine/src/dpx_pdfencrypt.rs
@@ -7,8 +7,8 @@
          unused_mut)]
 
 extern crate libc;
+use crate::dpx_pdfobj::pdf_obj;
 extern "C" {
-    pub type pdf_obj;
     #[no_mangle]
     fn sprintf(_: *mut i8, _: *const i8, _: ...) -> i32;
     #[no_mangle]

--- a/engine/src/dpx_pdffont.rs
+++ b/engine/src/dpx_pdffont.rs
@@ -8,6 +8,7 @@
 
 extern crate libc;
 use crate::dpx_pdfobj::pdf_obj;
+use libc::free;
 extern "C" {
     pub type Type0Font;
     #[no_mangle]
@@ -36,8 +37,6 @@ extern "C" {
     fn rand() -> i32;
     #[no_mangle]
     fn srand(__seed: u32);
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn getenv(__name: *const i8) -> *mut i8;
     #[no_mangle]

--- a/engine/src/dpx_pdffont.rs
+++ b/engine/src/dpx_pdffont.rs
@@ -7,8 +7,8 @@
          unused_mut)]
 
 extern crate libc;
+use crate::dpx_pdfobj::pdf_obj;
 extern "C" {
-    pub type pdf_obj;
     pub type Type0Font;
     #[no_mangle]
     fn __errno_location() -> *mut i32;

--- a/engine/src/dpx_pdfnames.rs
+++ b/engine/src/dpx_pdfnames.rs
@@ -7,8 +7,8 @@
          unused_mut)]
 
 extern crate libc;
+use crate::dpx_pdfobj::pdf_obj;
 extern "C" {
-    pub type pdf_obj;
     #[no_mangle]
     fn __ctype_b_loc() -> *mut *const u16;
     #[no_mangle]

--- a/engine/src/dpx_pdfnames.rs
+++ b/engine/src/dpx_pdfnames.rs
@@ -8,11 +8,10 @@
 
 extern crate libc;
 use crate::dpx_pdfobj::pdf_obj;
+use libc::free;
 extern "C" {
     #[no_mangle]
     fn __ctype_b_loc() -> *mut *const u16;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn qsort(__base: *mut libc::c_void, __nmemb: size_t, __size: size_t, __compar: __compar_fn_t);
     #[no_mangle]

--- a/engine/src/dpx_pdfobj.rs
+++ b/engine/src/dpx_pdfobj.rs
@@ -7,6 +7,7 @@
          unused_mut)]
 
 extern crate libc;
+use libc::free;
 extern "C" {
     #[no_mangle]
     fn __ctype_b_loc() -> *mut *const u16;
@@ -18,8 +19,6 @@ extern "C" {
     fn atoi(__nptr: *const i8) -> i32;
     #[no_mangle]
     fn strtoul(_: *const i8, _: *mut *mut i8, _: i32) -> u64;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn abs(_: libc::c_int) -> libc::c_int;
     #[no_mangle]

--- a/engine/src/dpx_pdfobj.rs
+++ b/engine/src/dpx_pdfobj.rs
@@ -366,7 +366,6 @@ pub unsafe extern "C" fn pdf_set_compression(mut level: i32) {
             b"You don\'t have compression compiled in. Possibly libz wasn\'t found by configure.\x00"
                 as *const u8 as *const i8,
         );
-        return;
     }
     if cfg!(feature = "legacy-libz") && level != 0i32 {
         dpx_warning(
@@ -2508,11 +2507,11 @@ unsafe extern "C" fn write_stream(mut stream: *mut pdf_stream, mut handle: rust_
                 (filtered_length as libc::c_ulong)
                     .wrapping_sub(buffer_length)
                     .wrapping_sub(
-                        (if !filters.is_null() {
+                        if !filters.is_null() {
                             strlen(b"/FlateDecode \x00" as *const u8 as *const libc::c_char)
                         } else {
                             strlen(b"/Filter/FlateDecode\n\x00" as *const u8 as *const libc::c_char)
-                        }),
+                        },
                     ),
             ) as libc::c_int as libc::c_int;
             filtered = buffer;

--- a/engine/src/dpx_pdfparse.rs
+++ b/engine/src/dpx_pdfparse.rs
@@ -7,13 +7,12 @@
          unused_mut)]
 extern crate libc;
 use crate::dpx_pdfobj::{pdf_obj, pdf_file};
+use libc::free;
 extern "C" {
     #[no_mangle]
     fn pow(_: f64, _: f64) -> f64;
     #[no_mangle]
     fn __ctype_b_loc() -> *mut *const u16;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_pdfparse.rs
+++ b/engine/src/dpx_pdfparse.rs
@@ -6,9 +6,8 @@
          unused_assignments,
          unused_mut)]
 extern crate libc;
+use crate::dpx_pdfobj::{pdf_obj, pdf_file};
 extern "C" {
-    pub type pdf_obj;
-    pub type pdf_file;
     #[no_mangle]
     fn pow(_: f64, _: f64) -> f64;
     #[no_mangle]

--- a/engine/src/dpx_pdfresource.rs
+++ b/engine/src/dpx_pdfresource.rs
@@ -7,6 +7,7 @@
          unused_mut)]
 
 extern crate libc;
+use crate::dpx_pdfobj::pdf_obj;
 extern "C" {
     /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 
@@ -30,8 +31,6 @@ extern "C" {
         Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
     */
     /* Here is the complete list of PDF object types */
-    /* A deeper object hierarchy will be considered as (illegal) loop. */
-    pub type pdf_obj;
     #[no_mangle]
     fn free(__ptr: *mut libc::c_void);
     #[no_mangle]

--- a/engine/src/dpx_pdfresource.rs
+++ b/engine/src/dpx_pdfresource.rs
@@ -8,6 +8,7 @@
 
 extern crate libc;
 use crate::dpx_pdfobj::pdf_obj;
+use libc::free;
 extern "C" {
     /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 
@@ -31,8 +32,6 @@ extern "C" {
         Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
     */
     /* Here is the complete list of PDF object types */
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn strcpy(_: *mut i8, _: *const i8) -> *mut i8;
     #[no_mangle]

--- a/engine/src/dpx_pdfximage.rs
+++ b/engine/src/dpx_pdfximage.rs
@@ -9,9 +9,8 @@
 extern crate libc;
 use super::dpx_pdfdraw::pdf_dev_transform;
 use crate::dpx_pdfobj::pdf_obj;
+use libc::free;
 extern "C" {
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memset(_: *mut libc::c_void, _: i32, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_pdfximage.rs
+++ b/engine/src/dpx_pdfximage.rs
@@ -8,9 +8,8 @@
 
 extern crate libc;
 use super::dpx_pdfdraw::pdf_dev_transform;
+use crate::dpx_pdfobj::pdf_obj;
 extern "C" {
-    /* A deeper object hierarchy will be considered as (illegal) loop. */
-    pub type pdf_obj;
     #[no_mangle]
     fn free(__ptr: *mut libc::c_void);
     #[no_mangle]

--- a/engine/src/dpx_pkfont.rs
+++ b/engine/src/dpx_pkfont.rs
@@ -7,11 +7,11 @@
          unused_mut)]
 
 extern crate libc;
+use crate::dpx_pdfobj::pdf_obj;
 extern "C" {
     pub type _IO_wide_data;
     pub type _IO_codecvt;
     pub type _IO_marker;
-    pub type pdf_obj;
     pub type pdf_font;
     #[no_mangle]
     fn pdf_font_set_fontname(font: *mut pdf_font, fontname: *const i8) -> i32;

--- a/engine/src/dpx_pkfont.rs
+++ b/engine/src/dpx_pkfont.rs
@@ -8,6 +8,7 @@
 
 extern crate libc;
 use crate::dpx_pdfobj::pdf_obj;
+use libc::free;
 extern "C" {
     pub type _IO_wide_data;
     pub type _IO_codecvt;
@@ -63,8 +64,6 @@ extern "C" {
     fn fclose(__stream: *mut FILE) -> i32;
     #[no_mangle]
     fn _tt_abort(format: *const i8, _: ...) -> !;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memset(_: *mut libc::c_void, _: i32, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_pngimage.rs
+++ b/engine/src/dpx_pngimage.rs
@@ -2,10 +2,9 @@ use libpng_sys::ffi::*;
 use std::convert::TryInto;
 
 use crate::dpx_pdfobj::pdf_obj;
+use libc::free;
 extern "C" {
     pub type pdf_ximage_;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memmove(_: *mut libc::c_void, _: *const libc::c_void, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_pngimage.rs
+++ b/engine/src/dpx_pngimage.rs
@@ -1,8 +1,8 @@
 use libpng_sys::ffi::*;
 use std::convert::TryInto;
 
+use crate::dpx_pdfobj::pdf_obj;
 extern "C" {
-    pub type pdf_obj;
     pub type pdf_ximage_;
     #[no_mangle]
     fn free(__ptr: *mut libc::c_void);

--- a/engine/src/dpx_pst_obj.rs
+++ b/engine/src/dpx_pst_obj.rs
@@ -7,6 +7,7 @@
          unused_mut)]
 
 extern crate libc;
+use libc::free;
 extern "C" {
     #[no_mangle]
     fn __errno_location() -> *mut i32;
@@ -16,8 +17,6 @@ extern "C" {
     fn strtod(_: *const i8, _: *mut *mut i8) -> f64;
     #[no_mangle]
     fn strtol(_: *const i8, _: *mut *mut i8, _: i32) -> i64;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_sfnt.rs
+++ b/engine/src/dpx_sfnt.rs
@@ -8,9 +8,8 @@
 
 extern crate libc;
 use crate::dpx_pdfobj::pdf_obj;
+use libc::free;
 extern "C" {
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_sfnt.rs
+++ b/engine/src/dpx_sfnt.rs
@@ -7,8 +7,8 @@
          unused_mut)]
 
 extern crate libc;
+use crate::dpx_pdfobj::pdf_obj;
 extern "C" {
-    pub type pdf_obj;
     #[no_mangle]
     fn free(__ptr: *mut libc::c_void);
     #[no_mangle]

--- a/engine/src/dpx_spc_color.rs
+++ b/engine/src/dpx_spc_color.rs
@@ -7,11 +7,10 @@
          unused_mut)]
 
 extern crate libc;
+use libc::free;
 extern "C" {
     #[no_mangle]
     fn __ctype_b_loc() -> *mut *const u16;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn strcmp(_: *const i8, _: *const i8) -> i32;
     #[no_mangle]

--- a/engine/src/dpx_spc_dvipdfmx.rs
+++ b/engine/src/dpx_spc_dvipdfmx.rs
@@ -7,9 +7,8 @@
          unused_mut)]
 
 extern crate libc;
+use libc::free;
 extern "C" {
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memcmp(_: *const libc::c_void, _: *const libc::c_void, _: u64) -> i32;
     #[no_mangle]

--- a/engine/src/dpx_spc_dvipdfmx.rs
+++ b/engine/src/dpx_spc_dvipdfmx.rs
@@ -106,7 +106,7 @@ unsafe extern "C" fn spc_handler_null(mut spe: *mut spc_env, mut args: *mut spc_
     (*args).curptr = (*args).endptr;
     0i32
 }
-static mut dvipdfmx_handlers: [spc_handler; 1] = unsafe {
+static mut dvipdfmx_handlers: [spc_handler; 1] = {
     [{
         let mut init = spc_handler {
             key: b"config\x00" as *const u8 as *const i8,

--- a/engine/src/dpx_spc_dvips.rs
+++ b/engine/src/dpx_spc_dvips.rs
@@ -6,7 +6,7 @@
          unused_assignments,
          unused_mut)]
 extern crate libc;
-
+use crate::dpx_pdfobj::pdf_obj;
 use super::dpx_pdfdraw::pdf_dev_concat;
 extern "C" {
     /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
@@ -31,8 +31,6 @@ extern "C" {
         Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
     */
     /* Here is the complete list of PDF object types */
-    /* A deeper object hierarchy will be considered as (illegal) loop. */
-    pub type pdf_obj;
     #[no_mangle]
     fn __ctype_b_loc() -> *mut *const u16;
     #[no_mangle]
@@ -664,7 +662,7 @@ unsafe extern "C" fn spc_handler_ps_default(mut spe: *mut spc_env, mut args: *mu
     pdf_dev_grestore();
     error
 }
-static mut dvips_handlers: [spc_handler; 10] = unsafe {
+static mut dvips_handlers: [spc_handler; 10] = {
     [
         {
             let mut init = spc_handler {

--- a/engine/src/dpx_spc_dvips.rs
+++ b/engine/src/dpx_spc_dvips.rs
@@ -8,6 +8,7 @@
 extern crate libc;
 use crate::dpx_pdfobj::pdf_obj;
 use super::dpx_pdfdraw::pdf_dev_concat;
+use libc::free;
 extern "C" {
     /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 
@@ -33,8 +34,6 @@ extern "C" {
     /* Here is the complete list of PDF object types */
     #[no_mangle]
     fn __ctype_b_loc() -> *mut *const u16;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_spc_html.rs
+++ b/engine/src/dpx_spc_html.rs
@@ -7,9 +7,8 @@
          unused_mut)]
 extern crate libc;
 use super::dpx_pdfdraw::{pdf_dev_concat, pdf_dev_transform};
+use crate::dpx_pdfobj::pdf_obj;
 extern "C" {
-    /* A deeper object hierarchy will be considered as (illegal) loop. */
-    pub type pdf_obj;
     #[no_mangle]
     fn __ctype_b_loc() -> *mut *const u16;
     #[no_mangle]

--- a/engine/src/dpx_spc_html.rs
+++ b/engine/src/dpx_spc_html.rs
@@ -8,6 +8,7 @@
 extern crate libc;
 use super::dpx_pdfdraw::{pdf_dev_concat, pdf_dev_transform};
 use crate::dpx_pdfobj::pdf_obj;
+use libc::free;
 extern "C" {
     #[no_mangle]
     fn __ctype_b_loc() -> *mut *const u16;
@@ -15,8 +16,6 @@ extern "C" {
     fn tan(_: f64) -> f64;
     #[no_mangle]
     fn atof(__nptr: *const i8) -> f64;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_spc_misc.rs
+++ b/engine/src/dpx_spc_misc.rs
@@ -7,8 +7,8 @@
          unused_mut)]
 
 extern crate libc;
+use crate::dpx_pdfobj::pdf_obj;
 extern "C" {
-    pub type pdf_obj;
     #[no_mangle]
     fn __ctype_b_loc() -> *mut *const u16;
     #[no_mangle]
@@ -271,7 +271,7 @@ unsafe extern "C" fn spc_handler_null(mut spe: *mut spc_env, mut args: *mut spc_
     (*args).curptr = (*args).endptr;
     0i32
 }
-static mut misc_handlers: [spc_handler; 6] = unsafe {
+static mut misc_handlers: [spc_handler; 6] = {
     [
         {
             let mut init = spc_handler {

--- a/engine/src/dpx_spc_pdfm.rs
+++ b/engine/src/dpx_spc_pdfm.rs
@@ -9,6 +9,7 @@ extern crate libc;
 use super::dpx_pdfdev::pdf_sprint_matrix;
 use super::dpx_pdfdraw::{pdf_dev_concat, pdf_dev_transform};
 use crate::dpx_pdfobj::{pdf_obj, pdf_file};
+use libc::free;
 extern "C" {
     #[no_mangle]
     fn spc_clear_objects();
@@ -80,8 +81,6 @@ extern "C" {
     fn pdf_obj_typeof(object: *mut pdf_obj) -> i32;
     #[no_mangle]
     fn pdf_release_obj(object: *mut pdf_obj);
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memcmp(_: *const libc::c_void, _: *const libc::c_void, _: u64) -> i32;
     #[no_mangle]

--- a/engine/src/dpx_spc_pdfm.rs
+++ b/engine/src/dpx_spc_pdfm.rs
@@ -8,9 +8,8 @@
 extern crate libc;
 use super::dpx_pdfdev::pdf_sprint_matrix;
 use super::dpx_pdfdraw::{pdf_dev_concat, pdf_dev_transform};
+use crate::dpx_pdfobj::{pdf_obj, pdf_file};
 extern "C" {
-    pub type pdf_obj;
-    pub type pdf_file;
     #[no_mangle]
     fn spc_clear_objects();
     #[no_mangle]
@@ -2822,7 +2821,7 @@ unsafe extern "C" fn spc_handler_pdfm_tounicode(
     free(cmap_name as *mut libc::c_void);
     0i32
 }
-static mut pdfm_handlers: [spc_handler; 80] = unsafe {
+static mut pdfm_handlers: [spc_handler; 80] = {
     [
         {
             let mut init = spc_handler {

--- a/engine/src/dpx_spc_tpic.rs
+++ b/engine/src/dpx_spc_tpic.rs
@@ -9,6 +9,7 @@
 extern crate libc;
 use super::dpx_pdfdraw::pdf_dev_concat;
 use crate::dpx_pdfobj::pdf_obj;
+use libc::free;
 extern "C" {
     #[no_mangle]
     fn __ctype_b_loc() -> *mut *const u16;
@@ -58,8 +59,6 @@ extern "C" {
     fn memcmp(_: *const libc::c_void, _: *const libc::c_void, _: u64) -> i32;
     #[no_mangle]
     fn atof(__nptr: *const i8) -> f64;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn parse_float_decimal(pp: *mut *const i8, endptr: *const i8) -> *mut i8;
     #[no_mangle]

--- a/engine/src/dpx_spc_tpic.rs
+++ b/engine/src/dpx_spc_tpic.rs
@@ -8,8 +8,8 @@
 
 extern crate libc;
 use super::dpx_pdfdraw::pdf_dev_concat;
+use crate::dpx_pdfobj::pdf_obj;
 extern "C" {
-    pub type pdf_obj;
     #[no_mangle]
     fn __ctype_b_loc() -> *mut *const u16;
     #[no_mangle]
@@ -1106,7 +1106,7 @@ unsafe extern "C" fn spc_handler_tpic__setopts(mut spe: *mut spc_env, mut ap: *m
     error
 }
 /* DEBUG */
-static mut tpic_handlers: [spc_handler; 13] = unsafe {
+static mut tpic_handlers: [spc_handler; 13] = {
     [
         {
             let mut init = spc_handler {

--- a/engine/src/dpx_spc_util.rs
+++ b/engine/src/dpx_spc_util.rs
@@ -7,6 +7,7 @@
          unused_mut)]
 
 extern crate libc;
+use libc::free;
 extern "C" {
     #[no_mangle]
     fn atof(__nptr: *const i8) -> f64;
@@ -32,8 +33,6 @@ extern "C" {
     fn strcmp(_: *const i8, _: *const i8) -> i32;
     #[no_mangle]
     fn memcmp(_: *const libc::c_void, _: *const libc::c_void, _: u64) -> i32;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn parse_float_decimal(pp: *mut *const i8, endptr: *const i8) -> *mut i8;
     #[no_mangle]

--- a/engine/src/dpx_spc_xtx.rs
+++ b/engine/src/dpx_spc_xtx.rs
@@ -7,9 +7,8 @@
          unused_mut)]
 extern crate libc;
 use super::dpx_pdfdraw::pdf_dev_concat;
+use libc::free;
 extern "C" {
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memcmp(_: *const libc::c_void, _: *const libc::c_void, _: u64) -> i32;
     #[no_mangle]

--- a/engine/src/dpx_spc_xtx.rs
+++ b/engine/src/dpx_spc_xtx.rs
@@ -661,7 +661,7 @@ unsafe extern "C" fn spc_handler_xtx_unsupported(
     (*args).curptr = (*args).endptr;
     0i32
 }
-static mut xtx_handlers: [spc_handler; 21] = unsafe {
+static mut xtx_handlers: [spc_handler; 21] = {
     [
         {
             let mut init = spc_handler {

--- a/engine/src/dpx_specials.rs
+++ b/engine/src/dpx_specials.rs
@@ -7,8 +7,8 @@
          unused_mut)]
 extern crate libc;
 use super::dpx_pdfdraw::pdf_dev_transform;
+use crate::dpx_pdfobj::pdf_obj;
 extern "C" {
-    pub type pdf_obj;
     #[no_mangle]
     fn __ctype_b_loc() -> *mut *const u16;
     #[no_mangle]
@@ -763,7 +763,7 @@ unsafe extern "C" fn check_garbage(mut args: *mut spc_arg) {
         dump((*args).curptr, (*args).endptr);
     };
 }
-static mut known_specials: [C2RustUnnamed_0; 9] = unsafe {
+static mut known_specials: [C2RustUnnamed_0; 9] = {
     [
         {
             let mut init = C2RustUnnamed_0 {

--- a/engine/src/dpx_subfont.rs
+++ b/engine/src/dpx_subfont.rs
@@ -7,6 +7,7 @@
          unused_mut)]
 
 extern crate libc;
+use libc::free;
 extern "C" {
     #[no_mangle]
     fn __ctype_b_loc() -> *mut *const u16;
@@ -51,8 +52,6 @@ extern "C" {
     fn strchr(_: *const i8, _: i32) -> *mut i8;
     #[no_mangle]
     fn strlen(_: *const i8) -> u64;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     /* Tectonic-enabled versions */
     #[no_mangle]
     fn tt_mfgets(buffer: *mut i8, length: i32, file: rust_input_handle_t) -> *mut i8;

--- a/engine/src/dpx_t1_char.rs
+++ b/engine/src/dpx_t1_char.rs
@@ -7,9 +7,8 @@
          unused_mut)]
 
 extern crate libc;
+use libc::free;
 extern "C" {
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn qsort(__base: *mut libc::c_void, __nmemb: size_t, __size: size_t, __compar: __compar_fn_t);
     #[no_mangle]

--- a/engine/src/dpx_t1_load.rs
+++ b/engine/src/dpx_t1_load.rs
@@ -7,10 +7,9 @@
          unused_mut)]
 
 extern crate libc;
+use libc::free;
 extern "C" {
     pub type pst_obj;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_tfm.rs
+++ b/engine/src/dpx_tfm.rs
@@ -7,9 +7,8 @@
          unused_mut)]
 
 extern crate libc;
+use libc::free;
 extern "C" {
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn tt_get_positive_quad(handle: rust_input_handle_t, type_0: *const i8, name: *const i8)
         -> u32;

--- a/engine/src/dpx_truetype.rs
+++ b/engine/src/dpx_truetype.rs
@@ -7,6 +7,7 @@
          unused_mut)]
 
 extern crate libc;
+use crate::dpx_pdfobj::pdf_obj;
 extern "C" {
     /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 
@@ -30,8 +31,6 @@ extern "C" {
         Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
     */
     /* Here is the complete list of PDF object types */
-    /* A deeper object hierarchy will be considered as (illegal) loop. */
-    pub type pdf_obj;
     pub type pdf_font;
     pub type otl_gsub;
     #[no_mangle]

--- a/engine/src/dpx_truetype.rs
+++ b/engine/src/dpx_truetype.rs
@@ -8,6 +8,7 @@
 
 extern crate libc;
 use crate::dpx_pdfobj::pdf_obj;
+use libc::free;
 extern "C" {
     /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 
@@ -35,8 +36,6 @@ extern "C" {
     pub type otl_gsub;
     #[no_mangle]
     fn atoi(__nptr: *const i8) -> i32;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_tt_aux.rs
+++ b/engine/src/dpx_tt_aux.rs
@@ -7,6 +7,7 @@
          unused_mut)]
 
 extern crate libc;
+use crate::dpx_pdfobj::pdf_obj;
 extern "C" {
     /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 
@@ -30,8 +31,6 @@ extern "C" {
         Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
     */
     /* Here is the complete list of PDF object types */
-    /* A deeper object hierarchy will be considered as (illegal) loop. */
-    pub type pdf_obj;
     #[no_mangle]
     fn free(__ptr: *mut libc::c_void);
     #[no_mangle]

--- a/engine/src/dpx_tt_aux.rs
+++ b/engine/src/dpx_tt_aux.rs
@@ -8,6 +8,7 @@
 
 extern crate libc;
 use crate::dpx_pdfobj::pdf_obj;
+use libc::free;
 extern "C" {
     /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 
@@ -31,8 +32,6 @@ extern "C" {
         Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
     */
     /* Here is the complete list of PDF object types */
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_tt_cmap.rs
+++ b/engine/src/dpx_tt_cmap.rs
@@ -8,6 +8,7 @@
 
 extern crate libc;
 use crate::dpx_pdfobj::pdf_obj;
+use libc::free;
 extern "C" {
     /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 
@@ -34,8 +35,6 @@ extern "C" {
     pub type otl_gsub;
     #[no_mangle]
     fn sprintf(_: *mut i8, _: *const i8, _: ...) -> i32;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_tt_cmap.rs
+++ b/engine/src/dpx_tt_cmap.rs
@@ -7,6 +7,7 @@
          unused_mut)]
 
 extern crate libc;
+use crate::dpx_pdfobj::pdf_obj;
 extern "C" {
     /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 
@@ -30,8 +31,6 @@ extern "C" {
         Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
     */
     /* Here is the complete list of PDF object types */
-    /* A deeper object hierarchy will be considered as (illegal) loop. */
-    pub type pdf_obj;
     pub type otl_gsub;
     #[no_mangle]
     fn sprintf(_: *mut i8, _: *const i8, _: ...) -> i32;

--- a/engine/src/dpx_tt_glyf.rs
+++ b/engine/src/dpx_tt_glyf.rs
@@ -7,9 +7,8 @@
          unused_mut)]
 
 extern crate libc;
+use libc::free;
 extern "C" {
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn qsort(__base: *mut libc::c_void, __nmemb: size_t, __size: size_t, __compar: __compar_fn_t);
     #[no_mangle]

--- a/engine/src/dpx_tt_gsub.rs
+++ b/engine/src/dpx_tt_gsub.rs
@@ -7,6 +7,7 @@
          unused_mut)]
 
 extern crate libc;
+use libc::free;
 extern "C" {
     /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 
@@ -28,8 +29,6 @@ extern "C" {
         Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
     */
     pub type otl_opt;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memset(_: *mut libc::c_void, _: i32, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_tt_post.rs
+++ b/engine/src/dpx_tt_post.rs
@@ -7,9 +7,8 @@
          unused_mut)]
 
 extern crate libc;
+use libc::free;
 extern "C" {
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn strcmp(_: *const i8, _: *const i8) -> i32;
     #[no_mangle]

--- a/engine/src/dpx_type0.rs
+++ b/engine/src/dpx_type0.rs
@@ -8,6 +8,7 @@
 
 extern crate libc;
 use crate::dpx_pdfobj::pdf_obj;
+use libc::free;
 extern "C" {
     pub type CIDFont;
     #[no_mangle]
@@ -50,8 +51,6 @@ extern "C" {
     fn strcpy(_: *mut i8, _: *const i8) -> *mut i8;
     #[no_mangle]
     fn memset(_: *mut libc::c_void, _: i32, _: u64) -> *mut libc::c_void;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn CIDFont_get_fontname(font: *mut CIDFont) -> *mut i8;
     #[no_mangle]

--- a/engine/src/dpx_type0.rs
+++ b/engine/src/dpx_type0.rs
@@ -7,8 +7,8 @@
          unused_mut)]
 
 extern crate libc;
+use crate::dpx_pdfobj::pdf_obj;
 extern "C" {
-    pub type pdf_obj;
     pub type CIDFont;
     #[no_mangle]
     fn pdf_add_stream(

--- a/engine/src/dpx_type1.rs
+++ b/engine/src/dpx_type1.rs
@@ -8,6 +8,7 @@
 
 extern crate libc;
 use crate::dpx_pdfobj::pdf_obj;
+use libc::free;
 extern "C" {
     pub type pdf_font;
     #[no_mangle]
@@ -72,8 +73,6 @@ extern "C" {
     fn pdf_release_obj(object: *mut pdf_obj);
     #[no_mangle]
     fn sprintf(_: *mut i8, _: *const i8, _: ...) -> i32;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memset(_: *mut libc::c_void, _: i32, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/dpx_type1.rs
+++ b/engine/src/dpx_type1.rs
@@ -7,8 +7,8 @@
          unused_mut)]
 
 extern crate libc;
+use crate::dpx_pdfobj::pdf_obj;
 extern "C" {
-    pub type pdf_obj;
     pub type pdf_font;
     #[no_mangle]
     fn pdf_font_set_subtype(font: *mut pdf_font, subtype: i32) -> i32;

--- a/engine/src/dpx_type1c.rs
+++ b/engine/src/dpx_type1c.rs
@@ -7,6 +7,7 @@
          unused_mut)]
 
 extern crate libc;
+use crate::dpx_pdfobj::pdf_obj;
 extern "C" {
     /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 
@@ -30,8 +31,6 @@ extern "C" {
         Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
     */
     /* Here is the complete list of PDF object types */
-    /* A deeper object hierarchy will be considered as (illegal) loop. */
-    pub type pdf_obj;
     pub type pdf_font;
     #[no_mangle]
     fn free(__ptr: *mut libc::c_void);

--- a/engine/src/dpx_type1c.rs
+++ b/engine/src/dpx_type1c.rs
@@ -8,6 +8,7 @@
 
 extern crate libc;
 use crate::dpx_pdfobj::pdf_obj;
+use libc::free;
 extern "C" {
     /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 
@@ -32,8 +33,6 @@ extern "C" {
     */
     /* Here is the complete list of PDF object types */
     pub type pdf_font;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn strcmp(_: *const i8, _: *const i8) -> i32;
     #[no_mangle]

--- a/engine/src/dpx_vf.rs
+++ b/engine/src/dpx_vf.rs
@@ -6,12 +6,11 @@
          unused_assignments,
          unused_mut)]
 extern crate libc;
+use libc::free;
 extern "C" {
     pub type _IO_wide_data;
     pub type _IO_codecvt;
     pub type _IO_marker;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/xetex_ext.rs
+++ b/engine/src/xetex_ext.rs
@@ -7,14 +7,13 @@
          unused_mut)]
 extern crate libc;
 use crate::stub_icu as icu;
+use libc::free;
 
 extern "C" {
     pub type _FcPattern;
     pub type XeTeXFont_rec;
     pub type XeTeXLayoutEngine_rec;
     pub type Opaque_TECkit_Converter;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/xetex_ini.rs
+++ b/engine/src/xetex_ini.rs
@@ -7,9 +7,8 @@
          unused_mut)]
 
 extern crate libc;
+use libc::free;
 extern "C" {
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memset(_: *mut libc::c_void, _: i32, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/xetex_io.rs
+++ b/engine/src/xetex_io.rs
@@ -7,12 +7,11 @@
          unused_mut)]
 extern crate libc;
 use crate::stub_icu as icu;
+use libc::free;
 extern "C" {
     pub type Opaque_TECkit_Converter;
     #[no_mangle]
     fn __errno_location() -> *mut i32;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn strlen(_: *const i8) -> u64;
     /* The internal, C/C++ interface: */

--- a/engine/src/xetex_pic.rs
+++ b/engine/src/xetex_pic.rs
@@ -8,9 +8,8 @@
 
 extern crate libc;
 use super::dpx_pdfdraw::pdf_dev_transform;
+use crate::dpx_pdfobj::{pdf_obj, pdf_file};
 extern "C" {
-    pub type pdf_file;
-    pub type pdf_obj;
     #[no_mangle]
     fn free(__ptr: *mut libc::c_void);
     #[no_mangle]

--- a/engine/src/xetex_pic.rs
+++ b/engine/src/xetex_pic.rs
@@ -9,9 +9,8 @@
 extern crate libc;
 use super::dpx_pdfdraw::pdf_dev_transform;
 use crate::dpx_pdfobj::{pdf_obj, pdf_file};
+use libc::free;
 extern "C" {
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: u64) -> *mut libc::c_void;
     #[no_mangle]

--- a/engine/src/xetex_shipout.rs
+++ b/engine/src/xetex_shipout.rs
@@ -7,9 +7,8 @@
          unused_mut)]
 
 extern crate libc;
+use libc::free;
 extern "C" {
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn strlen(_: *const i8) -> u64;
     #[no_mangle]

--- a/engine/src/xetex_synctex.rs
+++ b/engine/src/xetex_synctex.rs
@@ -9,9 +9,8 @@
 )]
 
 extern crate libc;
+use libc::free;
 extern "C" {
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn strcpy(_: *mut i8, _: *const i8) -> *mut i8;
     #[no_mangle]

--- a/engine/src/xetex_texmfmp.rs
+++ b/engine/src/xetex_texmfmp.rs
@@ -7,9 +7,8 @@
          unused_mut)]
 
 extern crate libc;
+use libc::free;
 extern "C" {
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn strlen(_: *const i8) -> u64;
     /* The internal, C/C++ interface: */

--- a/engine/src/xetex_xetex0.rs
+++ b/engine/src/xetex_xetex0.rs
@@ -7,10 +7,9 @@
          unused_mut)]
 
 extern crate libc;
+use libc::free;
 extern "C" {
     pub type XeTeXLayoutEngine_rec;
-    #[no_mangle]
-    fn free(__ptr: *mut libc::c_void);
     #[no_mangle]
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: u64) -> *mut libc::c_void;
     #[no_mangle]


### PR DESCRIPTION
Removes some declarations in favour of imports. Also fixes some warnings. I didn't fix warnings regarding type limits on purpose; their types are likely invalid.