### PR TITLE
deduplicate functions

### DIFF
--- a/engine/src/dpx_agl.rs
+++ b/engine/src/dpx_agl.rs
@@ -9,8 +9,8 @@
 )]
 
 use crate::dpx_pdfparse::parse_ident;
-use crate::strstartswith;
 use crate::{info, warn};
+use crate::{streq_ptr, strstartswith};
 
 use crate::ttstub_input_close;
 use libc::free;
@@ -186,13 +186,6 @@ pub struct C2RustUnnamed_0 {
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    } /* Acutesmall, Gravesmall, etc */
-    false
-}
 static mut verbose: i32 = 0i32;
 #[no_mangle]
 pub unsafe extern "C" fn agl_set_verbose(mut level: i32) {

--- a/engine/src/dpx_agl.rs
+++ b/engine/src/dpx_agl.rs
@@ -9,6 +9,7 @@
 )]
 
 use crate::dpx_pdfparse::parse_ident;
+use crate::strstartswith;
 use crate::{info, warn};
 
 use crate::ttstub_input_close;
@@ -191,15 +192,6 @@ unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
         return strcmp(s1, s2) == 0i32;
     } /* Acutesmall, Gravesmall, etc */
     false
-}
-#[inline]
-unsafe extern "C" fn strstartswith(mut s: *const i8, mut prefix: *const i8) -> *const i8 {
-    let mut length: size_t = 0;
-    length = strlen(prefix);
-    if strncmp(s, prefix, length) == 0i32 {
-        return s.offset(length as isize);
-    }
-    0 as *const i8
 }
 static mut verbose: i32 = 0i32;
 #[no_mangle]

--- a/engine/src/dpx_cff.rs
+++ b/engine/src/dpx_cff.rs
@@ -1,11 +1,14 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
+use crate::streq_ptr;
 use crate::warn;
 
 use crate::{ttstub_input_read, ttstub_input_seek};
@@ -268,13 +271,6 @@ pub struct cff_font {
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
-}
 static mut cff_stdstr: [*const i8; 391] = [
     b".notdef\x00" as *const u8 as *const i8,
     b"space\x00" as *const u8 as *const i8,

--- a/engine/src/dpx_cff_dict.rs
+++ b/engine/src/dpx_cff_dict.rs
@@ -8,6 +8,7 @@
     unused_mut
 )]
 
+use crate::mfree;
 use crate::streq_ptr;
 use crate::stub_errno as errno;
 use crate::warn;
@@ -254,11 +255,6 @@ pub struct cff_font {
 pub struct C2RustUnnamed_2 {
     pub opname: *const i8,
     pub argtype: i32,
-}
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr);
-    0 as *mut libc::c_void
 }
 /* tectonic/core-strutils.h: miscellaneous C string utilities
    Copyright 2016-2018 the Tectonic Project

--- a/engine/src/dpx_cff_dict.rs
+++ b/engine/src/dpx_cff_dict.rs
@@ -1,11 +1,14 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
+use crate::streq_ptr;
 use crate::stub_errno as errno;
 use crate::warn;
 use libc::free;
@@ -264,13 +267,6 @@ unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
-}
 #[no_mangle]
 pub unsafe extern "C" fn cff_new_dict() -> *mut cff_dict {
     let mut dict: *mut cff_dict = 0 as *mut cff_dict;

--- a/engine/src/dpx_cid.rs
+++ b/engine/src/dpx_cid.rs
@@ -9,8 +9,8 @@
 )]
 
 use crate::dpx_pdfparse::parse_pdf_dict;
-use crate::strstartswith;
 use crate::{info, warn};
+use crate::{streq_ptr, strstartswith};
 
 use crate::dpx_pdfobj::{
     pdf_add_dict, pdf_file, pdf_link_obj, pdf_lookup_dict, pdf_name_value, pdf_new_name,
@@ -326,13 +326,6 @@ pub struct C2RustUnnamed_3 {
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
-}
 /* tectonic/core-memory.h: basic dynamic memory helpers
    Copyright 2016-2018 the Tectonic Project
    Licensed under the MIT License.

--- a/engine/src/dpx_cid.rs
+++ b/engine/src/dpx_cid.rs
@@ -9,6 +9,7 @@
 )]
 
 use crate::dpx_pdfparse::parse_pdf_dict;
+use crate::strstartswith;
 use crate::{info, warn};
 
 use crate::dpx_pdfobj::{
@@ -325,15 +326,6 @@ pub struct C2RustUnnamed_3 {
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn strstartswith(mut s: *const i8, mut prefix: *const i8) -> *const i8 {
-    let mut length: size_t = 0;
-    length = strlen(prefix);
-    if strncmp(s, prefix, length) == 0i32 {
-        return s.offset(length as isize);
-    }
-    0 as *const i8
-}
 #[inline]
 unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
     if !s1.is_null() && !s2.is_null() {

--- a/engine/src/dpx_cid.rs
+++ b/engine/src/dpx_cid.rs
@@ -9,6 +9,7 @@
 )]
 
 use crate::dpx_pdfparse::parse_pdf_dict;
+use crate::mfree;
 use crate::{info, warn};
 use crate::{streq_ptr, strstartswith};
 
@@ -330,11 +331,6 @@ pub struct C2RustUnnamed_3 {
    Copyright 2016-2018 the Tectonic Project
    Licensed under the MIT License.
 */
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr);
-    0 as *mut libc::c_void
-}
 static mut CIDFont_stdcc_def: [C2RustUnnamed_0; 7] = [
     {
         let mut init = C2RustUnnamed_0 {

--- a/engine/src/dpx_cidtype2.rs
+++ b/engine/src/dpx_cidtype2.rs
@@ -1,11 +1,14 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
+use crate::streq_ptr;
 use crate::{info, warn};
 
 use crate::dpx_pdfobj::{
@@ -448,13 +451,6 @@ pub struct C2RustUnnamed_3 {
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
-}
 /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 
    Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,

--- a/engine/src/dpx_cmap.rs
+++ b/engine/src/dpx_cmap.rs
@@ -8,6 +8,7 @@
     unused_mut
 )]
 
+use crate::mfree;
 use crate::streq_ptr;
 use crate::{info, warn};
 
@@ -161,11 +162,6 @@ pub struct CMap_cache {
     pub num: i32,
     pub max: i32,
     pub cmaps: *mut *mut CMap,
-}
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr);
-    0 as *mut libc::c_void
 }
 /* tectonic/core-strutils.h: miscellaneous C string utilities
    Copyright 2016-2018 the Tectonic Project

--- a/engine/src/dpx_cmap.rs
+++ b/engine/src/dpx_cmap.rs
@@ -1,11 +1,14 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
+use crate::streq_ptr;
 use crate::{info, warn};
 
 use crate::{ttstub_input_close, ttstub_input_open};
@@ -171,13 +174,6 @@ unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
-}
 /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 
    Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,

--- a/engine/src/dpx_cmap_read.rs
+++ b/engine/src/dpx_cmap_read.rs
@@ -1,11 +1,14 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
+use crate::strstartswith;
 use crate::warn;
 
 use crate::{ttstub_input_get_size, ttstub_input_read, ttstub_input_seek};
@@ -252,15 +255,6 @@ pub struct ifreader {
     pub unread: size_t,
 }
 pub type pst_type = i32;
-#[inline]
-unsafe extern "C" fn strstartswith(mut s: *const i8, mut prefix: *const i8) -> *const i8 {
-    let mut length: size_t = 0;
-    length = strlen(prefix);
-    if strncmp(s, prefix, length) == 0i32 {
-        return s.offset(length as isize);
-    }
-    0 as *const i8
-}
 /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 
    Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,

--- a/engine/src/dpx_dpxconf.rs
+++ b/engine/src/dpx_dpxconf.rs
@@ -1,11 +1,14 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
+use crate::streq_ptr;
 extern "C" {
     #[no_mangle]
     fn strcmp(_: *const i8, _: *const i8) -> i32;
@@ -19,13 +22,6 @@ pub struct paper {
     pub name: *const i8,
     pub pswidth: f64,
     pub psheight: f64,
-}
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
 }
 /* This is DVIPDFMx, an eXtended version of DVIPDFM by Mark A. Wicks.
 

--- a/engine/src/dpx_dpxfile.rs
+++ b/engine/src/dpx_dpxfile.rs
@@ -1,10 +1,14 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+
+use crate::mfree;
 use crate::{ttstub_input_close, ttstub_input_open, ttstub_input_read, ttstub_input_seek};
 use libc::free;
 extern "C" {
@@ -69,11 +73,6 @@ pub type ssize_t = __ssize_t;
 use crate::TTInputFormat;
 
 pub type rust_input_handle_t = *mut libc::c_void;
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr);
-    0 as *mut libc::c_void
-}
 /* quasi-hack to get the primary input */
 /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
    Copyright (C) 2007-2016 by Jin-Hwan Cho and Shunsaku Hirata,

--- a/engine/src/dpx_dpxutil.rs
+++ b/engine/src/dpx_dpxutil.rs
@@ -8,6 +8,7 @@
     unused_mut
 )]
 
+use crate::mfree;
 use libc::free;
 extern "C" {
     #[no_mangle]
@@ -67,11 +68,6 @@ pub struct ht_iter {
    Copyright 2016-2018 the Tectonic Project
    Licensed under the MIT License.
 */
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr);
-    0 as *mut libc::c_void
-}
 /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 
     Copyright (C) 2002-2017 by Jin-Hwan Cho and Shunsaku Hirata,

--- a/engine/src/dpx_dvi.rs
+++ b/engine/src/dpx_dvi.rs
@@ -8,6 +8,7 @@
     unused_mut
 )]
 
+use crate::mfree;
 use crate::streq_ptr;
 use crate::warn;
 
@@ -903,11 +904,6 @@ pub struct tt_vhea_table {
     pub numOfLongVerMetrics: u16,
     pub numOfExSideBearings: u16,
     /* extra information */
-}
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr);
-    0 as *mut libc::c_void
 }
 /* tectonic/core-strutils.h: miscellaneous C string utilities
    Copyright 2016-2018 the Tectonic Project

--- a/engine/src/dpx_dvi.rs
+++ b/engine/src/dpx_dvi.rs
@@ -1,11 +1,14 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
+use crate::streq_ptr;
 use crate::warn;
 
 use super::dpx_pdfcolor::{pdf_color_pop, pdf_color_push, pdf_color_rgbcolor};
@@ -913,13 +916,6 @@ unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
-}
 /* UTF-32 over U+FFFF -> UTF-16 surrogate pair */
 /* Interal Variables */
 static mut dvi_handle: rust_input_handle_t = 0 as *const libc::c_void as *mut libc::c_void;

--- a/engine/src/dpx_epdf.rs
+++ b/engine/src/dpx_epdf.rs
@@ -19,6 +19,7 @@ use crate::dpx_pdfobj::{
     pdf_stream_dataptr, pdf_stream_dict, pdf_stream_length,
 };
 use crate::dpx_pdfparse::{parse_ident, parse_pdf_array};
+use crate::streq_ptr;
 use libc::free;
 extern "C" {
     pub type _IO_wide_data;
@@ -139,13 +140,6 @@ pub const OP_UNKNOWN: C2RustUnnamed_0 = 16;
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
-}
 /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 
     Copyright (C) 2007-2017 by Jin-Hwan Cho and Shunsaku Hirata,

--- a/engine/src/dpx_fontmap.rs
+++ b/engine/src/dpx_fontmap.rs
@@ -8,6 +8,7 @@
     unused_mut
 )]
 
+use crate::mfree;
 use crate::{info, warn};
 use crate::{streq_ptr, strstartswith};
 
@@ -209,11 +210,6 @@ pub struct ht_entry {
     pub next: *mut ht_entry,
 }
 pub type hval_free_func = Option<unsafe extern "C" fn(_: *mut libc::c_void) -> ()>;
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr);
-    0 as *mut libc::c_void
-}
 /* quasi-hack to get the primary input */
 /* tectonic/core-strutils.h: miscellaneous C string utilities
    Copyright 2016-2018 the Tectonic Project

--- a/engine/src/dpx_fontmap.rs
+++ b/engine/src/dpx_fontmap.rs
@@ -8,8 +8,8 @@
     unused_mut
 )]
 
-use crate::strstartswith;
 use crate::{info, warn};
+use crate::{streq_ptr, strstartswith};
 
 use crate::ttstub_input_close;
 use libc::free;
@@ -222,13 +222,6 @@ unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
-}
 static mut verbose: i32 = 0i32;
 #[no_mangle]
 pub unsafe extern "C" fn pdf_fontmap_set_verbose(mut level: i32) {

--- a/engine/src/dpx_fontmap.rs
+++ b/engine/src/dpx_fontmap.rs
@@ -8,6 +8,7 @@
     unused_mut
 )]
 
+use crate::strstartswith;
 use crate::{info, warn};
 
 use crate::ttstub_input_close;
@@ -227,15 +228,6 @@ unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
         return strcmp(s1, s2) == 0i32;
     }
     false
-}
-#[inline]
-unsafe extern "C" fn strstartswith(mut s: *const i8, mut prefix: *const i8) -> *const i8 {
-    let mut length: size_t = 0;
-    length = strlen(prefix);
-    if strncmp(s, prefix, length) == 0i32 {
-        return s.offset(length as isize);
-    }
-    0 as *const i8
 }
 static mut verbose: i32 = 0i32;
 #[no_mangle]

--- a/engine/src/dpx_jpegimage.rs
+++ b/engine/src/dpx_jpegimage.rs
@@ -1,11 +1,14 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
+use crate::mfree;
 use crate::warn;
 
 use crate::dpx_pdfobj::{
@@ -195,11 +198,6 @@ pub struct JPEG_APPn_JFIF {
    Copyright 2016-2018 the Tectonic Project
    Licensed under the MIT License.
 */
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr);
-    0 as *mut libc::c_void
-}
 #[no_mangle]
 pub unsafe extern "C" fn check_for_jpeg(mut handle: rust_input_handle_t) -> i32 {
     let mut jpeg_sig: [u8; 2] = [0; 2];

--- a/engine/src/dpx_mpost.rs
+++ b/engine/src/dpx_mpost.rs
@@ -9,8 +9,8 @@
 )]
 
 use crate::dpx_pdfparse::parse_number;
-use crate::strstartswith;
 use crate::warn;
+use crate::{streq_ptr, strstartswith};
 
 use super::dpx_pdfcolor::{pdf_color_cmykcolor, pdf_color_graycolor, pdf_color_rgbcolor};
 use super::dpx_pdfdraw::{
@@ -429,13 +429,6 @@ unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
-}
 /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 
     Copyright (C) 2007-2016 by Jin-Hwan Cho and Shunsaku Hirata,

--- a/engine/src/dpx_mpost.rs
+++ b/engine/src/dpx_mpost.rs
@@ -9,6 +9,7 @@
 )]
 
 use crate::dpx_pdfparse::parse_number;
+use crate::mfree;
 use crate::warn;
 use crate::{streq_ptr, strstartswith};
 
@@ -416,11 +417,6 @@ pub struct mp_font {
 pub struct operators {
     pub token: *const i8,
     pub opcode: i32,
-}
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr);
-    0 as *mut libc::c_void
 }
 /* tectonic/core-strutils.h: miscellaneous C string utilities
    Copyright 2016-2018 the Tectonic Project

--- a/engine/src/dpx_mpost.rs
+++ b/engine/src/dpx_mpost.rs
@@ -9,6 +9,7 @@
 )]
 
 use crate::dpx_pdfparse::parse_number;
+use crate::strstartswith;
 use crate::warn;
 
 use super::dpx_pdfcolor::{pdf_color_cmykcolor, pdf_color_graycolor, pdf_color_rgbcolor};
@@ -434,15 +435,6 @@ unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
         return strcmp(s1, s2) == 0i32;
     }
     false
-}
-#[inline]
-unsafe extern "C" fn strstartswith(mut s: *const i8, mut prefix: *const i8) -> *const i8 {
-    let mut length: size_t = 0;
-    length = strlen(prefix);
-    if strncmp(s, prefix, length) == 0i32 {
-        return s.offset(length as isize);
-    }
-    0 as *const i8
 }
 /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 

--- a/engine/src/dpx_otl_conf.rs
+++ b/engine/src/dpx_otl_conf.rs
@@ -15,6 +15,7 @@ use crate::dpx_pdfobj::{
     pdf_lookup_dict, pdf_name_value, pdf_new_array, pdf_new_dict, pdf_new_name, pdf_new_null,
     pdf_new_number, pdf_new_string, pdf_obj, pdf_ref_obj, pdf_release_obj, pdf_string_value,
 };
+use crate::streq_ptr;
 use crate::{ttstub_input_close, ttstub_input_get_size, ttstub_input_open, ttstub_input_read};
 use libc::free;
 extern "C" {
@@ -80,13 +81,6 @@ pub type rust_input_handle_t = *mut libc::c_void;
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
-}
 static mut verbose: i32 = 0i32;
 #[no_mangle]
 pub unsafe extern "C" fn otl_conf_set_verbose(mut level: i32) {

--- a/engine/src/dpx_pdfcolor.rs
+++ b/engine/src/dpx_pdfcolor.rs
@@ -8,6 +8,7 @@
     unused_mut
 )]
 
+use crate::mfree;
 use crate::{info, warn};
 
 use crate::dpx_pdfobj::{
@@ -170,11 +171,6 @@ pub struct C2RustUnnamed_2 {
    Copyright 2016-2018 the Tectonic Project
    Licensed under the MIT License.
 */
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr);
-    0 as *mut libc::c_void
-}
 /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,

--- a/engine/src/dpx_pdfdev.rs
+++ b/engine/src/dpx_pdfdev.rs
@@ -1,16 +1,19 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
 use crate::{info, warn};
 
 use super::dpx_pdfcolor::{pdf_color_clear_stack, pdf_color_get_current};
 use super::dpx_pdfdraw::{pdf_dev_concat, pdf_dev_set_color, pdf_dev_transform};
 use crate::dpx_pdfobj::{pdf_link_obj, pdf_obj, pdf_release_obj};
+use crate::streq_ptr;
 use libc::free;
 extern "C" {
     #[no_mangle]
@@ -473,13 +476,6 @@ pub struct C2RustUnnamed_6 {
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
-}
 /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,

--- a/engine/src/dpx_pdfdoc.rs
+++ b/engine/src/dpx_pdfdoc.rs
@@ -8,6 +8,7 @@
     unused_mut
 )]
 
+use crate::mfree;
 use crate::streq_ptr;
 use crate::{info, warn};
 
@@ -571,11 +572,6 @@ pub struct C2RustUnnamed_4 {
     pub broken: i32,
     pub annot_dict: *mut pdf_obj,
     pub rect: pdf_rect,
-}
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr);
-    0 as *mut libc::c_void
 }
 /* quasi-hack to get the primary input */
 /* tectonic/core-strutils.h: miscellaneous C string utilities

--- a/engine/src/dpx_pdfdoc.rs
+++ b/engine/src/dpx_pdfdoc.rs
@@ -1,11 +1,14 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
+use crate::streq_ptr;
 use crate::{info, warn};
 
 use super::dpx_pdfcolor::{
@@ -582,13 +585,6 @@ unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
-}
 static mut verbose: i32 = 0i32;
 static mut manual_thumb_enabled: i8 = 0_i8;
 static mut thumb_basename: *mut i8 = 0 as *const i8 as *mut i8;

--- a/engine/src/dpx_pdfdraw.rs
+++ b/engine/src/dpx_pdfdraw.rs
@@ -1,11 +1,14 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
+use crate::mfree;
 use crate::warn;
 
 use super::dpx_pdfcolor::{
@@ -144,11 +147,6 @@ pub struct C2RustUnnamed_0 {
     pub opchr: i8,
     pub n_pts: i32,
     pub strkey: *const i8,
-}
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr);
-    0 as *mut libc::c_void
 }
 unsafe extern "C" fn inversematrix(mut W: &mut pdf_tmatrix, mut M: &pdf_tmatrix) -> i32 {
     let mut det: f64 = 0.;

--- a/engine/src/dpx_pdfencoding.rs
+++ b/engine/src/dpx_pdfencoding.rs
@@ -15,6 +15,7 @@ use crate::dpx_pdfobj::{
     pdf_new_array, pdf_new_dict, pdf_new_name, pdf_new_number, pdf_obj, pdf_release_obj,
 };
 use crate::dpx_pdfparse::{parse_pdf_array, parse_pdf_name, pdfparse_skip_line};
+use crate::mfree;
 use crate::streq_ptr;
 use crate::{ttstub_input_close, ttstub_input_get_size, ttstub_input_open, ttstub_input_read};
 use libc::free;
@@ -317,11 +318,6 @@ pub struct agl_name {
    Copyright 2016-2018 the Tectonic Project
    Licensed under the MIT License.
 */
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr);
-    0 as *mut libc::c_void
-}
 static mut verbose: u8 = 0_u8;
 #[no_mangle]
 pub unsafe extern "C" fn pdf_encoding_set_verbose(mut level: i32) {

--- a/engine/src/dpx_pdfencoding.rs
+++ b/engine/src/dpx_pdfencoding.rs
@@ -1,10 +1,12 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
 use crate::info;
 
@@ -13,6 +15,7 @@ use crate::dpx_pdfobj::{
     pdf_new_array, pdf_new_dict, pdf_new_name, pdf_new_number, pdf_obj, pdf_release_obj,
 };
 use crate::dpx_pdfparse::{parse_pdf_array, parse_pdf_name, pdfparse_skip_line};
+use crate::streq_ptr;
 use crate::{ttstub_input_close, ttstub_input_get_size, ttstub_input_open, ttstub_input_read};
 use libc::free;
 extern "C" {
@@ -309,13 +312,6 @@ pub struct agl_name {
     pub unicodes: [i32; 16],
     pub alternate: *mut agl_name,
     pub is_predef: i32,
-}
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
 }
 /* tectonic/core-memory.h: basic dynamic memory helpers
    Copyright 2016-2018 the Tectonic Project

--- a/engine/src/dpx_pdffont.rs
+++ b/engine/src/dpx_pdffont.rs
@@ -12,8 +12,12 @@ use crate::dpx_pdfobj::{
     pdf_add_dict, pdf_link_obj, pdf_lookup_dict, pdf_new_dict, pdf_new_name, pdf_obj,
     pdf_obj_typeof, pdf_ref_obj, pdf_release_obj, pdf_stream_length,
 };
+use crate::mfree;
+use crate::streq_ptr;
 use crate::streq_ptr;
 use crate::stub_errno as errno;
+use crate::stub_errno as errno;
+use crate::{info, warn};
 use crate::{info, warn};
 use libc::free;
 extern "C" {
@@ -455,11 +459,6 @@ pub struct CIDSysInfo {
     pub registry: *mut i8,
     pub ordering: *mut i8,
     pub supplement: i32,
-}
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr);
-    0 as *mut libc::c_void
 }
 /* tectonic/core-strutils.h: miscellaneous C string utilities
    Copyright 2016-2018 the Tectonic Project

--- a/engine/src/dpx_pdffont.rs
+++ b/engine/src/dpx_pdffont.rs
@@ -14,10 +14,7 @@ use crate::dpx_pdfobj::{
 };
 use crate::mfree;
 use crate::streq_ptr;
-use crate::streq_ptr;
 use crate::stub_errno as errno;
-use crate::stub_errno as errno;
-use crate::{info, warn};
 use crate::{info, warn};
 use libc::free;
 extern "C" {

--- a/engine/src/dpx_pdffont.rs
+++ b/engine/src/dpx_pdffont.rs
@@ -1,18 +1,20 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
-
-use crate::stub_errno as errno;
-use crate::{info, warn};
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
 use crate::dpx_pdfobj::{
     pdf_add_dict, pdf_link_obj, pdf_lookup_dict, pdf_new_dict, pdf_new_name, pdf_obj,
     pdf_obj_typeof, pdf_ref_obj, pdf_release_obj, pdf_stream_length,
 };
+use crate::streq_ptr;
+use crate::stub_errno as errno;
+use crate::{info, warn};
 use libc::free;
 extern "C" {
     pub type Type0Font;
@@ -466,13 +468,6 @@ unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
-}
 static mut __verbose: i32 = 0i32;
 #[no_mangle]
 pub unsafe extern "C" fn pdf_font_set_verbose(mut level: i32) {

--- a/engine/src/dpx_pdfnames.rs
+++ b/engine/src/dpx_pdfnames.rs
@@ -8,6 +8,7 @@
     unused_mut
 )]
 
+use crate::mfree;
 use crate::warn;
 
 use crate::dpx_pdfobj::{
@@ -145,11 +146,6 @@ pub struct named_object {
     pub key: *mut i8,
     pub keylen: i32,
     pub value: *mut pdf_obj,
-}
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr);
-    0 as *mut libc::c_void
 }
 unsafe extern "C" fn printable_key(mut key: *const i8, mut keylen: i32) -> *mut i8 {
     static mut pkey: [i8; 36] = [0; 36];

--- a/engine/src/dpx_pdfobj.rs
+++ b/engine/src/dpx_pdfobj.rs
@@ -9,8 +9,8 @@
 )]
 
 use crate::dpx_pdfparse::{parse_number, parse_pdf_dict, parse_pdf_object, parse_unsigned};
-use crate::strstartswith;
 use crate::{info, warn};
+use crate::{streq_ptr, strstartswith};
 use std::ffi::CStr;
 
 use crate::{
@@ -281,13 +281,6 @@ unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
-}
 static mut pdf_output_handle: rust_output_handle_t = 0 as *const libc::c_void as *mut libc::c_void;
 static mut pdf_output_file_position: i32 = 0i32;
 static mut pdf_output_line_position: i32 = 0i32;

--- a/engine/src/dpx_pdfobj.rs
+++ b/engine/src/dpx_pdfobj.rs
@@ -9,6 +9,7 @@
 )]
 
 use crate::dpx_pdfparse::{parse_number, parse_pdf_dict, parse_pdf_object, parse_unsigned};
+use crate::mfree;
 use crate::{info, warn};
 use crate::{streq_ptr, strstartswith};
 use std::ffi::CStr;
@@ -268,11 +269,6 @@ pub struct pdf_number {
 #[repr(C)]
 pub struct pdf_boolean {
     pub value: i8,
-}
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr);
-    0 as *mut libc::c_void
 }
 /* tectonic/core-strutils.h: miscellaneous C string utilities
    Copyright 2016-2018 the Tectonic Project

--- a/engine/src/dpx_pdfobj.rs
+++ b/engine/src/dpx_pdfobj.rs
@@ -9,6 +9,7 @@
 )]
 
 use crate::dpx_pdfparse::{parse_number, parse_pdf_dict, parse_pdf_object, parse_unsigned};
+use crate::strstartswith;
 use crate::{info, warn};
 use std::ffi::CStr;
 
@@ -286,15 +287,6 @@ unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
         return strcmp(s1, s2) == 0i32;
     }
     false
-}
-#[inline]
-unsafe extern "C" fn strstartswith(mut s: *const i8, mut prefix: *const i8) -> *const i8 {
-    let mut length: size_t = 0;
-    length = strlen(prefix);
-    if strncmp(s, prefix, length) == 0i32 {
-        return s.offset(length as isize);
-    }
-    0 as *const i8
 }
 static mut pdf_output_handle: rust_output_handle_t = 0 as *const libc::c_void as *mut libc::c_void;
 static mut pdf_output_file_position: i32 = 0i32;

--- a/engine/src/dpx_pdfparse.rs
+++ b/engine/src/dpx_pdfparse.rs
@@ -8,6 +8,7 @@
     unused_mut
 )]
 
+use crate::strstartswith;
 use crate::{info, warn};
 
 use crate::dpx_pdfobj::{
@@ -122,15 +123,6 @@ pub type size_t = u64;
 #[repr(C)]
 pub struct C2RustUnnamed_0 {
     pub tainted: i32,
-}
-#[inline]
-unsafe extern "C" fn strstartswith(mut s: *const i8, mut prefix: *const i8) -> *const i8 {
-    let mut length: size_t = 0;
-    length = strlen(prefix);
-    if strncmp(s, prefix, length) == 0i32 {
-        return s.offset(length as isize);
-    }
-    0 as *const i8
 }
 static mut parser_state: C2RustUnnamed_0 = {
     let mut init = C2RustUnnamed_0 { tainted: 0i32 };

--- a/engine/src/dpx_pdfresource.rs
+++ b/engine/src/dpx_pdfresource.rs
@@ -1,11 +1,14 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
+use crate::streq_ptr;
 use crate::warn;
 
 use crate::dpx_pdfobj::{pdf_link_obj, pdf_obj, pdf_ref_obj, pdf_release_obj};
@@ -105,13 +108,6 @@ unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
-}
 static mut pdf_resource_categories: [C2RustUnnamed; 9] = [
     {
         let mut init = C2RustUnnamed {

--- a/engine/src/dpx_pdfresource.rs
+++ b/engine/src/dpx_pdfresource.rs
@@ -12,6 +12,7 @@ use crate::streq_ptr;
 use crate::warn;
 
 use crate::dpx_pdfobj::{pdf_link_obj, pdf_obj, pdf_ref_obj, pdf_release_obj};
+use crate::mfree;
 use libc::free;
 extern "C" {
     /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
@@ -95,11 +96,6 @@ pub struct res_cache {
 pub struct C2RustUnnamed {
     pub name: *const i8,
     pub cat_id: i32,
-}
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr);
-    0 as *mut libc::c_void
 }
 /* tectonic/core-strutils.h: miscellaneous C string utilities
    Copyright 2016-2018 the Tectonic Project

--- a/engine/src/dpx_pdfximage.rs
+++ b/engine/src/dpx_pdfximage.rs
@@ -8,6 +8,7 @@
     unused_mut
 )]
 
+use crate::mfree;
 use crate::{info, warn};
 use crate::{streq_ptr, strstartswith};
 
@@ -308,11 +309,6 @@ pub struct ic_ {
     pub count: i32,
     pub capacity: i32,
     pub ximages: *mut pdf_ximage,
-}
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr);
-    0 as *mut libc::c_void
 }
 /* tectonic/core-strutils.h: miscellaneous C string utilities
    Copyright 2016-2018 the Tectonic Project

--- a/engine/src/dpx_pdfximage.rs
+++ b/engine/src/dpx_pdfximage.rs
@@ -1,11 +1,14 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
+use crate::strstartswith;
 use crate::{info, warn};
 
 use super::dpx_pdfdraw::pdf_dev_transform;
@@ -324,15 +327,6 @@ unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
         return strcmp(s1, s2) == 0i32;
     } /* unsafe? */
     false
-}
-#[inline]
-unsafe extern "C" fn strstartswith(mut s: *const i8, mut prefix: *const i8) -> *const i8 {
-    let mut length: size_t = 0;
-    length = strlen(prefix);
-    if strncmp(s, prefix, length) == 0i32 {
-        return s.offset(length as isize);
-    }
-    0 as *const i8
 }
 static mut _opts: opt_ = {
     let mut init = opt_ {

--- a/engine/src/dpx_pdfximage.rs
+++ b/engine/src/dpx_pdfximage.rs
@@ -8,8 +8,8 @@
     unused_mut
 )]
 
-use crate::strstartswith;
 use crate::{info, warn};
+use crate::{streq_ptr, strstartswith};
 
 use super::dpx_pdfdraw::pdf_dev_transform;
 use crate::dpx_pdfobj::{
@@ -321,13 +321,6 @@ unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    } /* unsafe? */
-    false
-}
 static mut _opts: opt_ = {
     let mut init = opt_ {
         verbose: 0i32,

--- a/engine/src/dpx_sfnt.rs
+++ b/engine/src/dpx_sfnt.rs
@@ -1,15 +1,18 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
 use crate::dpx_pdfobj::{
     pdf_add_dict, pdf_add_stream, pdf_new_name, pdf_new_number, pdf_new_stream, pdf_obj,
     pdf_release_obj, pdf_stream_dict,
 };
+use crate::mfree;
 use crate::{ttstub_input_read, ttstub_input_seek};
 use libc::free;
 extern "C" {
@@ -82,11 +85,6 @@ pub struct sfnt {
     pub directory: *mut sfnt_table_directory,
     pub handle: rust_input_handle_t,
     pub offset: u32,
-}
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr); /* tag name */
-    return 0 as *mut libc::c_void; /* typefaces number */
 }
 #[no_mangle]
 pub unsafe extern "C" fn sfnt_open(mut handle: rust_input_handle_t) -> *mut sfnt {

--- a/engine/src/dpx_spc_color.rs
+++ b/engine/src/dpx_spc_color.rs
@@ -11,6 +11,7 @@
 use super::dpx_pdfcolor::{pdf_color_clear_stack, pdf_color_pop, pdf_color_push, pdf_color_set};
 use super::dpx_pdfdoc::pdf_doc_set_bgcolor;
 use super::dpx_spc_util::spc_util_read_colorspec;
+use crate::streq_ptr;
 use libc::free;
 extern "C" {
     #[no_mangle]
@@ -46,13 +47,6 @@ pub use super::dpx_pdfcolor::pdf_color;
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
-}
 /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,

--- a/engine/src/dpx_spc_dvipdfmx.rs
+++ b/engine/src/dpx_spc_dvipdfmx.rs
@@ -1,11 +1,14 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
+use crate::streq_ptr;
 use libc::free;
 extern "C" {
     #[no_mangle]
@@ -60,13 +63,7 @@ pub struct spc_handler {
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
-}
+
 /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,

--- a/engine/src/dpx_spc_dvips.rs
+++ b/engine/src/dpx_spc_dvips.rs
@@ -8,6 +8,7 @@
     unused_mut
 )]
 
+use crate::mfree;
 use crate::strstartswith;
 use crate::warn;
 
@@ -179,11 +180,6 @@ pub struct load_options {
     pub page_no: i32,
     pub bbox_type: i32,
     pub dict: *mut pdf_obj,
-}
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr);
-    0 as *mut libc::c_void
 }
 /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 

--- a/engine/src/dpx_spc_dvips.rs
+++ b/engine/src/dpx_spc_dvips.rs
@@ -8,6 +8,7 @@
     unused_mut
 )]
 
+use crate::strstartswith;
 use crate::warn;
 
 use super::dpx_pdfdraw::pdf_dev_concat;
@@ -183,15 +184,6 @@ pub struct load_options {
 unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
     free(ptr);
     0 as *mut libc::c_void
-}
-#[inline]
-unsafe extern "C" fn strstartswith(mut s: *const i8, mut prefix: *const i8) -> *const i8 {
-    let mut length: size_t = 0;
-    length = strlen(prefix);
-    if strncmp(s, prefix, length) == 0i32 {
-        return s.offset(length as isize);
-    }
-    0 as *const i8
 }
 /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 

--- a/engine/src/dpx_spc_html.rs
+++ b/engine/src/dpx_spc_html.rs
@@ -14,6 +14,7 @@ use crate::dpx_pdfobj::{
     pdf_new_dict, pdf_new_name, pdf_new_null, pdf_new_number, pdf_new_string, pdf_obj,
     pdf_obj_typeof, pdf_ref_obj, pdf_release_obj, pdf_string_value,
 };
+use crate::streq_ptr;
 use libc::free;
 extern "C" {
     #[no_mangle]
@@ -220,13 +221,6 @@ unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
-}
 static mut _html_state: spc_html_ = {
     let mut init = spc_html_ {
         opts: {

--- a/engine/src/dpx_spc_html.rs
+++ b/engine/src/dpx_spc_html.rs
@@ -14,6 +14,7 @@ use crate::dpx_pdfobj::{
     pdf_new_dict, pdf_new_name, pdf_new_null, pdf_new_number, pdf_new_string, pdf_obj,
     pdf_obj_typeof, pdf_ref_obj, pdf_release_obj, pdf_string_value,
 };
+use crate::mfree;
 use crate::streq_ptr;
 use libc::free;
 extern "C" {
@@ -209,11 +210,6 @@ pub struct load_options {
 
 use super::dpx_pdfdev::pdf_coord;
 
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr);
-    0 as *mut libc::c_void
-}
 /* tectonic/core-strutils.h: miscellaneous C string utilities
    Copyright 2016-2018 the Tectonic Project
    Licensed under the MIT License.

--- a/engine/src/dpx_spc_pdfm.rs
+++ b/engine/src/dpx_spc_pdfm.rs
@@ -8,8 +8,8 @@
     unused_mut
 )]
 
-use crate::strstartswith;
 use crate::warn;
+use crate::{streq_ptr, strstartswith};
 
 use super::dpx_pdfcolor::{
     pdf_color_copycolor, pdf_color_get_current, pdf_color_pop, pdf_color_push, pdf_color_set,
@@ -520,13 +520,6 @@ use super::dpx_pdfdev::pdf_coord;
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
-}
 static mut _pdf_stat: spc_pdf_ = {
     let mut init = spc_pdf_ {
         annot_dict: 0 as *const pdf_obj as *mut pdf_obj,

--- a/engine/src/dpx_spc_pdfm.rs
+++ b/engine/src/dpx_spc_pdfm.rs
@@ -1,11 +1,14 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
+use crate::strstartswith;
 use crate::warn;
 
 use super::dpx_pdfcolor::{
@@ -523,15 +526,6 @@ unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
         return strcmp(s1, s2) == 0i32;
     }
     false
-}
-#[inline]
-unsafe extern "C" fn strstartswith(mut s: *const i8, mut prefix: *const i8) -> *const i8 {
-    let mut length: size_t = 0;
-    length = strlen(prefix);
-    if strncmp(s, prefix, length) == 0i32 {
-        return s.offset(length as isize);
-    }
-    0 as *const i8
 }
 static mut _pdf_stat: spc_pdf_ = {
     let mut init = spc_pdf_ {

--- a/engine/src/dpx_spc_tpic.rs
+++ b/engine/src/dpx_spc_tpic.rs
@@ -8,6 +8,7 @@
     unused_mut
 )]
 
+use crate::mfree;
 use crate::streq_ptr;
 use crate::warn;
 
@@ -166,11 +167,6 @@ use super::dpx_pdfdev::pdf_tmatrix;
    Copyright 2016-2018 the Tectonic Project
    Licensed under the MIT License.
 */
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr);
-    0 as *mut libc::c_void
-}
 unsafe extern "C" fn skip_blank(mut pp: *mut *const i8, mut endptr: *const i8) {
     let mut p: *const i8 = *pp;
     while p < endptr && (*p as i32 & !0x7fi32 == 0i32 && crate::isblank(*p as _) != 0) {

--- a/engine/src/dpx_spc_tpic.rs
+++ b/engine/src/dpx_spc_tpic.rs
@@ -8,6 +8,7 @@
     unused_mut
 )]
 
+use crate::streq_ptr;
 use crate::warn;
 
 use super::dpx_pdfcolor::{pdf_color_brighten_color, pdf_color_get_current};
@@ -161,13 +162,6 @@ pub use super::dpx_pdfcolor::pdf_color;
 
 use super::dpx_pdfdev::pdf_tmatrix;
 
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
-}
 /* tectonic/core-memory.h: basic dynamic memory helpers
    Copyright 2016-2018 the Tectonic Project
    Licensed under the MIT License.

--- a/engine/src/dpx_spc_util.rs
+++ b/engine/src/dpx_spc_util.rs
@@ -12,6 +12,7 @@ use super::dpx_pdfcolor::{
     pdf_color_cmykcolor, pdf_color_copycolor, pdf_color_graycolor, pdf_color_rgbcolor,
     pdf_color_spotcolor,
 };
+use crate::streq_ptr;
 use libc::free;
 extern "C" {
     #[no_mangle]
@@ -65,13 +66,6 @@ use super::dpx_specials::{spc_arg, spc_env};
 pub struct colordef_ {
     pub key: *const i8,
     pub color: pdf_color,
-}
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
 }
 /* tectonic/core-memory.h: basic dynamic memory helpers
    Copyright 2016-2018 the Tectonic Project

--- a/engine/src/dpx_spc_util.rs
+++ b/engine/src/dpx_spc_util.rs
@@ -12,6 +12,7 @@ use super::dpx_pdfcolor::{
     pdf_color_cmykcolor, pdf_color_copycolor, pdf_color_graycolor, pdf_color_rgbcolor,
     pdf_color_spotcolor,
 };
+use crate::mfree;
 use crate::streq_ptr;
 use libc::free;
 extern "C" {
@@ -71,11 +72,6 @@ pub struct colordef_ {
    Copyright 2016-2018 the Tectonic Project
    Licensed under the MIT License.
 */
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr);
-    0 as *mut libc::c_void
-}
 /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 
     Copyright (C) 2007-2017 by Jin-Hwan Cho and Shunsaku Hirata,

--- a/engine/src/dpx_spc_xtx.rs
+++ b/engine/src/dpx_spc_xtx.rs
@@ -1,15 +1,18 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
 use super::dpx_pdfdoc::pdf_doc_set_bgcolor;
 use super::dpx_pdfdraw::{pdf_dev_concat, pdf_dev_get_fixed_point, pdf_dev_set_fixed_point};
 use super::dpx_spc_util::spc_util_read_colorspec;
 use crate::dpx_pdfparse::{parse_ident, parse_val_ident};
+use crate::streq_ptr;
 use libc::free;
 extern "C" {
     #[no_mangle]
@@ -206,13 +209,6 @@ pub use super::dpx_pdfcolor::pdf_color;
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
-}
 /*  This is xdvipdfmx, an extended version of dvipdfmx,
     an eXtended version of dvipdfm by Mark A. Wicks.
 

--- a/engine/src/dpx_subfont.rs
+++ b/engine/src/dpx_subfont.rs
@@ -8,6 +8,7 @@
     unused_mut
 )]
 
+use crate::streq_ptr;
 use crate::{info, warn};
 
 use crate::{ttstub_input_close, ttstub_input_open, ttstub_input_seek};
@@ -132,13 +133,6 @@ pub struct sfd_file_ {
 pub struct sfd_rec_ {
     pub vector: [u16; 256],
     /* 0 for undefined */
-}
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
 }
 /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 

--- a/engine/src/dpx_t1_char.rs
+++ b/engine/src/dpx_t1_char.rs
@@ -1,11 +1,14 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
+use crate::mfree;
 use crate::warn;
 
 use libc::free;
@@ -169,11 +172,6 @@ pub struct t1_stemgroup {
    Copyright 2016-2018 the Tectonic Project
    Licensed under the MIT License.
 */
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr);
-    0 as *mut libc::c_void
-}
 static mut status: i32 = -1i32;
 static mut phase: i32 = -1i32;
 static mut nest: i32 = -1i32;

--- a/engine/src/dpx_t1_load.rs
+++ b/engine/src/dpx_t1_load.rs
@@ -8,6 +8,7 @@
     unused_mut
 )]
 
+use crate::mfree;
 use crate::warn;
 use crate::{streq_ptr, strstartswith};
 
@@ -353,11 +354,6 @@ pub struct cff_font {
     pub is_notdef_notzero: i32,
 }
 pub type pst_type = i32;
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr);
-    0 as *mut libc::c_void
-}
 /* tectonic/core-strutils.h: miscellaneous C string utilities
    Copyright 2016-2018 the Tectonic Project
    Licensed under the MIT License.

--- a/engine/src/dpx_t1_load.rs
+++ b/engine/src/dpx_t1_load.rs
@@ -1,11 +1,14 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
+use crate::strstartswith;
 use crate::warn;
 
 use crate::{ttstub_input_getc, ttstub_input_read, ttstub_input_seek};
@@ -368,15 +371,6 @@ unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
         return strcmp(s1, s2) == 0i32;
     }
     false
-}
-#[inline]
-unsafe extern "C" fn strstartswith(mut s: *const i8, mut prefix: *const i8) -> *const i8 {
-    let mut length: size_t = 0;
-    length = strlen(prefix);
-    if strncmp(s, prefix, length) == 0i32 {
-        return s.offset(length as isize);
-    }
-    0 as *const i8
 }
 unsafe extern "C" fn t1_decrypt(
     mut key: u16,

--- a/engine/src/dpx_t1_load.rs
+++ b/engine/src/dpx_t1_load.rs
@@ -8,8 +8,8 @@
     unused_mut
 )]
 
-use crate::strstartswith;
 use crate::warn;
+use crate::{streq_ptr, strstartswith};
 
 use crate::{ttstub_input_getc, ttstub_input_read, ttstub_input_seek};
 use libc::free;
@@ -365,13 +365,6 @@ unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
-}
 unsafe extern "C" fn t1_decrypt(
     mut key: u16,
     mut dst: *mut u8,

--- a/engine/src/dpx_tfm.rs
+++ b/engine/src/dpx_tfm.rs
@@ -8,6 +8,7 @@
     unused_mut
 )]
 
+use crate::mfree;
 use crate::streq_ptr;
 use crate::{info, warn};
 
@@ -176,11 +177,6 @@ pub struct range_map {
 pub struct char_map {
     pub coverage: coverage,
     pub indices: *mut u16,
-}
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr);
-    0 as *mut libc::c_void
 }
 /* tectonic/core-strutils.h: miscellaneous C string utilities
    Copyright 2016-2018 the Tectonic Project

--- a/engine/src/dpx_tfm.rs
+++ b/engine/src/dpx_tfm.rs
@@ -1,11 +1,14 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
+use crate::streq_ptr;
 use crate::{info, warn};
 
 use crate::{ttstub_input_close, ttstub_input_get_size, ttstub_input_open, ttstub_input_seek};
@@ -186,13 +189,6 @@ unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
-}
 static mut verbose: i32 = 0i32;
 unsafe extern "C" fn tfm_font_init(mut tfm: *mut tfm_font) {
     (*tfm).header = 0 as *mut fixword;

--- a/engine/src/dpx_truetype.rs
+++ b/engine/src/dpx_truetype.rs
@@ -8,6 +8,7 @@
     unused_mut
 )]
 
+use crate::streq_ptr;
 use crate::{info, warn};
 
 use crate::dpx_pdfobj::{
@@ -458,13 +459,6 @@ pub struct agl_name {
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
-}
 /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 
    Copyright (C) 2007-2016 by Jin-Hwan Cho and Shunsaku Hirata,

--- a/engine/src/dpx_tt_cmap.rs
+++ b/engine/src/dpx_tt_cmap.rs
@@ -1,14 +1,17 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
 use crate::{info, warn};
 
 use crate::dpx_pdfobj::pdf_obj;
+use crate::mfree;
 use crate::{ttstub_input_close, ttstub_input_seek};
 use libc::free;
 extern "C" {
@@ -768,11 +771,6 @@ pub struct tt_maxp_table {
     pub maxSizeOfInstructions: u16,
     pub maxComponentElements: u16,
     pub maxComponentDepth: u16,
-}
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr); /* the number of subHeaders is one plus the max of subHeaderKeys */
-    0 as *mut libc::c_void
 }
 static mut verbose: i32 = 0i32;
 #[no_mangle]

--- a/engine/src/dpx_tt_gsub.rs
+++ b/engine/src/dpx_tt_gsub.rs
@@ -1,11 +1,14 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
+use crate::streq_ptr;
 use crate::{info, warn};
 
 use crate::ttstub_input_seek;
@@ -296,13 +299,6 @@ unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
-}
 static mut verbose: i32 = 0i32;
 #[no_mangle]
 pub unsafe extern "C" fn otl_gsub_set_verbose(mut level: i32) {

--- a/engine/src/dpx_tt_gsub.rs
+++ b/engine/src/dpx_tt_gsub.rs
@@ -8,6 +8,7 @@
     unused_mut
 )]
 
+use crate::mfree;
 use crate::streq_ptr;
 use crate::{info, warn};
 
@@ -286,11 +287,6 @@ pub struct clt_langsys_table {
     pub LookupOrder: Offset,
     pub ReqFeatureIndex: u16,
     pub FeatureIndex: clt_number_list,
-}
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr);
-    0 as *mut libc::c_void
 }
 /* tectonic/core-strutils.h: miscellaneous C string utilities
    Copyright 2016-2018 the Tectonic Project

--- a/engine/src/dpx_tt_post.rs
+++ b/engine/src/dpx_tt_post.rs
@@ -1,11 +1,14 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
+use crate::streq_ptr;
 use crate::warn;
 
 use crate::ttstub_input_read;
@@ -133,13 +136,6 @@ pub struct tt_post_table {
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
-}
 /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,

--- a/engine/src/dpx_type0.rs
+++ b/engine/src/dpx_type0.rs
@@ -1,15 +1,18 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
 use crate::dpx_pdfobj::{
     pdf_add_array, pdf_add_dict, pdf_add_stream, pdf_link_obj, pdf_lookup_dict, pdf_new_array,
     pdf_new_dict, pdf_new_name, pdf_new_stream, pdf_obj, pdf_ref_obj, pdf_release_obj,
 };
+use crate::streq_ptr;
 use libc::free;
 extern "C" {
     pub type CIDFont;
@@ -269,13 +272,6 @@ pub struct rangeDef {
     pub dim: size_t,
     pub codeLo: *mut u8,
     pub codeHi: *mut u8,
-}
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
 }
 static mut __verbose: i32 = 0i32;
 #[no_mangle]

--- a/engine/src/dpx_type1.rs
+++ b/engine/src/dpx_type1.rs
@@ -8,6 +8,7 @@
     unused_mut
 )]
 
+use crate::mfree;
 use crate::streq_ptr;
 use crate::{info, warn};
 
@@ -414,11 +415,6 @@ pub struct C2RustUnnamed_3 {
     pub lly: f64,
     pub urx: f64,
     pub ury: f64,
-}
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr);
-    0 as *mut libc::c_void
 }
 /* tectonic/core-strutils.h: miscellaneous C string utilities
    Copyright 2016-2018 the Tectonic Project

--- a/engine/src/dpx_type1.rs
+++ b/engine/src/dpx_type1.rs
@@ -1,11 +1,14 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
+use crate::streq_ptr;
 use crate::{info, warn};
 
 use crate::dpx_pdfobj::{
@@ -424,13 +427,7 @@ unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
-}
+
 /* Force bold at small text sizes */
 unsafe extern "C" fn is_basefont(mut name: *const i8) -> bool {
     static mut basefonts: [*const i8; 14] = [

--- a/engine/src/dpx_type1c.rs
+++ b/engine/src/dpx_type1c.rs
@@ -1,11 +1,14 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
+use crate::streq_ptr;
 use crate::{info, warn};
 
 use crate::dpx_pdfobj::{
@@ -560,13 +563,6 @@ pub struct C2RustUnnamed_3 {
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
-}
 /* This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 
    Copyright (C) 2008-2016 by Jin-Hwan Cho, Matthias Franz, and Shunsaku Hirata,

--- a/engine/src/dpx_vf.rs
+++ b/engine/src/dpx_vf.rs
@@ -1,11 +1,14 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
+use crate::streq_ptr;
 use crate::warn;
 
 use crate::{ttstub_input_close, ttstub_input_open, ttstub_input_read};
@@ -179,13 +182,6 @@ pub struct font_def {
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
-}
 static mut verbose: u8 = 0_u8;
 #[no_mangle]
 pub unsafe extern "C" fn vf_set_verbose(mut level: i32) {

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -1063,3 +1063,12 @@ pub(crate) unsafe extern "C" fn mfree(ptr: *mut libc::c_void) -> *mut libc::c_vo
 pub(crate) unsafe extern "C" fn is_char_node(p: i32) -> bool {
     p >= xetex_ini::hi_mem_min
 }
+
+#[inline]
+unsafe extern "C" fn print_c_string(mut str: *const i8) {
+    while *str != 0 {
+        let fresh0 = str;
+        str = str.offset(1);
+        xetex_output::print_char(*fresh0 as i32);
+    }
+}

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -1052,3 +1052,9 @@ pub(crate) unsafe extern "C" fn streq_ptr(s1: *const i8, s2: *const i8) -> bool 
     }
     false
 }
+
+#[inline]
+pub(crate) unsafe extern "C" fn mfree(ptr: *mut libc::c_void) -> *mut libc::c_void {
+    libc::free(ptr);
+    std::ptr::null_mut()
+}

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -1072,3 +1072,9 @@ unsafe extern "C" fn print_c_string(mut str: *const i8) {
         xetex_output::print_char(*fresh0 as i32);
     }
 }
+
+#[inline]
+unsafe extern "C" fn is_non_discardable_node(p: i32) -> bool {
+    use xetex_ini::mem;
+    ((*mem.offset(p as isize)).b16.s1 as i32) < 9i32
+}

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -1044,3 +1044,11 @@ pub(crate) unsafe extern "C" fn strstartswith(s: *const i8, prefix: *const i8) -
     }
     0 as *const i8
 }
+
+#[inline]
+pub(crate) unsafe extern "C" fn streq_ptr(s1: *const i8, s2: *const i8) -> bool {
+    if !s1.is_null() && !s2.is_null() {
+        return libc::strcmp(s1, s2) == 0i32;
+    }
+    false
+}

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -1029,6 +1029,7 @@ mod xetex_xetex0;
 mod macro_stub;
 mod stub_errno;
 mod stub_icu;
+mod xetex_xetexd;
 
 pub use xetex_engine_interface::tt_xetex_set_int_variable;
 
@@ -1057,24 +1058,4 @@ pub(crate) unsafe extern "C" fn streq_ptr(s1: *const i8, s2: *const i8) -> bool 
 pub(crate) unsafe extern "C" fn mfree(ptr: *mut libc::c_void) -> *mut libc::c_void {
     libc::free(ptr);
     std::ptr::null_mut()
-}
-
-#[inline]
-pub(crate) unsafe extern "C" fn is_char_node(p: i32) -> bool {
-    p >= xetex_ini::hi_mem_min
-}
-
-#[inline]
-unsafe extern "C" fn print_c_string(mut str: *const i8) {
-    while *str != 0 {
-        let fresh0 = str;
-        str = str.offset(1);
-        xetex_output::print_char(*fresh0 as i32);
-    }
-}
-
-#[inline]
-unsafe extern "C" fn is_non_discardable_node(p: i32) -> bool {
-    use xetex_ini::mem;
-    ((*mem.offset(p as isize)).b16.s1 as i32) < 9i32
 }

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -1058,3 +1058,8 @@ pub(crate) unsafe extern "C" fn mfree(ptr: *mut libc::c_void) -> *mut libc::c_vo
     libc::free(ptr);
     std::ptr::null_mut()
 }
+
+#[inline]
+pub(crate) unsafe extern "C" fn is_char_node(p: i32) -> bool {
+    p >= xetex_ini::hi_mem_min
+}

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -1035,3 +1035,12 @@ pub use xetex_engine_interface::tt_xetex_set_int_variable;
 pub(crate) fn isblank(c: libc::c_int) -> libc::c_int {
     (c == ' ' as _ || c == '\t' as _) as _
 }
+
+#[inline]
+pub(crate) unsafe extern "C" fn strstartswith(s: *const i8, prefix: *const i8) -> *const i8 {
+    let length = libc::strlen(prefix);
+    if libc::strncmp(s, prefix, length) == 0i32 {
+        return s.offset(length as isize);
+    }
+    0 as *const i8
+}

--- a/engine/src/xetex_engine_interface.rs
+++ b/engine/src/xetex_engine_interface.rs
@@ -1,11 +1,14 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
+use crate::streq_ptr;
 extern "C" {
     #[no_mangle]
     fn strcmp(_: *const i8, _: *const i8) -> i32;
@@ -25,13 +28,6 @@ extern "C" {
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
-}
 /* engine-interface.c: programmatic interface to control the engine behavior
    Copyright 2016-2018 The Tectonic Project
    Licensed under the MIT License.

--- a/engine/src/xetex_ext.rs
+++ b/engine/src/xetex_ext.rs
@@ -8,8 +8,8 @@
     unused_mut
 )]
 
-use crate::strstartswith;
 use crate::stub_icu as icu;
+use crate::{streq_ptr, strstartswith};
 use crate::{ttstub_input_close, ttstub_input_get_size, ttstub_input_open, ttstub_input_read};
 use libc::free;
 
@@ -527,13 +527,6 @@ unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-#[inline]
-unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
-    if !s1.is_null() && !s2.is_null() {
-        return strcmp(s1, s2) == 0i32;
-    }
-    false
-}
 /* ***************************************************************************\
  Part of the XeTeX typesetting system
  Copyright (c) 1994-2008 by SIL International

--- a/engine/src/xetex_ext.rs
+++ b/engine/src/xetex_ext.rs
@@ -1,10 +1,14 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+
+use crate::strstartswith;
 use crate::stub_icu as icu;
 use crate::{ttstub_input_close, ttstub_input_get_size, ttstub_input_open, ttstub_input_read};
 use libc::free;
@@ -529,15 +533,6 @@ unsafe extern "C" fn streq_ptr(mut s1: *const i8, mut s2: *const i8) -> bool {
         return strcmp(s1, s2) == 0i32;
     }
     false
-}
-#[inline]
-unsafe extern "C" fn strstartswith(mut s: *const i8, mut prefix: *const i8) -> *const i8 {
-    let mut length: size_t = 0;
-    length = strlen(prefix);
-    if strncmp(s, prefix, length) == 0i32 {
-        return s.offset(length as isize);
-    }
-    0 as *const i8
 }
 /* ***************************************************************************\
  Part of the XeTeX typesetting system

--- a/engine/src/xetex_ext.rs
+++ b/engine/src/xetex_ext.rs
@@ -8,6 +8,7 @@
     unused_mut
 )]
 
+use crate::mfree;
 use crate::stub_icu as icu;
 use crate::{streq_ptr, strstartswith};
 use crate::{ttstub_input_close, ttstub_input_get_size, ttstub_input_open, ttstub_input_read};
@@ -515,11 +516,6 @@ pub struct b16x4_le_t {
     pub s3: u16,
 }
 pub type UniChar = UInt16;
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr);
-    0 as *mut libc::c_void
-}
 /* tectonic/core-strutils.h: miscellaneous C string utilities
    Copyright 2016-2018 the Tectonic Project
    Licensed under the MIT License.

--- a/engine/src/xetex_ext.rs
+++ b/engine/src/xetex_ext.rs
@@ -9,8 +9,8 @@
 )]
 
 use crate::mfree;
-use crate::print_c_string;
 use crate::stub_icu as icu;
+use crate::xetex_xetexd::print_c_string;
 use crate::{streq_ptr, strstartswith};
 use crate::{ttstub_input_close, ttstub_input_get_size, ttstub_input_open, ttstub_input_read};
 use libc::free;

--- a/engine/src/xetex_ext.rs
+++ b/engine/src/xetex_ext.rs
@@ -9,6 +9,7 @@
 )]
 
 use crate::mfree;
+use crate::print_c_string;
 use crate::stub_icu as icu;
 use crate::{streq_ptr, strstartswith};
 use crate::{ttstub_input_close, ttstub_input_get_size, ttstub_input_open, ttstub_input_read};
@@ -566,17 +567,6 @@ unsafe extern "C" fn SWAP32(p: u32) -> u32 {
         .wrapping_add(p << 24i32)
 }
 /* xetex-shipout */
-/* Inlines */
-#[inline]
-unsafe extern "C" fn print_c_string(mut str: *const i8) {
-    /* Strings printed this way will end up in the .log as well
-     * as the terminal output. */
-    while *str != 0 {
-        let fresh0 = str;
-        str = str.offset(1);
-        print_char(*fresh0 as i32);
-    }
-}
 /* ***************************************************************************\
  Part of the XeTeX typesetting system
  Copyright (c) 1994-2008 by SIL International

--- a/engine/src/xetex_ini.rs
+++ b/engine/src/xetex_ini.rs
@@ -9,11 +9,11 @@
 )]
 
 use super::xetex_texmfmp::get_date_and_time;
+use crate::mfree;
 use crate::{
     ttstub_input_close, ttstub_input_open, ttstub_input_read, ttstub_output_close,
     ttstub_output_flush, ttstub_output_open, ttstub_output_open_stdout, ttstub_output_write,
 };
-use crate::mfree;
 use libc::free;
 extern "C" {
     #[no_mangle]
@@ -608,25 +608,8 @@ pub struct input_state_t {
    Copyright 2016-2018 the Tectonic Project
    Licensed under the MIT License.
 */
-<<<<<<< HEAD
 
 pub use super::xetex_io::UFILE;
-
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr);
-    0 as *mut libc::c_void
-=======
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct UFILE {
-    pub handle: rust_input_handle_t,
-    pub savedChar: i64,
-    pub skipNextLF: i16,
-    pub encodingMode: i16,
-    pub conversionData: *mut libc::c_void,
->>>>>>> 979ea0d1... gather mfree
-}
 /* xetex-ini.c: WEB initialization code translated to C
    Copyright 2016-2018 The Tectonic Project
    Licensed under the MIT License.
@@ -776,7 +759,7 @@ pub static mut mem: *mut memory_word = 0 as *const memory_word as *mut memory_wo
 #[no_mangle]
 pub static mut lo_mem_max: i32 = 0;
 #[no_mangle]
-pub static mut hi_mem_min: i32 = 0;
+pub(crate) static mut hi_mem_min: i32 = 0;
 #[no_mangle]
 pub static mut var_used: i32 = 0;
 #[no_mangle]

--- a/engine/src/xetex_ini.rs
+++ b/engine/src/xetex_ini.rs
@@ -1,16 +1,19 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
 use super::xetex_texmfmp::get_date_and_time;
 use crate::{
     ttstub_input_close, ttstub_input_open, ttstub_input_read, ttstub_output_close,
     ttstub_output_flush, ttstub_output_open, ttstub_output_open_stdout, ttstub_output_write,
 };
+use crate::mfree;
 use libc::free;
 extern "C" {
     #[no_mangle]
@@ -605,6 +608,7 @@ pub struct input_state_t {
    Copyright 2016-2018 the Tectonic Project
    Licensed under the MIT License.
 */
+<<<<<<< HEAD
 
 pub use super::xetex_io::UFILE;
 
@@ -612,6 +616,16 @@ pub use super::xetex_io::UFILE;
 unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
     free(ptr);
     0 as *mut libc::c_void
+=======
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct UFILE {
+    pub handle: rust_input_handle_t,
+    pub savedChar: i64,
+    pub skipNextLF: i16,
+    pub encodingMode: i16,
+    pub conversionData: *mut libc::c_void,
+>>>>>>> 979ea0d1... gather mfree
 }
 /* xetex-ini.c: WEB initialization code translated to C
    Copyright 2016-2018 The Tectonic Project

--- a/engine/src/xetex_io.rs
+++ b/engine/src/xetex_io.rs
@@ -8,9 +8,9 @@
     unused_mut
 )]
 
-use crate::print_c_string;
 use crate::stub_errno as errno;
 use crate::stub_icu as icu;
+use crate::xetex_xetexd::print_c_string;
 use crate::{
     ttstub_input_close, ttstub_input_getc, ttstub_input_open, ttstub_input_open_primary,
     ttstub_input_seek, ttstub_input_ungetc,

--- a/engine/src/xetex_io.rs
+++ b/engine/src/xetex_io.rs
@@ -1,10 +1,14 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+
+use crate::print_c_string;
 use crate::stub_errno as errno;
 use crate::stub_icu as icu;
 use crate::{
@@ -12,6 +16,7 @@ use crate::{
     ttstub_input_seek, ttstub_input_ungetc,
 };
 use libc::free;
+
 extern "C" {
     pub type Opaque_TECkit_Converter;
     #[no_mangle]
@@ -417,14 +422,6 @@ pub struct UFILE {
     pub conversionData: *mut libc::c_void,
 }
 
-#[inline]
-unsafe extern "C" fn print_c_string(mut str: *const i8) {
-    while *str != 0 {
-        let fresh0 = str;
-        str = str.offset(1);
-        print_char(*fresh0 as i32);
-    }
-}
 /* tectonic/xetex-io.c: low-level input/output functions tied to the XeTeX engine
    Copyright 2016-2019 The Tectonic Project
    Licensed under the MIT License.

--- a/engine/src/xetex_linebreak.rs
+++ b/engine/src/xetex_linebreak.rs
@@ -9,7 +9,7 @@
 )]
 
 use crate::xetex_ini::hi_mem_min;
-use crate::{is_char_node, is_non_discardable_node};
+use crate::xetex_xetexd::{is_char_node, is_non_discardable_node};
 
 extern "C" {
     #[no_mangle]

--- a/engine/src/xetex_linebreak.rs
+++ b/engine/src/xetex_linebreak.rs
@@ -8,8 +8,8 @@
     unused_mut
 )]
 
-use crate::is_char_node;
 use crate::xetex_ini::hi_mem_min;
+use crate::{is_char_node, is_non_discardable_node};
 
 extern "C" {
     #[no_mangle]
@@ -258,10 +258,6 @@ pub struct list_state_record {
     pub prev_graf: i32,
     pub mode_line: i32,
     pub aux: memory_word,
-}
-#[inline]
-unsafe extern "C" fn is_non_discardable_node(p: i32) -> bool {
-    ((*mem.offset(p as isize)).b16.s1 as i32) < 9i32
 }
 static mut passive: i32 = 0;
 static mut cur_active_width: [scaled_t; 7] = [0; 7];

--- a/engine/src/xetex_linebreak.rs
+++ b/engine/src/xetex_linebreak.rs
@@ -1,10 +1,15 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+
+use crate::is_char_node;
+use crate::xetex_ini::hi_mem_min;
 
 extern "C" {
     #[no_mangle]
@@ -27,8 +32,6 @@ extern "C" {
     static mut temp_ptr: i32;
     #[no_mangle]
     static mut mem: *mut memory_word;
-    #[no_mangle]
-    static mut hi_mem_min: i32;
     #[no_mangle]
     static mut avail: i32;
     #[no_mangle]
@@ -255,10 +258,6 @@ pub struct list_state_record {
     pub prev_graf: i32,
     pub mode_line: i32,
     pub aux: memory_word,
-}
-#[inline]
-unsafe extern "C" fn is_char_node(p: i32) -> bool {
-    p >= hi_mem_min
 }
 #[inline]
 unsafe extern "C" fn is_non_discardable_node(p: i32) -> bool {

--- a/engine/src/xetex_math.rs
+++ b/engine/src/xetex_math.rs
@@ -8,7 +8,7 @@
     unused_mut
 )]
 
-use crate::is_char_node;
+use crate::xetex_xetexd::is_char_node;
 
 extern "C" {
     pub type XeTeXLayoutEngine_rec;

--- a/engine/src/xetex_math.rs
+++ b/engine/src/xetex_math.rs
@@ -1,10 +1,14 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+
+use crate::is_char_node;
 
 extern "C" {
     pub type XeTeXLayoutEngine_rec;
@@ -24,8 +28,6 @@ extern "C" {
     static mut temp_ptr: i32;
     #[no_mangle]
     static mut mem: *mut memory_word;
-    #[no_mangle]
-    static mut hi_mem_min: i32;
     #[no_mangle]
     static mut avail: i32;
     #[no_mangle]
@@ -381,11 +383,6 @@ pub struct list_state_record {
     pub prev_graf: i32,
     pub mode_line: i32,
     pub aux: memory_word,
-}
-/* Inlines */
-#[inline]
-unsafe extern "C" fn is_char_node(p: i32) -> bool {
-    p >= hi_mem_min
 }
 static mut null_delimiter: b16x4 = b16x4 {
     s0: 0,

--- a/engine/src/xetex_pagebuilder.rs
+++ b/engine/src/xetex_pagebuilder.rs
@@ -1,11 +1,14 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
+use crate::is_non_discardable_node;
 extern "C" {
     /* Needed here for UFILE */
     /* variables! */
@@ -195,10 +198,6 @@ pub struct list_state_record {
     pub prev_graf: i32,
     pub mode_line: i32,
     pub aux: memory_word,
-}
-#[inline]
-unsafe extern "C" fn is_non_discardable_node(p: i32) -> bool {
-    ((*mem.offset(p as isize)).b16.s1 as i32) < 9i32
 }
 /* tectonic/xetex-pagebuilder.c: the page builder
    Copyright 2017-2018 The Tectonic Project

--- a/engine/src/xetex_pagebuilder.rs
+++ b/engine/src/xetex_pagebuilder.rs
@@ -8,7 +8,7 @@
     unused_mut
 )]
 
-use crate::is_non_discardable_node;
+use crate::xetex_xetexd::is_non_discardable_node;
 extern "C" {
     /* Needed here for UFILE */
     /* variables! */

--- a/engine/src/xetex_shipout.rs
+++ b/engine/src/xetex_shipout.rs
@@ -1,15 +1,18 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
+use super::xetex_ini::selector;
+use crate::is_char_node;
 use crate::{ttstub_output_close, ttstub_output_flush, ttstub_output_open, ttstub_output_write};
 use libc::free;
 
-use super::xetex_ini::selector;
 extern "C" {
     #[no_mangle]
     fn strlen(_: *const i8) -> u64;
@@ -59,8 +62,6 @@ extern "C" {
     static mut temp_ptr: i32;
     #[no_mangle]
     static mut mem: *mut memory_word;
-    #[no_mangle]
-    static mut hi_mem_min: i32;
     #[no_mangle]
     static mut avail: i32;
     #[no_mangle]
@@ -574,10 +575,6 @@ unsafe extern "C" fn print_c_string(mut str: *const i8) {
 #[inline]
 unsafe extern "C" fn cur_length() -> pool_pointer {
     pool_ptr - *str_start.offset((str_ptr - 65536i32) as isize)
-}
-#[inline]
-unsafe extern "C" fn is_char_node(p: i32) -> bool {
-    p >= hi_mem_min
 }
 /* DVI code */
 static mut dvi_file: rust_output_handle_t = 0 as *const libc::c_void as *mut libc::c_void;

--- a/engine/src/xetex_shipout.rs
+++ b/engine/src/xetex_shipout.rs
@@ -9,7 +9,7 @@
 )]
 
 use super::xetex_ini::selector;
-use crate::{is_char_node, print_c_string};
+use crate::xetex_xetexd::{is_char_node, print_c_string};
 use crate::{ttstub_output_close, ttstub_output_flush, ttstub_output_open, ttstub_output_write};
 use libc::free;
 

--- a/engine/src/xetex_shipout.rs
+++ b/engine/src/xetex_shipout.rs
@@ -9,7 +9,7 @@
 )]
 
 use super::xetex_ini::selector;
-use crate::is_char_node;
+use crate::{is_char_node, print_c_string};
 use crate::{ttstub_output_close, ttstub_output_flush, ttstub_output_open, ttstub_output_write};
 use libc::free;
 
@@ -563,14 +563,6 @@ pub struct list_state_record {
     pub prev_graf: i32,
     pub mode_line: i32,
     pub aux: memory_word,
-}
-#[inline]
-unsafe extern "C" fn print_c_string(mut str: *const i8) {
-    while *str != 0 {
-        let fresh0 = str;
-        str = str.offset(1);
-        print_char(*fresh0 as i32);
-    }
 }
 #[inline]
 unsafe extern "C" fn cur_length() -> pool_pointer {

--- a/engine/src/xetex_synctex.rs
+++ b/engine/src/xetex_synctex.rs
@@ -8,6 +8,7 @@
     unused_mut
 )]
 
+use crate::mfree;
 use crate::{
     ttstub_fprintf, ttstub_issue_error, ttstub_issue_warning, ttstub_output_close,
     ttstub_output_open,
@@ -191,11 +192,6 @@ pub struct Context {
  *  eventually modified by the magnification.
  */
 type synctex_recorder_t = Option<unsafe extern "C" fn(_: i32) -> ()>;
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr);
-    0 as *mut libc::c_void
-}
 
 const default_synctex_ctxt: Context = Context {
     file: ptr::null_mut(),

--- a/engine/src/xetex_xetex0.rs
+++ b/engine/src/xetex_xetex0.rs
@@ -10,10 +10,10 @@
 
 use super::xetex_ini::{history, old_setting, selector};
 use super::xetex_io::{tt_xetex_open_input, u_open_in};
-use crate::is_char_node;
 use crate::mfree;
 use crate::print_c_string;
 use crate::xetex_ini::hi_mem_min;
+use crate::{is_char_node, is_non_discardable_node};
 use crate::{
     ttstub_input_close, ttstub_input_getc, ttstub_issue_warning, ttstub_output_close,
     ttstub_output_flush, ttstub_output_open, ttstub_output_putc,
@@ -1190,10 +1190,6 @@ pub use super::xetex_io::UFILE;
 unsafe extern "C" fn cur_length() -> pool_pointer {
     /*41: The length of the current string in the pool */
     pool_ptr - *str_start.offset((str_ptr - 65536i32) as isize)
-}
-#[inline]
-unsafe extern "C" fn is_non_discardable_node(p: i32) -> bool {
-    ((*mem.offset(p as isize)).b16.s1 as i32) < 9i32
 }
 /* xetex-xetex0.c: bulk of the WEB code translated to C
    Copyright 2016-2018 The Tectonic Project

--- a/engine/src/xetex_xetex0.rs
+++ b/engine/src/xetex_xetex0.rs
@@ -10,11 +10,13 @@
 
 use super::xetex_ini::{history, old_setting, selector};
 use super::xetex_io::{tt_xetex_open_input, u_open_in};
+use crate::is_char_node;
+use crate::mfree;
+use crate::xetex_ini::hi_mem_min;
 use crate::{
     ttstub_input_close, ttstub_input_getc, ttstub_issue_warning, ttstub_output_close,
     ttstub_output_flush, ttstub_output_open, ttstub_output_putc,
 };
-use crate::mfree;
 use libc::free;
 extern "C" {
     pub type XeTeXLayoutEngine_rec;
@@ -168,8 +170,6 @@ extern "C" {
     static mut mem: *mut memory_word;
     #[no_mangle]
     static mut lo_mem_max: i32;
-    #[no_mangle]
-    static mut hi_mem_min: i32;
     #[no_mangle]
     static mut avail: i32;
     #[no_mangle]
@@ -1177,33 +1177,12 @@ pub struct input_state_t {
     pub name: i32,
     pub synctex_tag: i32,
 }
-<<<<<<< HEAD
 
 pub use super::xetex_io::UFILE;
 
-#[inline]
-unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
-    free(ptr);
-    0 as *mut libc::c_void
-=======
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct UFILE {
-    pub handle: rust_input_handle_t,
-    pub savedChar: i64,
-    pub skipNextLF: i16,
-    pub encodingMode: i16,
-    pub conversionData: *mut libc::c_void,
->>>>>>> 979ea0d1... gather mfree
-}
 /* xetex-pagebuilder */
 /* xetex-scaledmath */
 /* xetex-shipout */
-/* Inlines */
-#[inline]
-unsafe extern "C" fn is_char_node(p: i32) -> bool {
-    p >= hi_mem_min
-}
 /* Strings printed this way will end up in the .log as well
  * as the terminal output. */
 #[inline]

--- a/engine/src/xetex_xetex0.rs
+++ b/engine/src/xetex_xetex0.rs
@@ -1,10 +1,12 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 
 use super::xetex_ini::{history, old_setting, selector};
 use super::xetex_io::{tt_xetex_open_input, u_open_in};
@@ -12,6 +14,7 @@ use crate::{
     ttstub_input_close, ttstub_input_getc, ttstub_issue_warning, ttstub_output_close,
     ttstub_output_flush, ttstub_output_open, ttstub_output_putc,
 };
+use crate::mfree;
 use libc::free;
 extern "C" {
     pub type XeTeXLayoutEngine_rec;
@@ -1174,6 +1177,7 @@ pub struct input_state_t {
     pub name: i32,
     pub synctex_tag: i32,
 }
+<<<<<<< HEAD
 
 pub use super::xetex_io::UFILE;
 
@@ -1181,6 +1185,16 @@ pub use super::xetex_io::UFILE;
 unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
     free(ptr);
     0 as *mut libc::c_void
+=======
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct UFILE {
+    pub handle: rust_input_handle_t,
+    pub savedChar: i64,
+    pub skipNextLF: i16,
+    pub encodingMode: i16,
+    pub conversionData: *mut libc::c_void,
+>>>>>>> 979ea0d1... gather mfree
 }
 /* xetex-pagebuilder */
 /* xetex-scaledmath */

--- a/engine/src/xetex_xetex0.rs
+++ b/engine/src/xetex_xetex0.rs
@@ -11,9 +11,9 @@
 use super::xetex_ini::{history, old_setting, selector};
 use super::xetex_io::{tt_xetex_open_input, u_open_in};
 use crate::mfree;
-use crate::print_c_string;
 use crate::xetex_ini::hi_mem_min;
-use crate::{is_char_node, is_non_discardable_node};
+use crate::xetex_xetexd::print_c_string;
+use crate::xetex_xetexd::{is_char_node, is_non_discardable_node};
 use crate::{
     ttstub_input_close, ttstub_input_getc, ttstub_issue_warning, ttstub_output_close,
     ttstub_output_flush, ttstub_output_open, ttstub_output_putc,

--- a/engine/src/xetex_xetex0.rs
+++ b/engine/src/xetex_xetex0.rs
@@ -12,6 +12,7 @@ use super::xetex_ini::{history, old_setting, selector};
 use super::xetex_io::{tt_xetex_open_input, u_open_in};
 use crate::is_char_node;
 use crate::mfree;
+use crate::print_c_string;
 use crate::xetex_ini::hi_mem_min;
 use crate::{
     ttstub_input_close, ttstub_input_getc, ttstub_issue_warning, ttstub_output_close,
@@ -1193,14 +1194,6 @@ unsafe extern "C" fn cur_length() -> pool_pointer {
 #[inline]
 unsafe extern "C" fn is_non_discardable_node(p: i32) -> bool {
     ((*mem.offset(p as isize)).b16.s1 as i32) < 9i32
-}
-#[inline]
-unsafe extern "C" fn print_c_string(mut str: *const i8) {
-    while *str != 0 {
-        let fresh0 = str;
-        str = str.offset(1);
-        print_char(*fresh0 as i32);
-    }
 }
 /* xetex-xetex0.c: bulk of the WEB code translated to C
    Copyright 2016-2018 The Tectonic Project

--- a/engine/src/xetex_xetexd.rs
+++ b/engine/src/xetex_xetexd.rs
@@ -1,0 +1,21 @@
+use crate::{xetex_ini, xetex_output};
+
+#[inline]
+pub(crate) unsafe extern "C" fn is_non_discardable_node(p: i32) -> bool {
+    use xetex_ini::mem;
+    ((*mem.offset(p as isize)).b16.s1 as i32) < 9i32
+}
+
+#[inline]
+pub(crate) unsafe extern "C" fn is_char_node(p: i32) -> bool {
+    p >= xetex_ini::hi_mem_min
+}
+
+#[inline]
+pub(crate) unsafe extern "C" fn print_c_string(mut str: *const i8) {
+    while *str != 0 {
+        let fresh0 = str;
+        str = str.offset(1);
+        xetex_output::print_char(*fresh0 as i32);
+    }
+}


### PR DESCRIPTION
This recombines inlined functions, as rust can inline across files.

I was not quite sure where to put the resulting functions, so I put them at the end of lib.rs. Please let me know if you would like me to move them somewhere more appropriate!