### PR TITLE
use hashmap in dpx_spc_pdfm.rs

### DIFF
--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -37,6 +37,8 @@ macro_rules! warn(
     };
 );
 
+use std::collections::HashMap;
+
 pub type __off_t = i64;
 pub type __off64_t = i64;
 pub type __ssize_t = i64;
@@ -1018,8 +1020,8 @@ mod xetex_xetex0;
 
 #[macro_use]
 mod macro_stub;
-mod stub_icu;
 mod stub_errno;
+mod stub_icu;
 
 pub use xetex_engine_interface::tt_xetex_set_int_variable;
 


### PR DESCRIPTION
partial attempt at #32 

I am a bit uncertain on how to deal with name collisions. In ht_table the new entries are appended to the hashmap (multiple entries per key allowed). This implementation only stores one element per key.