### PR TITLE
convert xetex_macos.rs

### DIFF
--- a/engine/build.rs
+++ b/engine/build.rs
@@ -266,8 +266,6 @@ fn main() {
 
     if cfg!(target_os = "macos") {
         ccfg.define("XETEX_MAC", Some("1"));
-        ccfg.file("tectonic/xetex-macos.c");
-
         cppcfg.define("XETEX_MAC", Some("1"));
         cppcfg.file("tectonic/xetex-XeTeXFontInst_Mac.cpp");
         cppcfg.file("tectonic/xetex-XeTeXFontMgr_Mac.mm");

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -1014,6 +1014,7 @@ mod xetex_ext;
 mod xetex_ini;
 mod xetex_io;
 mod xetex_linebreak;
+mod xetex_macos;
 mod xetex_math;
 mod xetex_output;
 mod xetex_pagebuilder;

--- a/engine/src/xetex_ext.rs
+++ b/engine/src/xetex_ext.rs
@@ -1,224 +1,418 @@
-#![allow(
-    dead_code,
-    mutable_transmutes,
-    non_camel_case_types,
-    non_snake_case,
-    non_upper_case_globals,
-    unused_assignments,
-    unused_mut
-)]
-
-use crate::mfree;
-use crate::stub_icu as icu;
-use crate::xetex_xetexd::print_c_string;
-use crate::{streq_ptr, strstartswith};
-use crate::{ttstub_input_close, ttstub_input_get_size, ttstub_input_open, ttstub_input_read};
-use libc::free;
-
+#![allow(dead_code,
+         mutable_transmutes,
+         non_camel_case_types,
+         non_snake_case,
+         non_upper_case_globals,
+         unused_assignments,
+         unused_mut)]
+#![feature(const_raw_ptr_to_usize_cast,
+           extern_types,
+           ptr_wrapping_offset_from)]
+extern crate libc;
 extern "C" {
-    pub type _FcPattern;
-    pub type XeTeXFont_rec;
     pub type XeTeXLayoutEngine_rec;
+    pub type UBreakIterator;
+    pub type UConverter;
+    pub type __CFString;
+    /* Macs provide Fixed and FixedPoint */
+    pub type XeTeXFont_rec;
+    pub type __CFDictionary;
     pub type Opaque_TECkit_Converter;
+    pub type __CFArray;
+    pub type __CFBoolean;
+    pub type __CFNumber;
+    pub type CGColor;
+    pub type __CTFontDescriptor;
+    pub type __CTFont;
+    pub type UBiDi;
     #[no_mangle]
-    fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: u64) -> *mut libc::c_void;
+    fn CFBooleanGetValue(boolean: CFBooleanRef) -> Boolean;
     #[no_mangle]
-    fn strcpy(_: *mut i8, _: *const i8) -> *mut i8;
+    static kCTFontAttributeName: CFStringRef;
     #[no_mangle]
-    fn strncpy(_: *mut i8, _: *const i8, _: u64) -> *mut i8;
+    fn free(_: *mut libc::c_void);
     #[no_mangle]
-    fn strcat(_: *mut i8, _: *const i8) -> *mut i8;
+    fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
     #[no_mangle]
-    fn strcmp(_: *const i8, _: *const i8) -> i32;
+    fn strcat(_: *mut libc::c_char, _: *const libc::c_char) -> *mut libc::c_char;
     #[no_mangle]
-    fn strncmp(_: *const i8, _: *const i8, _: u64) -> i32;
+    fn strcmp(_: *const libc::c_char, _: *const libc::c_char) -> libc::c_int;
     #[no_mangle]
-    fn strdup(_: *const i8) -> *mut i8;
+    fn strcpy(_: *mut libc::c_char, _: *const libc::c_char) -> *mut libc::c_char;
     #[no_mangle]
-    fn strstr(_: *const i8, _: *const i8) -> *mut i8;
+    fn hb_tag_from_string(str: *const libc::c_char, len: libc::c_int) -> hb_tag_t;
     #[no_mangle]
-    fn strlen(_: *const i8) -> u64;
+    fn __assert_rtn(
+        _: *const libc::c_char,
+        _: *const libc::c_char,
+        _: libc::c_int,
+        _: *const libc::c_char,
+    ) -> !;
     #[no_mangle]
-    fn strcasecmp(_: *const i8, _: *const i8) -> i32;
-    /* The internal, C/C++ interface: */
-    #[no_mangle]
-    fn _tt_abort(format: *const i8, _: ...) -> !;
-    /* tectonic/core-memory.h: basic dynamic memory helpers
-       Copyright 2016-2018 the Tectonic Project
-       Licensed under the MIT License.
-    */
-    #[no_mangle]
-    fn xstrdup(s: *const i8) -> *mut i8;
-    #[no_mangle]
-    fn xmalloc(size: size_t) -> *mut libc::c_void;
-    #[no_mangle]
-    fn xrealloc(old_address: *mut libc::c_void, new_size: size_t) -> *mut libc::c_void;
+    fn strcasecmp(_: *const libc::c_char, _: *const libc::c_char) -> libc::c_int;
     #[no_mangle]
     fn xcalloc(nelem: size_t, elsize: size_t) -> *mut libc::c_void;
     #[no_mangle]
-    fn hb_tag_from_string(str: *const i8, len: i32) -> hb_tag_t;
+    fn xrealloc(old_address: *mut libc::c_void, new_size: size_t) -> *mut libc::c_void;
     #[no_mangle]
-    fn getCachedGlyphBBox(fontID: u16, glyphID: u16, bbox: *mut GlyphBBox) -> i32;
+    fn xmalloc(size: size_t) -> *mut libc::c_void;
     #[no_mangle]
-    fn cacheGlyphBBox(fontID: u16, glyphID: u16, bbox: *const GlyphBBox);
+    fn xstrdup(s: *const libc::c_char) -> *mut libc::c_char;
+    /* tectonic/core-bridge.h: declarations of C/C++ => Rust bridge API
+       Copyright 2016-2018 the Tectonic Project
+       Licensed under the MIT License.
+    */
+    /* Both XeTeX and bibtex use this enum: */
+    /* The weird enum values are historical and could be rationalized. But it is
+     * good to write them explicitly since they must be kept in sync with
+     * `src/engines/mod.rs`.
+     */
+    /* quasi-hack to get the primary input */
+    /* Bridge API. Keep synchronized with src/engines/mod.rs. */
+    /* These functions are not meant to be used in the C/C++ code. They define the
+     * API that we expose to the Rust side of things. */
+    /* The internal, C/C++ interface: */
+    /* Global symbols that route through the global API variable. Hopefully we
+     * will one day eliminate all of the global state and get rid of all of
+     * these. */
     #[no_mangle]
-    fn get_cp_code(fontNum: i32, code: u32, side: i32) -> i32;
+    fn ttstub_input_close(handle: rust_input_handle_t) -> libc::c_int;
     #[no_mangle]
-    fn maketexstring(s: *const i8) -> i32;
+    fn ttstub_input_read(
+        handle: rust_input_handle_t,
+        data: *mut libc::c_char,
+        len: size_t,
+    ) -> ssize_t;
     #[no_mangle]
-    fn getDefaultDirection(engine: XeTeXLayoutEngine) -> i32;
+    fn ttstub_input_get_size(handle: rust_input_handle_t) -> size_t;
     #[no_mangle]
-    fn createFont(fontRef: PlatformFontRef, pointSize: Fixed) -> XeTeXFont;
+    fn ttstub_input_open(
+        path: *const libc::c_char,
+        format: tt_input_format_type,
+        is_gz: libc::c_int,
+    ) -> rust_input_handle_t;
     #[no_mangle]
-    fn getAscentAndDescent(engine: XeTeXLayoutEngine, ascent: *mut f32, descent: *mut f32);
+    fn strlen(_: *const libc::c_char) -> libc::c_ulong;
     #[no_mangle]
-    fn setFontLayoutDir(font: XeTeXFont, vertical: i32);
+    fn strncmp(_: *const libc::c_char, _: *const libc::c_char, _: libc::c_ulong) -> libc::c_int;
     #[no_mangle]
-    fn layoutChars(
+    fn strncpy(_: *mut libc::c_char, _: *const libc::c_char, _: libc::c_ulong)
+        -> *mut libc::c_char;
+    #[no_mangle]
+    fn strstr(_: *const libc::c_char, _: *const libc::c_char) -> *mut libc::c_char;
+    #[no_mangle]
+    fn strdup(_: *const libc::c_char) -> *mut libc::c_char;
+    #[no_mangle]
+    fn _tt_abort(format: *const libc::c_char, _: ...) -> !;
+    #[no_mangle]
+    fn tan(_: libc::c_double) -> libc::c_double;
+    /* info for each glyph is location (FixedPoint) + glyph ID (uint16_t) */
+    /* glyph ID field in a glyph_node */
+    /* For Unicode encoding form interpretation... */
+    #[no_mangle]
+    fn getkXeTeXEmboldenAttributeName() -> CFStringRef;
+    #[no_mangle]
+    fn maketexstring(s: *const libc::c_char) -> libc::c_int;
+    #[no_mangle]
+    fn get_cp_code(fontNum: libc::c_int, code: libc::c_uint, side: libc::c_int) -> libc::c_int;
+    /* functions in XeTeX_mac.c */
+    #[no_mangle]
+    fn loadAATfont(
+        descriptor: CTFontDescriptorRef,
+        scaled_size: int32_t,
+        cp1: *const libc::c_char,
+    ) -> *mut libc::c_void;
+    #[no_mangle]
+    fn DoAATLayout(node: *mut libc::c_void, justify: libc::c_int);
+    #[no_mangle]
+    fn GetGlyphBBox_AAT(fontAttrs: CFDictionaryRef, gid: uint16_t, bbox: *mut GlyphBBox);
+    #[no_mangle]
+    fn GetGlyphWidth_AAT(fontAttrs: CFDictionaryRef, gid: uint16_t) -> libc::c_double;
+    #[no_mangle]
+    fn GetGlyphHeightDepth_AAT(
+        fontAttrs: CFDictionaryRef,
+        gid: uint16_t,
+        ht: *mut libc::c_float,
+        dp: *mut libc::c_float,
+    );
+    #[no_mangle]
+    fn GetGlyphSidebearings_AAT(
+        fontAttrs: CFDictionaryRef,
+        gid: uint16_t,
+        lsb: *mut libc::c_float,
+        rsb: *mut libc::c_float,
+    );
+    #[no_mangle]
+    fn GetGlyphItalCorr_AAT(fontAttrs: CFDictionaryRef, gid: uint16_t) -> libc::c_double;
+    #[no_mangle]
+    fn MapCharToGlyph_AAT(fontAttrs: CFDictionaryRef, ch: UInt32) -> libc::c_int;
+    #[no_mangle]
+    fn MapGlyphToIndex_AAT(
+        attributes: CFDictionaryRef,
+        glyphName: *const libc::c_char,
+    ) -> libc::c_int;
+    /* ***************************************************************************\
+     Part of the XeTeX typesetting system
+     Copyright (c) 1994-2008 by SIL International
+     Copyright (c) 2009 by Jonathan Kew
+     Copyright (c) 2012-2015 by Khaled Hosny
+
+     SIL Author(s): Jonathan Kew
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE
+    FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+    CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+    Except as contained in this notice, the name of the copyright holders
+    shall not be used in advertising or otherwise to promote the sale,
+    use or other dealings in this Software without prior written
+    authorization from the copyright holders.
+    \****************************************************************************/
+    /* graphite interface functions... */
+    #[no_mangle]
+    fn countGraphiteFeatures(engine: XeTeXLayoutEngine) -> uint32_t;
+    #[no_mangle]
+    fn findGraphiteFeature(
         engine: XeTeXLayoutEngine,
-        chars: *mut u16,
-        offset: i32,
-        count: i32,
-        max: i32,
-        rightToLeft: bool,
-    ) -> i32;
+        s: *const libc::c_char,
+        e: *const libc::c_char,
+        f: *mut hb_tag_t,
+        v: *mut libc::c_int,
+    ) -> bool;
     #[no_mangle]
-    fn getPointSize(engine: XeTeXLayoutEngine) -> f32;
+    fn countScripts(font: XeTeXFont) -> libc::c_uint;
+    #[no_mangle]
+    fn getReqEngine() -> libc::c_char;
+    #[no_mangle]
+    fn findNextGraphiteBreak() -> libc::c_int;
+    #[no_mangle]
+    fn initGraphiteBreaking(
+        engine: XeTeXLayoutEngine,
+        txtPtr: *const uint16_t,
+        txtLen: libc::c_int,
+    ) -> bool;
+    #[no_mangle]
+    fn getFontCharRange(engine: XeTeXLayoutEngine, reqFirst: libc::c_int) -> libc::c_int;
+    #[no_mangle]
+    fn getGlyphName(font: XeTeXFont, gid: uint16_t, len: *mut libc::c_int) -> *const libc::c_char;
+    #[no_mangle]
+    fn mapGlyphToIndex(engine: XeTeXLayoutEngine, glyphName: *const libc::c_char) -> libc::c_int;
+    #[no_mangle]
+    fn mapCharToGlyph(engine: XeTeXLayoutEngine, charCode: uint32_t) -> uint32_t;
+    #[no_mangle]
+    fn getGlyphItalCorr(engine: XeTeXLayoutEngine, glyphID: uint32_t) -> libc::c_float;
+    #[no_mangle]
+    fn getGlyphSidebearings(
+        engine: XeTeXLayoutEngine,
+        glyphID: uint32_t,
+        lsb: *mut libc::c_float,
+        rsb: *mut libc::c_float,
+    );
+    #[no_mangle]
+    fn getGlyphHeightDepth(
+        engine: XeTeXLayoutEngine,
+        glyphID: uint32_t,
+        height: *mut libc::c_float,
+        depth: *mut libc::c_float,
+    );
+    #[no_mangle]
+    fn getGlyphWidthFromEngine(engine: XeTeXLayoutEngine, glyphID: uint32_t) -> libc::c_float;
+    #[no_mangle]
+    fn getGlyphBounds(engine: XeTeXLayoutEngine, glyphID: uint32_t, bbox: *mut GlyphBBox);
+    #[no_mangle]
+    fn countLanguages(font: XeTeXFont, script: hb_tag_t) -> libc::c_uint;
+    #[no_mangle]
+    fn getFileNameFromCTFont(ctFontRef: CTFontRef, index: *mut uint32_t) -> *mut libc::c_char;
+    #[no_mangle]
+    fn GetFontCharRange_AAT(fontAttrs: CFDictionaryRef, reqFirst: libc::c_int) -> libc::c_int;
+    #[no_mangle]
+    fn fontFromInteger(font: int32_t) -> CTFontRef;
+    #[no_mangle]
+    fn GetGlyphNameFromCTFont(
+        ctFontRef: CTFontRef,
+        gid: uint16_t,
+        len: *mut libc::c_int,
+    ) -> *mut libc::c_char;
+    #[no_mangle]
+    fn findGraphiteFeatureSettingNamed(
+        engine: XeTeXLayoutEngine,
+        feature: uint32_t,
+        name: *const libc::c_char,
+        namelength: libc::c_int,
+    ) -> libc::c_long;
+    #[no_mangle]
+    fn findGraphiteFeatureNamed(
+        engine: XeTeXLayoutEngine,
+        name: *const libc::c_char,
+        namelength: libc::c_int,
+    ) -> libc::c_long;
+    #[no_mangle]
+    fn fontFromAttributes(fontAttrs: CFDictionaryRef) -> CTFontRef;
+    #[no_mangle]
+    fn getGraphiteFeatureSettingLabel(
+        engine: XeTeXLayoutEngine,
+        feature: uint32_t,
+        setting: uint32_t,
+    ) -> *mut libc::c_char;
+    #[no_mangle]
+    fn getGraphiteFeatureLabel(engine: XeTeXLayoutEngine, feature: uint32_t) -> *mut libc::c_char;
+    #[no_mangle]
+    fn getGraphiteFeatureDefaultSetting(engine: XeTeXLayoutEngine, feature: uint32_t) -> uint32_t;
+    #[no_mangle]
+    fn getGraphiteFeatureSettingCode(
+        engine: XeTeXLayoutEngine,
+        feature: uint32_t,
+        index: uint32_t,
+    ) -> uint32_t;
+    #[no_mangle]
+    fn getFullName(fontRef: PlatformFontRef) -> *const libc::c_char;
+    #[no_mangle]
+    fn getGraphiteFeatureCode(engine: XeTeXLayoutEngine, index: uint32_t) -> uint32_t;
+    #[no_mangle]
+    fn getRgbValue(engine: XeTeXLayoutEngine) -> uint32_t;
+    #[no_mangle]
+    fn getDefaultDirection(engine: XeTeXLayoutEngine) -> libc::c_int;
+    #[no_mangle]
+    fn getCapAndXHeight(
+        engine: XeTeXLayoutEngine,
+        capheight: *mut libc::c_float,
+        xheight: *mut libc::c_float,
+    );
+    #[no_mangle]
+    fn findSelectorByName(
+        feature: CFDictionaryRef,
+        name: *const libc::c_char,
+        nameLength: libc::c_int,
+    ) -> CFNumberRef;
+    #[no_mangle]
+    fn getAscentAndDescent(
+        engine: XeTeXLayoutEngine,
+        ascent: *mut libc::c_float,
+        descent: *mut libc::c_float,
+    );
+    #[no_mangle]
+    fn getPointSize(engine: XeTeXLayoutEngine) -> libc::c_float;
+    #[no_mangle]
+    fn findDictionaryInArray(
+        array: CFArrayRef,
+        nameKey: *const libc::c_void,
+        name: *const libc::c_char,
+        nameLength: libc::c_int,
+    ) -> CFDictionaryRef;
+    #[no_mangle]
+    fn findDictionaryInArrayWithIdentifier(
+        array: CFArrayRef,
+        identifierKey: *const libc::c_void,
+        identifier: libc::c_int,
+    ) -> CFDictionaryRef;
     #[no_mangle]
     fn getGlyphPositions(engine: XeTeXLayoutEngine, positions: *mut FloatPoint);
     #[no_mangle]
-    fn getGlyphAdvances(engine: XeTeXLayoutEngine, advances: *mut f32);
+    fn getCachedGlyphBBox(fontID: uint16_t, glyphID: uint16_t, bbox: *mut GlyphBBox)
+        -> libc::c_int;
     #[no_mangle]
-    fn getGlyphs(engine: XeTeXLayoutEngine, glyphs: *mut u32);
+    fn cacheGlyphBBox(fontID: uint16_t, glyphID: uint16_t, bbox: *const GlyphBBox);
     #[no_mangle]
-    fn findFontByName(name: *const i8, var: *mut i8, size: f64) -> PlatformFontRef;
+    fn createFont(fontRef: PlatformFontRef, pointSize: Fixed) -> XeTeXFont;
     #[no_mangle]
-    fn getReqEngine() -> i8;
+    fn createFontFromFile(
+        filename: *const libc::c_char,
+        index: libc::c_int,
+        pointSize: Fixed,
+    ) -> XeTeXFont;
     #[no_mangle]
-    fn setReqEngine(reqEngine: i8);
+    fn setFontLayoutDir(font: XeTeXFont, vertical: libc::c_int);
     #[no_mangle]
-    fn getFullName(fontRef: PlatformFontRef) -> *const i8;
-    #[no_mangle]
-    fn getFontFilename(engine: XeTeXLayoutEngine, index: *mut u32) -> *mut i8;
-    #[no_mangle]
-    fn getDesignSize(font: XeTeXFont) -> f64;
+    fn findFontByName(
+        name: *const libc::c_char,
+        var: *mut libc::c_char,
+        size: libc::c_double,
+    ) -> PlatformFontRef;
     #[no_mangle]
     fn deleteFont(font: XeTeXFont);
     #[no_mangle]
+    fn getFontFilename(engine: XeTeXLayoutEngine, index: *mut uint32_t) -> *mut libc::c_char;
+    #[no_mangle]
+    fn getDesignSize(font: XeTeXFont) -> libc::c_double;
+    #[no_mangle]
+    fn setReqEngine(reqEngine: libc::c_char);
+    #[no_mangle]
+    fn getFontTablePtr(font: XeTeXFont, tableTag: uint32_t) -> *mut libc::c_void;
+    #[no_mangle]
     fn getSlant(font: XeTeXFont) -> Fixed;
     #[no_mangle]
-    fn countScripts(font: XeTeXFont) -> u32;
+    fn countFeatures(font: XeTeXFont, script: hb_tag_t, language: hb_tag_t) -> libc::c_uint;
     #[no_mangle]
-    fn countLanguages(font: XeTeXFont, script: hb_tag_t) -> u32;
+    fn countGraphiteFeatureSettings(engine: XeTeXLayoutEngine, feature: uint32_t) -> uint32_t;
     #[no_mangle]
-    fn countFeatures(font: XeTeXFont, script: hb_tag_t, language: hb_tag_t) -> u32;
+    fn countGlyphs(font: XeTeXFont) -> libc::c_uint;
     #[no_mangle]
-    fn countGlyphs(font: XeTeXFont) -> u32;
+    fn getIndScript(font: XeTeXFont, index: libc::c_uint) -> hb_tag_t;
     #[no_mangle]
-    fn getIndScript(font: XeTeXFont, index: u32) -> hb_tag_t;
+    fn getIndLanguage(font: XeTeXFont, script: hb_tag_t, index: libc::c_uint) -> hb_tag_t;
     #[no_mangle]
-    fn getIndLanguage(font: XeTeXFont, script: hb_tag_t, index: u32) -> hb_tag_t;
+    fn getIndFeature(
+        font: XeTeXFont,
+        script: hb_tag_t,
+        language: hb_tag_t,
+        index: libc::c_uint,
+    ) -> hb_tag_t;
     #[no_mangle]
-    fn getIndFeature(font: XeTeXFont, script: hb_tag_t, language: hb_tag_t, index: u32)
-        -> hb_tag_t;
-    #[no_mangle]
-    fn getGlyphWidth(font: XeTeXFont, gid: u32) -> f32;
-    #[no_mangle]
-    fn createFontFromFile(filename: *const i8, index: i32, pointSize: Fixed) -> XeTeXFont;
-    #[no_mangle]
-    fn getCapAndXHeight(engine: XeTeXLayoutEngine, capheight: *mut f32, xheight: *mut f32);
-    #[no_mangle]
-    fn getEmboldenFactor(engine: XeTeXLayoutEngine) -> f32;
-    #[no_mangle]
-    fn getSlantFactor(engine: XeTeXLayoutEngine) -> f32;
-    #[no_mangle]
-    fn getExtendFactor(engine: XeTeXLayoutEngine) -> f32;
-    #[no_mangle]
-    fn getFontRef(engine: XeTeXLayoutEngine) -> PlatformFontRef;
-    #[no_mangle]
-    fn getFont(engine: XeTeXLayoutEngine) -> XeTeXFont;
-    #[no_mangle]
-    fn deleteLayoutEngine(engine: XeTeXLayoutEngine);
+    fn getGlyphWidth(font: XeTeXFont, gid: uint32_t) -> libc::c_float;
     #[no_mangle]
     fn createLayoutEngine(
         fontRef: PlatformFontRef,
         font: XeTeXFont,
         script: hb_tag_t,
-        language: *mut i8,
+        language: *mut libc::c_char,
         features: *mut hb_feature_t,
-        nFeatures: i32,
-        shapers: *mut *mut i8,
-        rgbValue: u32,
-        extend: f32,
-        slant: f32,
-        embolden: f32,
+        nFeatures: libc::c_int,
+        shapers: *mut *mut libc::c_char,
+        rgbValue: uint32_t,
+        extend: libc::c_float,
+        slant: libc::c_float,
+        embolden: libc::c_float,
     ) -> XeTeXLayoutEngine;
-    /* graphite interface functions... */
     #[no_mangle]
-    fn findGraphiteFeature(
+    fn deleteLayoutEngine(engine: XeTeXLayoutEngine);
+    #[no_mangle]
+    fn getFont(engine: XeTeXLayoutEngine) -> XeTeXFont;
+    #[no_mangle]
+    fn getFontRef(engine: XeTeXLayoutEngine) -> PlatformFontRef;
+    #[no_mangle]
+    fn getExtendFactor(engine: XeTeXLayoutEngine) -> libc::c_float;
+    #[no_mangle]
+    fn getSlantFactor(engine: XeTeXLayoutEngine) -> libc::c_float;
+    #[no_mangle]
+    fn getEmboldenFactor(engine: XeTeXLayoutEngine) -> libc::c_float;
+    #[no_mangle]
+    fn layoutChars(
         engine: XeTeXLayoutEngine,
-        s: *const i8,
-        e: *const i8,
-        f: *mut hb_tag_t,
-        v: *mut i32,
-    ) -> bool;
+        chars: *mut uint16_t,
+        offset: int32_t,
+        count: int32_t,
+        max: int32_t,
+        rightToLeft: bool,
+    ) -> libc::c_int;
     #[no_mangle]
-    fn findNextGraphiteBreak() -> i32;
+    fn getGlyphs(engine: XeTeXLayoutEngine, glyphs: *mut uint32_t);
     #[no_mangle]
-    fn initGraphiteBreaking(engine: XeTeXLayoutEngine, txtPtr: *const u16, txtLen: i32) -> bool;
-    #[no_mangle]
-    fn getFontCharRange(engine: XeTeXLayoutEngine, reqFirst: i32) -> i32;
-    #[no_mangle]
-    fn getGlyphName(font: XeTeXFont, gid: u16, len: *mut i32) -> *const i8;
-    #[no_mangle]
-    fn mapGlyphToIndex(engine: XeTeXLayoutEngine, glyphName: *const i8) -> i32;
-    #[no_mangle]
-    fn mapCharToGlyph(engine: XeTeXLayoutEngine, charCode: u32) -> u32;
-    #[no_mangle]
-    fn getGlyphItalCorr(engine: XeTeXLayoutEngine, glyphID: u32) -> f32;
-    #[no_mangle]
-    fn getGlyphSidebearings(engine: XeTeXLayoutEngine, glyphID: u32, lsb: *mut f32, rsb: *mut f32);
-    #[no_mangle]
-    fn getGlyphHeightDepth(
-        engine: XeTeXLayoutEngine,
-        glyphID: u32,
-        height: *mut f32,
-        depth: *mut f32,
-    );
-    #[no_mangle]
-    fn getGlyphWidthFromEngine(engine: XeTeXLayoutEngine, glyphID: u32) -> f32;
-    #[no_mangle]
-    fn getGlyphBounds(engine: XeTeXLayoutEngine, glyphID: u32, bbox: *mut GlyphBBox);
-    #[no_mangle]
-    fn getRgbValue(engine: XeTeXLayoutEngine) -> u32;
-    #[no_mangle]
-    fn countGraphiteFeatures(engine: XeTeXLayoutEngine) -> u32;
-    #[no_mangle]
-    fn getGraphiteFeatureCode(engine: XeTeXLayoutEngine, index: u32) -> u32;
-    #[no_mangle]
-    fn countGraphiteFeatureSettings(engine: XeTeXLayoutEngine, feature: u32) -> u32;
-    #[no_mangle]
-    fn getGraphiteFeatureSettingCode(engine: XeTeXLayoutEngine, feature: u32, index: u32) -> u32;
-    #[no_mangle]
-    fn getGraphiteFeatureDefaultSetting(engine: XeTeXLayoutEngine, feature: u32) -> u32;
-    #[no_mangle]
-    fn getGraphiteFeatureLabel(engine: XeTeXLayoutEngine, feature: u32) -> *mut i8;
-    #[no_mangle]
-    fn getGraphiteFeatureSettingLabel(
-        engine: XeTeXLayoutEngine,
-        feature: u32,
-        setting: u32,
-    ) -> *mut i8;
-    #[no_mangle]
-    fn findGraphiteFeatureNamed(engine: XeTeXLayoutEngine, name: *const i8, namelength: i32)
-        -> i64;
-    #[no_mangle]
-    fn findGraphiteFeatureSettingNamed(
-        engine: XeTeXLayoutEngine,
-        feature: u32,
-        name: *const i8,
-        namelength: i32,
-    ) -> i64;
+    fn getGlyphAdvances(engine: XeTeXLayoutEngine, advances: *mut libc::c_float);
     /* not the MS compiler, so try Metrowerks' platform macros */
     /* this seems to be needed for a gcc-mingw32 build to work... */
     /*
@@ -233,6 +427,9 @@ extern "C" {
         targetForm: UInt16,
         converter: *mut TECkit_Converter,
     ) -> TECkit_Status;
+    /*
+        Convert text from a buffer in memory
+    */
     #[no_mangle]
     fn TECkit_ConvertBuffer(
         converter: TECkit_Converter,
@@ -244,14 +441,1125 @@ extern "C" {
         outUsed: *mut UInt32,
         inputIsComplete: Byte,
     ) -> TECkit_Status;
+    /* *
+     * Allocate a <code>UBiDi</code> structure.
+     * Such an object is initially empty. It is assigned
+     * the Bidi properties of a piece of text containing one or more paragraphs
+     * by <code>ubidi_setPara()</code>
+     * or the Bidi properties of a line within a paragraph by
+     * <code>ubidi_setLine()</code>.<p>
+     * This object can be reused for as long as it is not deallocated
+     * by calling <code>ubidi_close()</code>.<p>
+     * <code>ubidi_setPara()</code> and <code>ubidi_setLine()</code> will allocate
+     * additional memory for internal structures as necessary.
+     *
+     * @return An empty <code>UBiDi</code> object.
+     * @stable ICU 2.0
+     */
+    #[no_mangle]
+    fn ubidi_open_64() -> *mut UBiDi;
+    /* *
+     * Allocate a <code>UBiDi</code> structure with preallocated memory
+     * for internal structures.
+     * This function provides a <code>UBiDi</code> object like <code>ubidi_open()</code>
+     * with no arguments, but it also preallocates memory for internal structures
+     * according to the sizings supplied by the caller.<p>
+     * Subsequent functions will not allocate any more memory, and are thus
+     * guaranteed not to fail because of lack of memory.<p>
+     * The preallocation can be limited to some of the internal memory
+     * by setting some values to 0 here. That means that if, e.g.,
+     * <code>maxRunCount</code> cannot be reasonably predetermined and should not
+     * be set to <code>maxLength</code> (the only failproof value) to avoid
+     * wasting memory, then <code>maxRunCount</code> could be set to 0 here
+     * and the internal structures that are associated with it will be allocated
+     * on demand, just like with <code>ubidi_open()</code>.
+     *
+     * @param maxLength is the maximum text or line length that internal memory
+     *        will be preallocated for. An attempt to associate this object with a
+     *        longer text will fail, unless this value is 0, which leaves the allocation
+     *        up to the implementation.
+     *
+     * @param maxRunCount is the maximum anticipated number of same-level runs
+     *        that internal memory will be preallocated for. An attempt to access
+     *        visual runs on an object that was not preallocated for as many runs
+     *        as the text was actually resolved to will fail,
+     *        unless this value is 0, which leaves the allocation up to the implementation.<br><br>
+     *        The number of runs depends on the actual text and maybe anywhere between
+     *        1 and <code>maxLength</code>. It is typically small.
+     *
+     * @param pErrorCode must be a valid pointer to an error code value.
+     *
+     * @return An empty <code>UBiDi</code> object with preallocated memory.
+     * @stable ICU 2.0
+     */
+    /* *
+     * <code>ubidi_close()</code> must be called to free the memory
+     * associated with a UBiDi object.<p>
+     *
+     * <strong>Important: </strong>
+     * A parent <code>UBiDi</code> object must not be destroyed or reused if
+     * it still has children.
+     * If a <code>UBiDi</code> object has become the <i>child</i>
+     * of another one (its <i>parent</i>) by calling
+     * <code>ubidi_setLine()</code>, then the child object must
+     * be destroyed (closed) or reused (by calling
+     * <code>ubidi_setPara()</code> or <code>ubidi_setLine()</code>)
+     * before the parent object.
+     *
+     * @param pBiDi is a <code>UBiDi</code> object.
+     *
+     * @see ubidi_setPara
+     * @see ubidi_setLine
+     * @stable ICU 2.0
+     */
+    #[no_mangle]
+    fn ubidi_close_64(pBiDi: *mut UBiDi);
+    /* *
+     * Modify the operation of the Bidi algorithm such that it
+     * approximates an "inverse Bidi" algorithm. This function
+     * must be called before <code>ubidi_setPara()</code>.
+     *
+     * <p>The normal operation of the Bidi algorithm as described
+     * in the Unicode Technical Report is to take text stored in logical
+     * (keyboard, typing) order and to determine the reordering of it for visual
+     * rendering.
+     * Some legacy systems store text in visual order, and for operations
+     * with standard, Unicode-based algorithms, the text needs to be transformed
+     * to logical order. This is effectively the inverse algorithm of the
+     * described Bidi algorithm. Note that there is no standard algorithm for
+     * this "inverse Bidi" and that the current implementation provides only an
+     * approximation of "inverse Bidi".</p>
+     *
+     * <p>With <code>isInverse</code> set to <code>TRUE</code>,
+     * this function changes the behavior of some of the subsequent functions
+     * in a way that they can be used for the inverse Bidi algorithm.
+     * Specifically, runs of text with numeric characters will be treated in a
+     * special way and may need to be surrounded with LRM characters when they are
+     * written in reordered sequence.</p>
+     *
+     * <p>Output runs should be retrieved using <code>ubidi_getVisualRun()</code>.
+     * Since the actual input for "inverse Bidi" is visually ordered text and
+     * <code>ubidi_getVisualRun()</code> gets the reordered runs, these are actually
+     * the runs of the logically ordered output.</p>
+     *
+     * <p>Calling this function with argument <code>isInverse</code> set to
+     * <code>TRUE</code> is equivalent to calling
+     * <code>ubidi_setReorderingMode</code> with argument
+     * <code>reorderingMode</code>
+     * set to <code>#UBIDI_REORDER_INVERSE_NUMBERS_AS_L</code>.<br>
+     * Calling this function with argument <code>isInverse</code> set to
+     * <code>FALSE</code> is equivalent to calling
+     * <code>ubidi_setReorderingMode</code> with argument
+     * <code>reorderingMode</code>
+     * set to <code>#UBIDI_REORDER_DEFAULT</code>.
+     *
+     * @param pBiDi is a <code>UBiDi</code> object.
+     *
+     * @param isInverse specifies "forward" or "inverse" Bidi operation.
+     *
+     * @see ubidi_setPara
+     * @see ubidi_writeReordered
+     * @see ubidi_setReorderingMode
+     * @stable ICU 2.0
+     */
+    /* *
+     * Is this Bidi object set to perform the inverse Bidi algorithm?
+     * <p>Note: calling this function after setting the reordering mode with
+     * <code>ubidi_setReorderingMode</code> will return <code>TRUE</code> if the
+     * reordering mode was set to <code>#UBIDI_REORDER_INVERSE_NUMBERS_AS_L</code>,
+     * <code>FALSE</code> for all other values.</p>
+     *
+     * @param pBiDi is a <code>UBiDi</code> object.
+     * @return TRUE if the Bidi object is set to perform the inverse Bidi algorithm
+     * by handling numbers as L.
+     *
+     * @see ubidi_setInverse
+     * @see ubidi_setReorderingMode
+     * @stable ICU 2.0
+     */
+    /* *
+     * Specify whether block separators must be allocated level zero,
+     * so that successive paragraphs will progress from left to right.
+     * This function must be called before <code>ubidi_setPara()</code>.
+     * Paragraph separators (B) may appear in the text.  Setting them to level zero
+     * means that all paragraph separators (including one possibly appearing
+     * in the last text position) are kept in the reordered text after the text
+     * that they follow in the source text.
+     * When this feature is not enabled, a paragraph separator at the last
+     * position of the text before reordering will go to the first position
+     * of the reordered text when the paragraph level is odd.
+     *
+     * @param pBiDi is a <code>UBiDi</code> object.
+     *
+     * @param orderParagraphsLTR specifies whether paragraph separators (B) must
+     * receive level 0, so that successive paragraphs progress from left to right.
+     *
+     * @see ubidi_setPara
+     * @stable ICU 3.4
+     */
+    /* *
+     * Is this Bidi object set to allocate level 0 to block separators so that
+     * successive paragraphs progress from left to right?
+     *
+     * @param pBiDi is a <code>UBiDi</code> object.
+     * @return TRUE if the Bidi object is set to allocate level 0 to block
+     *         separators.
+     *
+     * @see ubidi_orderParagraphsLTR
+     * @stable ICU 3.4
+     */
+    /* *
+     * <code>UBiDiReorderingMode</code> values indicate which variant of the Bidi
+     * algorithm to use.
+     *
+     * @see ubidi_setReorderingMode
+     * @stable ICU 3.6
+     */
+    /* * Regular Logical to Visual Bidi algorithm according to Unicode.
+     * This is a 0 value.
+     * @stable ICU 3.6 */
+    /* * Logical to Visual algorithm which handles numbers in a way which
+     * mimics the behavior of Windows XP.
+     * @stable ICU 3.6 */
+    /* * Logical to Visual algorithm grouping numbers with adjacent R characters
+     * (reversible algorithm).
+     * @stable ICU 3.6 */
+    /* * Reorder runs only to transform a Logical LTR string to the Logical RTL
+     * string with the same display, or vice-versa.<br>
+     * If this mode is set together with option
+     * <code>#UBIDI_OPTION_INSERT_MARKS</code>, some Bidi controls in the source
+     * text may be removed and other controls may be added to produce the
+     * minimum combination which has the required display.
+     * @stable ICU 3.6 */
+    /* * Visual to Logical algorithm which handles numbers like L
+     * (same algorithm as selected by <code>ubidi_setInverse(TRUE)</code>.
+     * @see ubidi_setInverse
+     * @stable ICU 3.6 */
+    /* * Visual to Logical algorithm equivalent to the regular Logical to Visual
+     * algorithm.
+     * @stable ICU 3.6 */
+    /* * Inverse Bidi (Visual to Logical) algorithm for the
+     * <code>UBIDI_REORDER_NUMBERS_SPECIAL</code> Bidi algorithm.
+     * @stable ICU 3.6 */
+    /* *
+     * Number of values for reordering mode.
+     * @deprecated ICU 58 The numeric value may change over time, see ICU ticket #12420.
+     */
+    // U_HIDE_DEPRECATED_API
+    /* *
+     * Modify the operation of the Bidi algorithm such that it implements some
+     * variant to the basic Bidi algorithm or approximates an "inverse Bidi"
+     * algorithm, depending on different values of the "reordering mode".
+     * This function must be called before <code>ubidi_setPara()</code>, and stays
+     * in effect until called again with a different argument.
+     *
+     * <p>The normal operation of the Bidi algorithm as described
+     * in the Unicode Standard Annex #9 is to take text stored in logical
+     * (keyboard, typing) order and to determine how to reorder it for visual
+     * rendering.</p>
+     *
+     * <p>With the reordering mode set to a value other than
+     * <code>#UBIDI_REORDER_DEFAULT</code>, this function changes the behavior of
+     * some of the subsequent functions in a way such that they implement an
+     * inverse Bidi algorithm or some other algorithm variants.</p>
+     *
+     * <p>Some legacy systems store text in visual order, and for operations
+     * with standard, Unicode-based algorithms, the text needs to be transformed
+     * into logical order. This is effectively the inverse algorithm of the
+     * described Bidi algorithm. Note that there is no standard algorithm for
+     * this "inverse Bidi", so a number of variants are implemented here.</p>
+     *
+     * <p>In other cases, it may be desirable to emulate some variant of the
+     * Logical to Visual algorithm (e.g. one used in MS Windows), or perform a
+     * Logical to Logical transformation.</p>
+     *
+     * <ul>
+     * <li>When the reordering mode is set to <code>#UBIDI_REORDER_DEFAULT</code>,
+     * the standard Bidi Logical to Visual algorithm is applied.</li>
+     *
+     * <li>When the reordering mode is set to
+     * <code>#UBIDI_REORDER_NUMBERS_SPECIAL</code>,
+     * the algorithm used to perform Bidi transformations when calling
+     * <code>ubidi_setPara</code> should approximate the algorithm used in
+     * Microsoft Windows XP rather than strictly conform to the Unicode Bidi
+     * algorithm.
+     * <br>
+     * The differences between the basic algorithm and the algorithm addressed
+     * by this option are as follows:
+     * <ul>
+     *   <li>Within text at an even embedding level, the sequence "123AB"
+     *   (where AB represent R or AL letters) is transformed to "123BA" by the
+     *   Unicode algorithm and to "BA123" by the Windows algorithm.</li>
+     *   <li>Arabic-Indic numbers (AN) are handled by the Windows algorithm just
+     *   like regular numbers (EN).</li>
+     * </ul></li>
+     *
+     * <li>When the reordering mode is set to
+     * <code>#UBIDI_REORDER_GROUP_NUMBERS_WITH_R</code>,
+     * numbers located between LTR text and RTL text are associated with the RTL
+     * text. For instance, an LTR paragraph with content "abc 123 DEF" (where
+     * upper case letters represent RTL characters) will be transformed to
+     * "abc FED 123" (and not "abc 123 FED"), "DEF 123 abc" will be transformed
+     * to "123 FED abc" and "123 FED abc" will be transformed to "DEF 123 abc".
+     * This makes the algorithm reversible and makes it useful when round trip
+     * (from visual to logical and back to visual) must be achieved without
+     * adding LRM characters. However, this is a variation from the standard
+     * Unicode Bidi algorithm.<br>
+     * The source text should not contain Bidi control characters other than LRM
+     * or RLM.</li>
+     *
+     * <li>When the reordering mode is set to
+     * <code>#UBIDI_REORDER_RUNS_ONLY</code>,
+     * a "Logical to Logical" transformation must be performed:
+     * <ul>
+     * <li>If the default text level of the source text (argument <code>paraLevel</code>
+     * in <code>ubidi_setPara</code>) is even, the source text will be handled as
+     * LTR logical text and will be transformed to the RTL logical text which has
+     * the same LTR visual display.</li>
+     * <li>If the default level of the source text is odd, the source text
+     * will be handled as RTL logical text and will be transformed to the
+     * LTR logical text which has the same LTR visual display.</li>
+     * </ul>
+     * This mode may be needed when logical text which is basically Arabic or
+     * Hebrew, with possible included numbers or phrases in English, has to be
+     * displayed as if it had an even embedding level (this can happen if the
+     * displaying application treats all text as if it was basically LTR).
+     * <br>
+     * This mode may also be needed in the reverse case, when logical text which is
+     * basically English, with possible included phrases in Arabic or Hebrew, has to
+     * be displayed as if it had an odd embedding level.
+     * <br>
+     * Both cases could be handled by adding LRE or RLE at the head of the text,
+     * if the display subsystem supports these formatting controls. If it does not,
+     * the problem may be handled by transforming the source text in this mode
+     * before displaying it, so that it will be displayed properly.<br>
+     * The source text should not contain Bidi control characters other than LRM
+     * or RLM.</li>
+     *
+     * <li>When the reordering mode is set to
+     * <code>#UBIDI_REORDER_INVERSE_NUMBERS_AS_L</code>, an "inverse Bidi" algorithm
+     * is applied.
+     * Runs of text with numeric characters will be treated like LTR letters and
+     * may need to be surrounded with LRM characters when they are written in
+     * reordered sequence (the option <code>#UBIDI_INSERT_LRM_FOR_NUMERIC</code> can
+     * be used with function <code>ubidi_writeReordered</code> to this end. This
+     * mode is equivalent to calling <code>ubidi_setInverse()</code> with
+     * argument <code>isInverse</code> set to <code>TRUE</code>.</li>
+     *
+     * <li>When the reordering mode is set to
+     * <code>#UBIDI_REORDER_INVERSE_LIKE_DIRECT</code>, the "direct" Logical to Visual
+     * Bidi algorithm is used as an approximation of an "inverse Bidi" algorithm.
+     * This mode is similar to mode <code>#UBIDI_REORDER_INVERSE_NUMBERS_AS_L</code>
+     * but is closer to the regular Bidi algorithm.
+     * <br>
+     * For example, an LTR paragraph with the content "FED 123 456 CBA" (where
+     * upper case represents RTL characters) will be transformed to
+     * "ABC 456 123 DEF", as opposed to "DEF 123 456 ABC"
+     * with mode <code>UBIDI_REORDER_INVERSE_NUMBERS_AS_L</code>.<br>
+     * When used in conjunction with option
+     * <code>#UBIDI_OPTION_INSERT_MARKS</code>, this mode generally
+     * adds Bidi marks to the output significantly more sparingly than mode
+     * <code>#UBIDI_REORDER_INVERSE_NUMBERS_AS_L</code> with option
+     * <code>#UBIDI_INSERT_LRM_FOR_NUMERIC</code> in calls to
+     * <code>ubidi_writeReordered</code>.</li>
+     *
+     * <li>When the reordering mode is set to
+     * <code>#UBIDI_REORDER_INVERSE_FOR_NUMBERS_SPECIAL</code>, the Logical to Visual
+     * Bidi algorithm used in Windows XP is used as an approximation of an "inverse Bidi" algorithm.
+     * <br>
+     * For example, an LTR paragraph with the content "abc FED123" (where
+     * upper case represents RTL characters) will be transformed to "abc 123DEF."</li>
+     * </ul>
+     *
+     * <p>In all the reordering modes specifying an "inverse Bidi" algorithm
+     * (i.e. those with a name starting with <code>UBIDI_REORDER_INVERSE</code>),
+     * output runs should be retrieved using
+     * <code>ubidi_getVisualRun()</code>, and the output text with
+     * <code>ubidi_writeReordered()</code>. The caller should keep in mind that in
+     * "inverse Bidi" modes the input is actually visually ordered text and
+     * reordered output returned by <code>ubidi_getVisualRun()</code> or
+     * <code>ubidi_writeReordered()</code> are actually runs or character string
+     * of logically ordered output.<br>
+     * For all the "inverse Bidi" modes, the source text should not contain
+     * Bidi control characters other than LRM or RLM.</p>
+     *
+     * <p>Note that option <code>#UBIDI_OUTPUT_REVERSE</code> of
+     * <code>ubidi_writeReordered</code> has no useful meaning and should not be
+     * used in conjunction with any value of the reordering mode specifying
+     * "inverse Bidi" or with value <code>UBIDI_REORDER_RUNS_ONLY</code>.
+     *
+     * @param pBiDi is a <code>UBiDi</code> object.
+     * @param reorderingMode specifies the required variant of the Bidi algorithm.
+     *
+     * @see UBiDiReorderingMode
+     * @see ubidi_setInverse
+     * @see ubidi_setPara
+     * @see ubidi_writeReordered
+     * @stable ICU 3.6
+     */
+    /* *
+     * What is the requested reordering mode for a given Bidi object?
+     *
+     * @param pBiDi is a <code>UBiDi</code> object.
+     * @return the current reordering mode of the Bidi object
+     * @see ubidi_setReorderingMode
+     * @stable ICU 3.6
+     */
+    /* *
+     * <code>UBiDiReorderingOption</code> values indicate which options are
+     * specified to affect the Bidi algorithm.
+     *
+     * @see ubidi_setReorderingOptions
+     * @stable ICU 3.6
+     */
+    /* *
+     * option value for <code>ubidi_setReorderingOptions</code>:
+     * disable all the options which can be set with this function
+     * @see ubidi_setReorderingOptions
+     * @stable ICU 3.6
+     */
+    /* *
+     * option bit for <code>ubidi_setReorderingOptions</code>:
+     * insert Bidi marks (LRM or RLM) when needed to ensure correct result of
+     * a reordering to a Logical order
+     *
+     * <p>This option must be set or reset before calling
+     * <code>ubidi_setPara</code>.</p>
+     *
+     * <p>This option is significant only with reordering modes which generate
+     * a result with Logical order, specifically:</p>
+     * <ul>
+     *   <li><code>#UBIDI_REORDER_RUNS_ONLY</code></li>
+     *   <li><code>#UBIDI_REORDER_INVERSE_NUMBERS_AS_L</code></li>
+     *   <li><code>#UBIDI_REORDER_INVERSE_LIKE_DIRECT</code></li>
+     *   <li><code>#UBIDI_REORDER_INVERSE_FOR_NUMBERS_SPECIAL</code></li>
+     * </ul>
+     *
+     * <p>If this option is set in conjunction with reordering mode
+     * <code>#UBIDI_REORDER_INVERSE_NUMBERS_AS_L</code> or with calling
+     * <code>ubidi_setInverse(TRUE)</code>, it implies
+     * option <code>#UBIDI_INSERT_LRM_FOR_NUMERIC</code>
+     * in calls to function <code>ubidi_writeReordered()</code>.</p>
+     *
+     * <p>For other reordering modes, a minimum number of LRM or RLM characters
+     * will be added to the source text after reordering it so as to ensure
+     * round trip, i.e. when applying the inverse reordering mode on the
+     * resulting logical text with removal of Bidi marks
+     * (option <code>#UBIDI_OPTION_REMOVE_CONTROLS</code> set before calling
+     * <code>ubidi_setPara()</code> or option <code>#UBIDI_REMOVE_BIDI_CONTROLS</code>
+     * in <code>ubidi_writeReordered</code>), the result will be identical to the
+     * source text in the first transformation.
+     *
+     * <p>This option will be ignored if specified together with option
+     * <code>#UBIDI_OPTION_REMOVE_CONTROLS</code>. It inhibits option
+     * <code>UBIDI_REMOVE_BIDI_CONTROLS</code> in calls to function
+     * <code>ubidi_writeReordered()</code> and it implies option
+     * <code>#UBIDI_INSERT_LRM_FOR_NUMERIC</code> in calls to function
+     * <code>ubidi_writeReordered()</code> if the reordering mode is
+     * <code>#UBIDI_REORDER_INVERSE_NUMBERS_AS_L</code>.</p>
+     *
+     * @see ubidi_setReorderingMode
+     * @see ubidi_setReorderingOptions
+     * @stable ICU 3.6
+     */
+    /* *
+     * option bit for <code>ubidi_setReorderingOptions</code>:
+     * remove Bidi control characters
+     *
+     * <p>This option must be set or reset before calling
+     * <code>ubidi_setPara</code>.</p>
+     *
+     * <p>This option nullifies option <code>#UBIDI_OPTION_INSERT_MARKS</code>.
+     * It inhibits option <code>#UBIDI_INSERT_LRM_FOR_NUMERIC</code> in calls
+     * to function <code>ubidi_writeReordered()</code> and it implies option
+     * <code>#UBIDI_REMOVE_BIDI_CONTROLS</code> in calls to that function.</p>
+     *
+     * @see ubidi_setReorderingMode
+     * @see ubidi_setReorderingOptions
+     * @stable ICU 3.6
+     */
+    /* *
+     * option bit for <code>ubidi_setReorderingOptions</code>:
+     * process the output as part of a stream to be continued
+     *
+     * <p>This option must be set or reset before calling
+     * <code>ubidi_setPara</code>.</p>
+     *
+     * <p>This option specifies that the caller is interested in processing large
+     * text object in parts.
+     * The results of the successive calls are expected to be concatenated by the
+     * caller. Only the call for the last part will have this option bit off.</p>
+     *
+     * <p>When this option bit is on, <code>ubidi_setPara()</code> may process
+     * less than the full source text in order to truncate the text at a meaningful
+     * boundary. The caller should call <code>ubidi_getProcessedLength()</code>
+     * immediately after calling <code>ubidi_setPara()</code> in order to
+     * determine how much of the source text has been processed.
+     * Source text beyond that length should be resubmitted in following calls to
+     * <code>ubidi_setPara</code>. The processed length may be less than
+     * the length of the source text if a character preceding the last character of
+     * the source text constitutes a reasonable boundary (like a block separator)
+     * for text to be continued.<br>
+     * If the last character of the source text constitutes a reasonable
+     * boundary, the whole text will be processed at once.<br>
+     * If nowhere in the source text there exists
+     * such a reasonable boundary, the processed length will be zero.<br>
+     * The caller should check for such an occurrence and do one of the following:
+     * <ul><li>submit a larger amount of text with a better chance to include
+     *         a reasonable boundary.</li>
+     *     <li>resubmit the same text after turning off option
+     *         <code>UBIDI_OPTION_STREAMING</code>.</li></ul>
+     * In all cases, this option should be turned off before processing the last
+     * part of the text.</p>
+     *
+     * <p>When the <code>UBIDI_OPTION_STREAMING</code> option is used,
+     * it is recommended to call <code>ubidi_orderParagraphsLTR()</code> with
+     * argument <code>orderParagraphsLTR</code> set to <code>TRUE</code> before
+     * calling <code>ubidi_setPara</code> so that later paragraphs may be
+     * concatenated to previous paragraphs on the right.</p>
+     *
+     * @see ubidi_setReorderingMode
+     * @see ubidi_setReorderingOptions
+     * @see ubidi_getProcessedLength
+     * @see ubidi_orderParagraphsLTR
+     * @stable ICU 3.6
+     */
+    /* *
+     * Specify which of the reordering options
+     * should be applied during Bidi transformations.
+     *
+     * @param pBiDi is a <code>UBiDi</code> object.
+     * @param reorderingOptions is a combination of zero or more of the following
+     * options:
+     * <code>#UBIDI_OPTION_DEFAULT</code>, <code>#UBIDI_OPTION_INSERT_MARKS</code>,
+     * <code>#UBIDI_OPTION_REMOVE_CONTROLS</code>, <code>#UBIDI_OPTION_STREAMING</code>.
+     *
+     * @see ubidi_getReorderingOptions
+     * @stable ICU 3.6
+     */
+    /* *
+     * What are the reordering options applied to a given Bidi object?
+     *
+     * @param pBiDi is a <code>UBiDi</code> object.
+     * @return the current reordering options of the Bidi object
+     * @see ubidi_setReorderingOptions
+     * @stable ICU 3.6
+     */
+    /* *
+     * Set the context before a call to ubidi_setPara().<p>
+     *
+     * ubidi_setPara() computes the left-right directionality for a given piece
+     * of text which is supplied as one of its arguments. Sometimes this piece
+     * of text (the "main text") should be considered in context, because text
+     * appearing before ("prologue") and/or after ("epilogue") the main text
+     * may affect the result of this computation.<p>
+     *
+     * This function specifies the prologue and/or the epilogue for the next
+     * call to ubidi_setPara(). The characters specified as prologue and
+     * epilogue should not be modified by the calling program until the call
+     * to ubidi_setPara() has returned. If successive calls to ubidi_setPara()
+     * all need specification of a context, ubidi_setContext() must be called
+     * before each call to ubidi_setPara(). In other words, a context is not
+     * "remembered" after the following successful call to ubidi_setPara().<p>
+     *
+     * If a call to ubidi_setPara() specifies UBIDI_DEFAULT_LTR or
+     * UBIDI_DEFAULT_RTL as paraLevel and is preceded by a call to
+     * ubidi_setContext() which specifies a prologue, the paragraph level will
+     * be computed taking in consideration the text in the prologue.<p>
+     *
+     * When ubidi_setPara() is called without a previous call to
+     * ubidi_setContext, the main text is handled as if preceded and followed
+     * by strong directional characters at the current paragraph level.
+     * Calling ubidi_setContext() with specification of a prologue will change
+     * this behavior by handling the main text as if preceded by the last
+     * strong character appearing in the prologue, if any.
+     * Calling ubidi_setContext() with specification of an epilogue will change
+     * the behavior of ubidi_setPara() by handling the main text as if followed
+     * by the first strong character or digit appearing in the epilogue, if any.<p>
+     *
+     * Note 1: if <code>ubidi_setContext</code> is called repeatedly without
+     *         calling <code>ubidi_setPara</code>, the earlier calls have no effect,
+     *         only the last call will be remembered for the next call to
+     *         <code>ubidi_setPara</code>.<p>
+     *
+     * Note 2: calling <code>ubidi_setContext(pBiDi, NULL, 0, NULL, 0, &errorCode)</code>
+     *         cancels any previous setting of non-empty prologue or epilogue.
+     *         The next call to <code>ubidi_setPara()</code> will process no
+     *         prologue or epilogue.<p>
+     *
+     * Note 3: users must be aware that even after setting the context
+     *         before a call to ubidi_setPara() to perform e.g. a logical to visual
+     *         transformation, the resulting string may not be identical to what it
+     *         would have been if all the text, including prologue and epilogue, had
+     *         been processed together.<br>
+     * Example (upper case letters represent RTL characters):<br>
+     * &nbsp;&nbsp;prologue = "<code>abc DE</code>"<br>
+     * &nbsp;&nbsp;epilogue = none<br>
+     * &nbsp;&nbsp;main text = "<code>FGH xyz</code>"<br>
+     * &nbsp;&nbsp;paraLevel = UBIDI_LTR<br>
+     * &nbsp;&nbsp;display without prologue = "<code>HGF xyz</code>"
+     *             ("HGF" is adjacent to "xyz")<br>
+     * &nbsp;&nbsp;display with prologue = "<code>abc HGFED xyz</code>"
+     *             ("HGF" is not adjacent to "xyz")<br>
+     *
+     * @param pBiDi is a paragraph <code>UBiDi</code> object.
+     *
+     * @param prologue is a pointer to the text which precedes the text that
+     *        will be specified in a coming call to ubidi_setPara().
+     *        If there is no prologue to consider, then <code>proLength</code>
+     *        must be zero and this pointer can be NULL.
+     *
+     * @param proLength is the length of the prologue; if <code>proLength==-1</code>
+     *        then the prologue must be zero-terminated.
+     *        Otherwise proLength must be >= 0. If <code>proLength==0</code>, it means
+     *        that there is no prologue to consider.
+     *
+     * @param epilogue is a pointer to the text which follows the text that
+     *        will be specified in a coming call to ubidi_setPara().
+     *        If there is no epilogue to consider, then <code>epiLength</code>
+     *        must be zero and this pointer can be NULL.
+     *
+     * @param epiLength is the length of the epilogue; if <code>epiLength==-1</code>
+     *        then the epilogue must be zero-terminated.
+     *        Otherwise epiLength must be >= 0. If <code>epiLength==0</code>, it means
+     *        that there is no epilogue to consider.
+     *
+     * @param pErrorCode must be a valid pointer to an error code value.
+     *
+     * @see ubidi_setPara
+     * @stable ICU 4.8
+     */
+    /* *
+     * Perform the Unicode Bidi algorithm. It is defined in the
+     * <a href="http://www.unicode.org/unicode/reports/tr9/">Unicode Standard Annex #9</a>,
+     * version 13,
+     * also described in The Unicode Standard, Version 4.0 .<p>
+     *
+     * This function takes a piece of plain text containing one or more paragraphs,
+     * with or without externally specified embedding levels from <i>styled</i>
+     * text and computes the left-right-directionality of each character.<p>
+     *
+     * If the entire text is all of the same directionality, then
+     * the function may not perform all the steps described by the algorithm,
+     * i.e., some levels may not be the same as if all steps were performed.
+     * This is not relevant for unidirectional text.<br>
+     * For example, in pure LTR text with numbers the numbers would get
+     * a resolved level of 2 higher than the surrounding text according to
+     * the algorithm. This implementation may set all resolved levels to
+     * the same value in such a case.<p>
+     *
+     * The text can be composed of multiple paragraphs. Occurrence of a block
+     * separator in the text terminates a paragraph, and whatever comes next starts
+     * a new paragraph. The exception to this rule is when a Carriage Return (CR)
+     * is followed by a Line Feed (LF). Both CR and LF are block separators, but
+     * in that case, the pair of characters is considered as terminating the
+     * preceding paragraph, and a new paragraph will be started by a character
+     * coming after the LF.
+     *
+     * @param pBiDi A <code>UBiDi</code> object allocated with <code>ubidi_open()</code>
+     *        which will be set to contain the reordering information,
+     *        especially the resolved levels for all the characters in <code>text</code>.
+     *
+     * @param text is a pointer to the text that the Bidi algorithm will be performed on.
+     *        This pointer is stored in the UBiDi object and can be retrieved
+     *        with <code>ubidi_getText()</code>.<br>
+     *        <strong>Note:</strong> the text must be (at least) <code>length</code> long.
+     *
+     * @param length is the length of the text; if <code>length==-1</code> then
+     *        the text must be zero-terminated.
+     *
+     * @param paraLevel specifies the default level for the text;
+     *        it is typically 0 (LTR) or 1 (RTL).
+     *        If the function shall determine the paragraph level from the text,
+     *        then <code>paraLevel</code> can be set to
+     *        either <code>#UBIDI_DEFAULT_LTR</code>
+     *        or <code>#UBIDI_DEFAULT_RTL</code>; if the text contains multiple
+     *        paragraphs, the paragraph level shall be determined separately for
+     *        each paragraph; if a paragraph does not include any strongly typed
+     *        character, then the desired default is used (0 for LTR or 1 for RTL).
+     *        Any other value between 0 and <code>#UBIDI_MAX_EXPLICIT_LEVEL</code>
+     *        is also valid, with odd levels indicating RTL.
+     *
+     * @param embeddingLevels (in) may be used to preset the embedding and override levels,
+     *        ignoring characters like LRE and PDF in the text.
+     *        A level overrides the directional property of its corresponding
+     *        (same index) character if the level has the
+     *        <code>#UBIDI_LEVEL_OVERRIDE</code> bit set.<br><br>
+     *        Aside from that bit, it must be
+     *        <code>paraLevel<=embeddingLevels[]<=UBIDI_MAX_EXPLICIT_LEVEL</code>,
+     *        except that level 0 is always allowed.
+     *        Level 0 for a paragraph separator prevents reordering of paragraphs;
+     *        this only works reliably if <code>#UBIDI_LEVEL_OVERRIDE</code>
+     *        is also set for paragraph separators.
+     *        Level 0 for other characters is treated as a wildcard
+     *        and is lifted up to the resolved level of the surrounding paragraph.<br><br>
+     *        <strong>Caution: </strong>A copy of this pointer, not of the levels,
+     *        will be stored in the <code>UBiDi</code> object;
+     *        the <code>embeddingLevels</code> array must not be
+     *        deallocated before the <code>UBiDi</code> structure is destroyed or reused,
+     *        and the <code>embeddingLevels</code>
+     *        should not be modified to avoid unexpected results on subsequent Bidi operations.
+     *        However, the <code>ubidi_setPara()</code> and
+     *        <code>ubidi_setLine()</code> functions may modify some or all of the levels.<br><br>
+     *        After the <code>UBiDi</code> object is reused or destroyed, the caller
+     *        must take care of the deallocation of the <code>embeddingLevels</code> array.<br><br>
+     *        <strong>Note:</strong> the <code>embeddingLevels</code> array must be
+     *        at least <code>length</code> long.
+     *        This pointer can be <code>NULL</code> if this
+     *        value is not necessary.
+     *
+     * @param pErrorCode must be a valid pointer to an error code value.
+     * @stable ICU 2.0
+     */
+    /* *
+     * <code>ubidi_setLine()</code> sets a <code>UBiDi</code> to
+     * contain the reordering information, especially the resolved levels,
+     * for all the characters in a line of text. This line of text is
+     * specified by referring to a <code>UBiDi</code> object representing
+     * this information for a piece of text containing one or more paragraphs,
+     * and by specifying a range of indexes in this text.<p>
+     * In the new line object, the indexes will range from 0 to <code>limit-start-1</code>.<p>
+     *
+     * This is used after calling <code>ubidi_setPara()</code>
+     * for a piece of text, and after line-breaking on that text.
+     * It is not necessary if each paragraph is treated as a single line.<p>
+     *
+     * After line-breaking, rules (L1) and (L2) for the treatment of
+     * trailing WS and for reordering are performed on
+     * a <code>UBiDi</code> object that represents a line.<p>
+     *
+     * <strong>Important: </strong><code>pLineBiDi</code> shares data with
+     * <code>pParaBiDi</code>.
+     * You must destroy or reuse <code>pLineBiDi</code> before <code>pParaBiDi</code>.
+     * In other words, you must destroy or reuse the <code>UBiDi</code> object for a line
+     * before the object for its parent paragraph.<p>
+     *
+     * The text pointer that was stored in <code>pParaBiDi</code> is also copied,
+     * and <code>start</code> is added to it so that it points to the beginning of the
+     * line for this object.
+     *
+     * @param pParaBiDi is the parent paragraph object. It must have been set
+     * by a successful call to ubidi_setPara.
+     *
+     * @param start is the line's first index into the text.
+     *
+     * @param limit is just behind the line's last index into the text
+     *        (its last index +1).<br>
+     *        It must be <code>0<=start<limit<=</code>containing paragraph limit.
+     *        If the specified line crosses a paragraph boundary, the function
+     *        will terminate with error code U_ILLEGAL_ARGUMENT_ERROR.
+     *
+     * @param pLineBiDi is the object that will now represent a line of the text.
+     *
+     * @param pErrorCode must be a valid pointer to an error code value.
+     *
+     * @see ubidi_setPara
+     * @see ubidi_getProcessedLength
+     * @stable ICU 2.0
+     */
+    /* *
+     * Get the directionality of the text.
+     *
+     * @param pBiDi is the paragraph or line <code>UBiDi</code> object.
+     *
+     * @return a value of <code>UBIDI_LTR</code>, <code>UBIDI_RTL</code>
+     *         or <code>UBIDI_MIXED</code>
+     *         that indicates if the entire text
+     *         represented by this object is unidirectional,
+     *         and which direction, or if it is mixed-directional.
+     * Note -  The value <code>UBIDI_NEUTRAL</code> is never returned from this method.
+     *
+     * @see UBiDiDirection
+     * @stable ICU 2.0
+     */
+    /* *
+     * Gets the base direction of the text provided according
+     * to the Unicode Bidirectional Algorithm. The base direction
+     * is derived from the first character in the string with bidirectional
+     * character type L, R, or AL. If the first such character has type L,
+     * <code>UBIDI_LTR</code> is returned. If the first such character has
+     * type R or AL, <code>UBIDI_RTL</code> is returned. If the string does
+     * not contain any character of these types, then
+     * <code>UBIDI_NEUTRAL</code> is returned.
+     *
+     * This is a lightweight function for use when only the base direction
+     * is needed and no further bidi processing of the text is needed.
+     *
+     * @param text is a pointer to the text whose base
+     *             direction is needed.
+     * Note: the text must be (at least) @c length long.
+     *
+     * @param length is the length of the text;
+     *               if <code>length==-1</code> then the text
+     *               must be zero-terminated.
+     *
+     * @return  <code>UBIDI_LTR</code>, <code>UBIDI_RTL</code>,
+     *          <code>UBIDI_NEUTRAL</code>
+     *
+     * @see UBiDiDirection
+     * @stable ICU 4.6
+     */
+    /* *
+     * Get the pointer to the text.
+     *
+     * @param pBiDi is the paragraph or line <code>UBiDi</code> object.
+     *
+     * @return The pointer to the text that the UBiDi object was created for.
+     *
+     * @see ubidi_setPara
+     * @see ubidi_setLine
+     * @stable ICU 2.0
+     */
+    /* *
+     * Get the length of the text.
+     *
+     * @param pBiDi is the paragraph or line <code>UBiDi</code> object.
+     *
+     * @return The length of the text that the UBiDi object was created for.
+     * @stable ICU 2.0
+     */
+    /* *
+     * Get the paragraph level of the text.
+     *
+     * @param pBiDi is the paragraph or line <code>UBiDi</code> object.
+     *
+     * @return The paragraph level. If there are multiple paragraphs, their
+     *         level may vary if the required paraLevel is UBIDI_DEFAULT_LTR or
+     *         UBIDI_DEFAULT_RTL.  In that case, the level of the first paragraph
+     *         is returned.
+     *
+     * @see UBiDiLevel
+     * @see ubidi_getParagraph
+     * @see ubidi_getParagraphByIndex
+     * @stable ICU 2.0
+     */
+    /* *
+     * Get the number of paragraphs.
+     *
+     * @param pBiDi is the paragraph or line <code>UBiDi</code> object.
+     *
+     * @return The number of paragraphs.
+     * @stable ICU 3.4
+     */
+    /* *
+     * Get a paragraph, given a position within the text.
+     * This function returns information about a paragraph.<br>
+     * Note: if the paragraph index is known, it is more efficient to
+     * retrieve the paragraph information using ubidi_getParagraphByIndex().<p>
+     *
+     * @param pBiDi is the paragraph or line <code>UBiDi</code> object.
+     *
+     * @param charIndex is the index of a character within the text, in the
+     *        range <code>[0..ubidi_getProcessedLength(pBiDi)-1]</code>.
+     *
+     * @param pParaStart will receive the index of the first character of the
+     *        paragraph in the text.
+     *        This pointer can be <code>NULL</code> if this
+     *        value is not necessary.
+     *
+     * @param pParaLimit will receive the limit of the paragraph.
+     *        The l-value that you point to here may be the
+     *        same expression (variable) as the one for
+     *        <code>charIndex</code>.
+     *        This pointer can be <code>NULL</code> if this
+     *        value is not necessary.
+     *
+     * @param pParaLevel will receive the level of the paragraph.
+     *        This pointer can be <code>NULL</code> if this
+     *        value is not necessary.
+     *
+     * @param pErrorCode must be a valid pointer to an error code value.
+     *
+     * @return The index of the paragraph containing the specified position.
+     *
+     * @see ubidi_getProcessedLength
+     * @stable ICU 3.4
+     */
+    /* *
+     * Get a paragraph, given the index of this paragraph.
+     *
+     * This function returns information about a paragraph.<p>
+     *
+     * @param pBiDi is the paragraph <code>UBiDi</code> object.
+     *
+     * @param paraIndex is the number of the paragraph, in the
+     *        range <code>[0..ubidi_countParagraphs(pBiDi)-1]</code>.
+     *
+     * @param pParaStart will receive the index of the first character of the
+     *        paragraph in the text.
+     *        This pointer can be <code>NULL</code> if this
+     *        value is not necessary.
+     *
+     * @param pParaLimit will receive the limit of the paragraph.
+     *        This pointer can be <code>NULL</code> if this
+     *        value is not necessary.
+     *
+     * @param pParaLevel will receive the level of the paragraph.
+     *        This pointer can be <code>NULL</code> if this
+     *        value is not necessary.
+     *
+     * @param pErrorCode must be a valid pointer to an error code value.
+     *
+     * @stable ICU 3.4
+     */
+    /* *
+     * Get the level for one character.
+     *
+     * @param pBiDi is the paragraph or line <code>UBiDi</code> object.
+     *
+     * @param charIndex the index of a character. It must be in the range
+     *         [0..ubidi_getProcessedLength(pBiDi)].
+     *
+     * @return The level for the character at charIndex (0 if charIndex is not
+     *         in the valid range).
+     *
+     * @see UBiDiLevel
+     * @see ubidi_getProcessedLength
+     * @stable ICU 2.0
+     */
+    /* *
+     * Get an array of levels for each character.<p>
+     *
+     * Note that this function may allocate memory under some
+     * circumstances, unlike <code>ubidi_getLevelAt()</code>.
+     *
+     * @param pBiDi is the paragraph or line <code>UBiDi</code> object, whose
+     *        text length must be strictly positive.
+     *
+     * @param pErrorCode must be a valid pointer to an error code value.
+     *
+     * @return The levels array for the text,
+     *         or <code>NULL</code> if an error occurs.
+     *
+     * @see UBiDiLevel
+     * @see ubidi_getProcessedLength
+     * @stable ICU 2.0
+     */
+    /* *
+     * Get a logical run.
+     * This function returns information about a run and is used
+     * to retrieve runs in logical order.<p>
+     * This is especially useful for line-breaking on a paragraph.
+     *
+     * @param pBiDi is the paragraph or line <code>UBiDi</code> object.
+     *
+     * @param logicalPosition is a logical position within the source text.
+     *
+     * @param pLogicalLimit will receive the limit of the corresponding run.
+     *        The l-value that you point to here may be the
+     *        same expression (variable) as the one for
+     *        <code>logicalPosition</code>.
+     *        This pointer can be <code>NULL</code> if this
+     *        value is not necessary.
+     *
+     * @param pLevel will receive the level of the corresponding run.
+     *        This pointer can be <code>NULL</code> if this
+     *        value is not necessary.
+     *
+     * @see ubidi_getProcessedLength
+     * @stable ICU 2.0
+     */
+    /* *
+     * Get the number of runs.
+     * This function may invoke the actual reordering on the
+     * <code>UBiDi</code> object, after <code>ubidi_setPara()</code>
+     * may have resolved only the levels of the text. Therefore,
+     * <code>ubidi_countRuns()</code> may have to allocate memory,
+     * and may fail doing so.
+     *
+     * @param pBiDi is the paragraph or line <code>UBiDi</code> object.
+     *
+     * @param pErrorCode must be a valid pointer to an error code value.
+     *
+     * @return The number of runs.
+     * @stable ICU 2.0
+     */
+    /* *
+     * Get one run's logical start, length, and directionality,
+     * which can be 0 for LTR or 1 for RTL.
+     * In an RTL run, the character at the logical start is
+     * visually on the right of the displayed run.
+     * The length is the number of characters in the run.<p>
+     * <code>ubidi_countRuns()</code> should be called
+     * before the runs are retrieved.
+     *
+     * @param pBiDi is the paragraph or line <code>UBiDi</code> object.
+     *
+     * @param runIndex is the number of the run in visual order, in the
+     *        range <code>[0..ubidi_countRuns(pBiDi)-1]</code>.
+     *
+     * @param pLogicalStart is the first logical character index in the text.
+     *        The pointer may be <code>NULL</code> if this index is not needed.
+     *
+     * @param pLength is the number of characters (at least one) in the run.
+     *        The pointer may be <code>NULL</code> if this is not needed.
+     *
+     * @return the directionality of the run,
+     *         <code>UBIDI_LTR==0</code> or <code>UBIDI_RTL==1</code>,
+     *         never <code>UBIDI_MIXED</code>,
+     *         never <code>UBIDI_NEUTRAL</code>.
+     *
+     * @see ubidi_countRuns
+     *
+     * Example:
+     * <pre>
+     * \code
+     * int32_t i, count=ubidi_countRuns(pBiDi),
+     *         logicalStart, visualIndex=0, length;
+     * for(i=0; i<count; ++i) {
+     *    if(UBIDI_LTR==ubidi_getVisualRun(pBiDi, i, &logicalStart, &length)) {
+     *         do { // LTR
+     *             show_char(text[logicalStart++], visualIndex++);
+     *         } while(--length>0);
+     *     } else {
+     *         logicalStart+=length;  // logicalLimit
+     *         do { // RTL
+     *             show_char(text[--logicalStart], visualIndex++);
+     *         } while(--length>0);
+     *     }
+     * }
+     *\endcode
+     * </pre>
+     *
+     * Note that in right-to-left runs, code like this places
+     * second surrogates before first ones (which is generally a bad idea)
+     * and combining characters before base characters.
+     * <p>
+     * Use of <code>ubidi_writeReordered()</code>, optionally with the
+     * <code>#UBIDI_KEEP_BASE_COMBINING</code> option, can be considered in order
+     * to avoid these issues.
+     * @stable ICU 2.0
+     */
+    #[no_mangle]
+    fn ubidi_getVisualRun_64(
+        pBiDi: *mut UBiDi,
+        runIndex: int32_t,
+        pLogicalStart: *mut int32_t,
+        pLength: *mut int32_t,
+    ) -> UBiDiDirection;
+    #[no_mangle]
+    fn ubidi_countRuns_64(pBiDi: *mut UBiDi, pErrorCode: *mut UErrorCode) -> int32_t;
+    #[no_mangle]
+    fn ubidi_getDirection_64(pBiDi: *const UBiDi) -> UBiDiDirection;
+    #[no_mangle]
+    fn ubidi_setPara_64(
+        pBiDi: *mut UBiDi,
+        text: *const UChar,
+        length: int32_t,
+        paraLevel: UBiDiLevel,
+        embeddingLevels: *mut UBiDiLevel,
+        pErrorCode: *mut UErrorCode,
+    );
+    /* *
+     * A recommended size (in bytes) for the memory buffer to be passed to ubrk_saveClone().
+     * @deprecated ICU 52. Do not rely on ubrk_safeClone() cloning into any provided buffer.
+     */
+    /* U_HIDE_DEPRECATED_API */
+    /* *
+    * Close a UBreakIterator.
+    * Once closed, a UBreakIterator may no longer be used.
+    * @param bi The break iterator to close.
+     * @stable ICU 2.0
+    */
+    #[no_mangle]
+    fn ubrk_close_64(bi: *mut UBreakIterator);
+    #[no_mangle]
+    fn ubrk_open_64(
+        type_0: UBreakIteratorType,
+        locale: *const libc::c_char,
+        text: *const UChar,
+        textLength: int32_t,
+        status: *mut UErrorCode,
+    ) -> *mut UBreakIterator;
+    #[no_mangle]
+    fn ubrk_setText_64(
+        bi: *mut UBreakIterator,
+        text: *const UChar,
+        textLength: int32_t,
+        status: *mut UErrorCode,
+    );
+    #[no_mangle]
+    fn ubrk_next_64(bi: *mut UBreakIterator) -> int32_t;
+    /* *
+     * Creates a UConverter object with the name of a coded character set specified as a C string.
+     * The actual name will be resolved with the alias file
+     * using a case-insensitive string comparison that ignores
+     * leading zeroes and all non-alphanumeric characters.
+     * E.g., the names "UTF8", "utf-8", "u*T@f08" and "Utf 8" are all equivalent.
+     * (See also ucnv_compareNames().)
+     * If <code>NULL</code> is passed for the converter name, it will create one with the
+     * getDefaultName return value.
+     *
+     * <p>A converter name for ICU 1.5 and above may contain options
+     * like a locale specification to control the specific behavior of
+     * the newly instantiated converter.
+     * The meaning of the options depends on the particular converter.
+     * If an option is not defined for or recognized by a given converter, then it is ignored.</p>
+     *
+     * <p>Options are appended to the converter name string, with a
+     * <code>UCNV_OPTION_SEP_CHAR</code> between the name and the first option and
+     * also between adjacent options.</p>
+     *
+     * <p>If the alias is ambiguous, then the preferred converter is used
+     * and the status is set to U_AMBIGUOUS_ALIAS_WARNING.</p>
+     *
+     * <p>The conversion behavior and names can vary between platforms. ICU may
+     * convert some characters differently from other platforms. Details on this topic
+     * are in the <a href="http://icu-project.org/userguide/conversion.html">User's
+     * Guide</a>. Aliases starting with a "cp" prefix have no specific meaning
+     * other than its an alias starting with the letters "cp". Please do not
+     * associate any meaning to these aliases.</p>
+     *
+     * \snippet samples/ucnv/convsamp.cpp ucnv_open
+     *
+     * @param converterName Name of the coded character set table.
+     *          This may have options appended to the string.
+     *          IANA alias character set names, IBM CCSIDs starting with "ibm-",
+     *          Windows codepage numbers starting with "windows-" are frequently
+     *          used for this parameter. See ucnv_getAvailableName and
+     *          ucnv_getAlias for a complete list that is available.
+     *          If this parameter is NULL, the default converter will be used.
+     * @param err outgoing error status <TT>U_MEMORY_ALLOCATION_ERROR, U_FILE_ACCESS_ERROR</TT>
+     * @return the created Unicode converter object, or <TT>NULL</TT> if an error occurred
+     * @see ucnv_openU
+     * @see ucnv_openCCSID
+     * @see ucnv_getAvailableName
+     * @see ucnv_getAlias
+     * @see ucnv_getDefaultName
+     * @see ucnv_close
+     * @see ucnv_compareNames
+     * @stable ICU 2.0
+     */
+    #[no_mangle]
+    fn ucnv_open_64(converterName: *const libc::c_char, err: *mut UErrorCode) -> *mut UConverter;
+    /* *
+     * \def U_CNV_SAFECLONE_BUFFERSIZE
+     * Definition of a buffer size that is designed to be large enough for
+     * converters to be cloned with ucnv_safeClone().
+     * @deprecated ICU 52. Do not rely on ucnv_safeClone() cloning into any provided buffer.
+     */
+    /* U_HIDE_DEPRECATED_API */
+    /* *
+     * Deletes the unicode converter and releases resources associated
+     * with just this instance.
+     * Does not free up shared converter tables.
+     *
+     * @param converter the converter object to be deleted
+     * @see ucnv_open
+     * @see ucnv_openU
+     * @see ucnv_openCCSID
+     * @stable ICU 2.0
+     */
+    #[no_mangle]
+    fn ucnv_close_64(converter: *mut UConverter);
     #[no_mangle]
     fn gr_label_destroy(label: *mut libc::c_void);
     #[no_mangle]
-    fn gettexstring(_: str_number) -> *mut i8;
+    fn gettexstring(_: str_number) -> *mut libc::c_char;
     #[no_mangle]
-    static mut name_of_file: *mut i8;
+    static mut name_of_file: *mut libc::c_char;
     #[no_mangle]
-    static mut name_length: i32;
+    static mut name_length: int32_t;
     #[no_mangle]
     static mut font_info: *mut memory_word;
     #[no_mangle]
@@ -259,13 +1567,13 @@ extern "C" {
     #[no_mangle]
     static mut font_layout_engine: *mut *mut libc::c_void;
     #[no_mangle]
-    static mut font_flags: *mut i8;
+    static mut font_flags: *mut libc::c_char;
     #[no_mangle]
     static mut font_letter_space: *mut scaled_t;
     #[no_mangle]
     static mut loaded_font_mapping: *mut libc::c_void;
     #[no_mangle]
-    static mut loaded_font_flags: i8;
+    static mut loaded_font_flags: libc::c_char;
     #[no_mangle]
     static mut loaded_font_letter_space: scaled_t;
     #[no_mangle]
@@ -273,15 +1581,15 @@ extern "C" {
     #[no_mangle]
     static mut mapped_text: *mut UTF16_code;
     #[no_mangle]
-    static mut xdv_buffer: *mut i8;
+    static mut xdv_buffer: *mut libc::c_char;
     #[no_mangle]
-    static mut height_base: *mut i32;
+    static mut height_base: *mut int32_t;
     #[no_mangle]
-    static mut depth_base: *mut i32;
+    static mut depth_base: *mut int32_t;
     #[no_mangle]
-    static mut param_base: *mut i32;
+    static mut param_base: *mut int32_t;
     #[no_mangle]
-    static mut native_font_type_flag: i32;
+    static mut native_font_type_flag: int32_t;
     #[no_mangle]
     fn begin_diagnostic();
     #[no_mangle]
@@ -289,79 +1597,151 @@ extern "C" {
     #[no_mangle]
     fn font_feature_warning(
         featureNameP: *const libc::c_void,
-        featLen: i32,
+        featLen: int32_t,
         settingNameP: *const libc::c_void,
-        setLen: i32,
+        setLen: int32_t,
     );
     #[no_mangle]
     fn font_mapping_warning(
         mappingNameP: *const libc::c_void,
-        mappingNameLen: i32,
-        warningType: i32,
+        mappingNameLen: int32_t,
+        warningType: int32_t,
     );
     #[no_mangle]
-    fn get_tracing_fonts_state() -> i32;
+    fn get_tracing_fonts_state() -> int32_t;
     #[no_mangle]
     fn print_raw_char(s: UTF16_code, incr_offset: bool);
     #[no_mangle]
-    fn print_char(s: i32);
+    fn print_char(s: int32_t);
     #[no_mangle]
     fn print_nl(s: str_number);
     #[no_mangle]
-    fn print_int(n: i32);
-    /* xetex-pagebuilder */
-    /* xetex-scaledmath */
+    fn print_int(n: int32_t);
     #[no_mangle]
-    fn xn_over_d(x: scaled_t, n: i32, d: i32) -> scaled_t;
+    fn xn_over_d(x: scaled_t, n: int32_t, d: int32_t) -> scaled_t;
+    #[no_mangle]
+    fn CFNumberGetValue(
+        number: CFNumberRef,
+        theType: CFNumberType,
+        valuePtr: *mut libc::c_void,
+    ) -> Boolean;
+    #[no_mangle]
+    fn CGColorGetComponents(color: CGColorRef) -> *const CGFloat;
+    #[no_mangle]
+    static kCTForegroundColorAttributeName: CFStringRef;
+    #[no_mangle]
+    static kCTVerticalFormsAttributeName: CFStringRef;
+    #[no_mangle]
+    fn CFArrayGetCount(theArray: CFArrayRef) -> CFIndex;
+    #[no_mangle]
+    fn CFStringGetLength(theString: CFStringRef) -> CFIndex;
+    #[no_mangle]
+    fn CFStringGetCharacters(theString: CFStringRef, range: CFRange, buffer: *mut UniChar);
+    #[no_mangle]
+    fn CFArrayGetValueAtIndex(theArray: CFArrayRef, idx: CFIndex) -> *const libc::c_void;
+    #[no_mangle]
+    fn CFDictionaryGetValue(
+        theDict: CFDictionaryRef,
+        key: *const libc::c_void,
+    ) -> *const libc::c_void;
+    #[no_mangle]
+    fn CTFontGetSize(font: CTFontRef) -> CGFloat;
+    #[no_mangle]
+    fn CTFontGetMatrix(font: CTFontRef) -> CGAffineTransform;
+    #[no_mangle]
+    fn CFDictionaryGetValueIfPresent(
+        theDict: CFDictionaryRef,
+        key: *const libc::c_void,
+        value: *mut *const libc::c_void,
+    ) -> Boolean;
+    #[no_mangle]
+    fn CFRelease(cf: CFTypeRef);
+    #[no_mangle]
+    fn CTFontGetAscent(font: CTFontRef) -> CGFloat;
+    #[no_mangle]
+    fn CTFontGetDescent(font: CTFontRef) -> CGFloat;
+    #[no_mangle]
+    fn CTFontGetGlyphCount(font: CTFontRef) -> CFIndex;
+    #[no_mangle]
+    fn CTFontGetSlantAngle(font: CTFontRef) -> CGFloat;
+    #[no_mangle]
+    fn CTFontGetCapHeight(font: CTFontRef) -> CGFloat;
+    #[no_mangle]
+    fn CTFontGetXHeight(font: CTFontRef) -> CGFloat;
+    #[no_mangle]
+    static kCTFontFeatureTypeIdentifierKey: CFStringRef;
+    #[no_mangle]
+    static kCTFontFeatureTypeNameKey: CFStringRef;
+    #[no_mangle]
+    static kCTFontFeatureTypeExclusiveKey: CFStringRef;
+    #[no_mangle]
+    static kCTFontFeatureTypeSelectorsKey: CFStringRef;
+    #[no_mangle]
+    static kCTFontFeatureSelectorIdentifierKey: CFStringRef;
+    #[no_mangle]
+    static kCTFontFeatureSelectorNameKey: CFStringRef;
+    #[no_mangle]
+    static kCTFontFeatureSelectorDefaultKey: CFStringRef;
+    #[no_mangle]
+    fn CTFontCopyFeatures(font: CTFontRef) -> CFArrayRef;
 }
-pub type __ssize_t = i64;
-pub type size_t = u64;
-pub type ssize_t = __ssize_t;
-
-use crate::TTInputFormat;
-
+pub type __darwin_size_t = libc::c_ulong;
+pub type __darwin_ssize_t = libc::c_long;
+pub type size_t = __darwin_size_t;
+pub type int32_t = libc::c_int;
+pub type uint8_t = libc::c_uchar;
+pub type uint16_t = libc::c_ushort;
+pub type uint32_t = libc::c_uint;
+pub type ssize_t = __darwin_ssize_t;
+pub type tt_input_format_type = libc::c_uint;
+pub const TTIF_TECTONIC_PRIMARY: tt_input_format_type = 59;
+pub const TTIF_OPENTYPE: tt_input_format_type = 47;
+pub const TTIF_SFD: tt_input_format_type = 46;
+pub const TTIF_CMAP: tt_input_format_type = 45;
+pub const TTIF_ENC: tt_input_format_type = 44;
+pub const TTIF_MISCFONTS: tt_input_format_type = 41;
+pub const TTIF_BINARY: tt_input_format_type = 40;
+pub const TTIF_TRUETYPE: tt_input_format_type = 36;
+pub const TTIF_VF: tt_input_format_type = 33;
+pub const TTIF_TYPE1: tt_input_format_type = 32;
+pub const TTIF_TEX_PS_HEADER: tt_input_format_type = 30;
+pub const TTIF_TEX: tt_input_format_type = 26;
+pub const TTIF_PICT: tt_input_format_type = 25;
+pub const TTIF_OVF: tt_input_format_type = 23;
+pub const TTIF_OFM: tt_input_format_type = 20;
+pub const TTIF_FONTMAP: tt_input_format_type = 11;
+pub const TTIF_FORMAT: tt_input_format_type = 10;
+pub const TTIF_CNF: tt_input_format_type = 8;
+pub const TTIF_BST: tt_input_format_type = 7;
+pub const TTIF_BIB: tt_input_format_type = 6;
+pub const TTIF_AFM: tt_input_format_type = 4;
+pub const TTIF_TFM: tt_input_format_type = 3;
 pub type rust_input_handle_t = *mut libc::c_void;
-/* quasi-hack to get the primary input */
-/* NB: assumes int is 4 bytes */
-/* n.b. if also using zlib.h, it must precede TECkit headers */
-pub type FcPattern = _FcPattern;
-pub type hb_tag_t = u32;
+pub type XeTeXLayoutEngine = *mut XeTeXLayoutEngine_rec;
 #[derive(Copy, Clone)]
-#[repr(C)]
-pub struct hb_feature_t {
-    pub tag: hb_tag_t,
-    pub value: u32,
-    pub start: u32,
-    pub end: u32,
-}
-pub type scaled_t = i32;
-pub type Fixed = scaled_t;
-#[derive(Copy, Clone)]
-#[repr(C)]
+#[repr(C, packed(2))]
 pub struct FixedPoint {
     pub x: Fixed,
     pub y: Fixed,
 }
-pub type CFDictionaryRef = *mut libc::c_void;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct FloatPoint {
-    pub x: f32,
-    pub y: f32,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct GlyphBBox {
-    pub xMin: f32,
-    pub yMin: f32,
-    pub xMax: f32,
-    pub yMax: f32,
-}
-pub type PlatformFontRef = *mut FcPattern;
+pub type Fixed = SInt32;
+pub type SInt32 = libc::c_int;
+pub type UChar = uint16_t;
+pub type UniChar = UInt16;
+pub type UInt16 = libc::c_ushort;
+pub type CFStringRef = *const __CFString;
+pub type UBiDiLevel = uint8_t;
 pub type XeTeXFont = *mut XeTeXFont_rec;
-pub type XeTeXLayoutEngine = *mut XeTeXLayoutEngine_rec;
-pub type Byte = UInt8;
-pub type UInt8 = u8;
+pub type CFDictionaryRef = *const __CFDictionary;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct hb_feature_t {
+    pub tag: hb_tag_t,
+    pub value: uint32_t,
+    pub start: libc::c_uint,
+    pub end: libc::c_uint,
+}
+pub type hb_tag_t = uint32_t;
 /*------------------------------------------------------------------------
 Copyright (C) 2002-2014 SIL International. All rights reserved.
 
@@ -419,20 +1799,263 @@ Description:
     A converter object is an opaque pointer
 */
 pub type TECkit_Converter = *mut Opaque_TECkit_Converter;
-pub type str_number = i32;
+pub type Byte = UInt8;
+pub type UInt8 = libc::c_uchar;
+pub type Boolean = libc::c_uchar;
+pub type UErrorCode = libc::c_int;
+pub const U_ERROR_LIMIT: UErrorCode = 66818;
+pub const U_PLUGIN_ERROR_LIMIT: UErrorCode = 66818;
+pub const U_PLUGIN_DIDNT_SET_LEVEL: UErrorCode = 66817;
+pub const U_PLUGIN_TOO_HIGH: UErrorCode = 66816;
+pub const U_PLUGIN_ERROR_START: UErrorCode = 66816;
+pub const U_STRINGPREP_CHECK_BIDI_ERROR: UErrorCode = 66562;
+pub const U_STRINGPREP_UNASSIGNED_ERROR: UErrorCode = 66561;
+pub const U_STRINGPREP_PROHIBITED_ERROR: UErrorCode = 66560;
+pub const U_IDNA_ERROR_LIMIT: UErrorCode = 66569;
+pub const U_IDNA_DOMAIN_NAME_TOO_LONG_ERROR: UErrorCode = 66568;
+pub const U_IDNA_ZERO_LENGTH_LABEL_ERROR: UErrorCode = 66567;
+pub const U_IDNA_LABEL_TOO_LONG_ERROR: UErrorCode = 66566;
+pub const U_IDNA_VERIFICATION_ERROR: UErrorCode = 66565;
+pub const U_IDNA_ACE_PREFIX_ERROR: UErrorCode = 66564;
+pub const U_IDNA_STD3_ASCII_RULES_ERROR: UErrorCode = 66563;
+pub const U_IDNA_CHECK_BIDI_ERROR: UErrorCode = 66562;
+pub const U_IDNA_UNASSIGNED_ERROR: UErrorCode = 66561;
+pub const U_IDNA_ERROR_START: UErrorCode = 66560;
+pub const U_IDNA_PROHIBITED_ERROR: UErrorCode = 66560;
+pub const U_REGEX_ERROR_LIMIT: UErrorCode = 66326;
+pub const U_REGEX_INVALID_CAPTURE_GROUP_NAME: UErrorCode = 66325;
+pub const U_REGEX_PATTERN_TOO_BIG: UErrorCode = 66324;
+pub const U_REGEX_STOPPED_BY_CALLER: UErrorCode = 66323;
+pub const U_REGEX_TIME_OUT: UErrorCode = 66322;
+pub const U_REGEX_STACK_OVERFLOW: UErrorCode = 66321;
+pub const U_REGEX_INVALID_RANGE: UErrorCode = 66320;
+pub const U_REGEX_MISSING_CLOSE_BRACKET: UErrorCode = 66319;
+pub const U_REGEX_OCTAL_TOO_BIG: UErrorCode = 66318;
+pub const U_REGEX_SET_CONTAINS_STRING: UErrorCode = 66317;
+pub const U_REGEX_LOOK_BEHIND_LIMIT: UErrorCode = 66316;
+pub const U_REGEX_INVALID_FLAG: UErrorCode = 66315;
+pub const U_REGEX_INVALID_BACK_REF: UErrorCode = 66314;
+pub const U_REGEX_MAX_LT_MIN: UErrorCode = 66313;
+pub const U_REGEX_BAD_INTERVAL: UErrorCode = 66312;
+pub const U_REGEX_NUMBER_TOO_BIG: UErrorCode = 66311;
+pub const U_REGEX_MISMATCHED_PAREN: UErrorCode = 66310;
+pub const U_REGEX_UNIMPLEMENTED: UErrorCode = 66309;
+pub const U_REGEX_PROPERTY_SYNTAX: UErrorCode = 66308;
+pub const U_REGEX_BAD_ESCAPE_SEQUENCE: UErrorCode = 66307;
+pub const U_REGEX_INVALID_STATE: UErrorCode = 66306;
+pub const U_REGEX_RULE_SYNTAX: UErrorCode = 66305;
+pub const U_REGEX_ERROR_START: UErrorCode = 66304;
+pub const U_REGEX_INTERNAL_ERROR: UErrorCode = 66304;
+pub const U_BRK_ERROR_LIMIT: UErrorCode = 66062;
+pub const U_BRK_MALFORMED_RULE_TAG: UErrorCode = 66061;
+pub const U_BRK_UNRECOGNIZED_OPTION: UErrorCode = 66060;
+pub const U_BRK_RULE_EMPTY_SET: UErrorCode = 66059;
+pub const U_BRK_INIT_ERROR: UErrorCode = 66058;
+pub const U_BRK_UNDEFINED_VARIABLE: UErrorCode = 66057;
+pub const U_BRK_NEW_LINE_IN_QUOTED_STRING: UErrorCode = 66056;
+pub const U_BRK_MISMATCHED_PAREN: UErrorCode = 66055;
+pub const U_BRK_VARIABLE_REDFINITION: UErrorCode = 66054;
+pub const U_BRK_ASSIGN_ERROR: UErrorCode = 66053;
+pub const U_BRK_UNCLOSED_SET: UErrorCode = 66052;
+pub const U_BRK_RULE_SYNTAX: UErrorCode = 66051;
+pub const U_BRK_SEMICOLON_EXPECTED: UErrorCode = 66050;
+pub const U_BRK_HEX_DIGITS_EXPECTED: UErrorCode = 66049;
+pub const U_BRK_ERROR_START: UErrorCode = 66048;
+pub const U_BRK_INTERNAL_ERROR: UErrorCode = 66048;
+pub const U_FMT_PARSE_ERROR_LIMIT: UErrorCode = 65812;
+pub const U_NUMBER_SKELETON_SYNTAX_ERROR: UErrorCode = 65811;
+pub const U_NUMBER_ARG_OUTOFBOUNDS_ERROR: UErrorCode = 65810;
+pub const U_FORMAT_INEXACT_ERROR: UErrorCode = 65809;
+pub const U_DECIMAL_NUMBER_SYNTAX_ERROR: UErrorCode = 65808;
+pub const U_DEFAULT_KEYWORD_MISSING: UErrorCode = 65807;
+pub const U_UNDEFINED_KEYWORD: UErrorCode = 65806;
+pub const U_DUPLICATE_KEYWORD: UErrorCode = 65805;
+pub const U_ARGUMENT_TYPE_MISMATCH: UErrorCode = 65804;
+pub const U_UNSUPPORTED_ATTRIBUTE: UErrorCode = 65803;
+pub const U_UNSUPPORTED_PROPERTY: UErrorCode = 65802;
+pub const U_UNMATCHED_BRACES: UErrorCode = 65801;
+pub const U_ILLEGAL_PAD_POSITION: UErrorCode = 65800;
+pub const U_PATTERN_SYNTAX_ERROR: UErrorCode = 65799;
+pub const U_MULTIPLE_PAD_SPECIFIERS: UErrorCode = 65798;
+pub const U_MULTIPLE_PERMILL_SYMBOLS: UErrorCode = 65797;
+pub const U_MULTIPLE_PERCENT_SYMBOLS: UErrorCode = 65796;
+pub const U_MALFORMED_EXPONENTIAL_PATTERN: UErrorCode = 65795;
+pub const U_MULTIPLE_EXPONENTIAL_SYMBOLS: UErrorCode = 65794;
+pub const U_MULTIPLE_DECIMAL_SEPERATORS: UErrorCode = 65793;
+pub const U_MULTIPLE_DECIMAL_SEPARATORS: UErrorCode = 65793;
+pub const U_FMT_PARSE_ERROR_START: UErrorCode = 65792;
+pub const U_UNEXPECTED_TOKEN: UErrorCode = 65792;
+pub const U_PARSE_ERROR_LIMIT: UErrorCode = 65571;
+pub const U_INVALID_FUNCTION: UErrorCode = 65570;
+pub const U_INVALID_ID: UErrorCode = 65569;
+pub const U_INTERNAL_TRANSLITERATOR_ERROR: UErrorCode = 65568;
+pub const U_ILLEGAL_CHARACTER: UErrorCode = 65567;
+pub const U_VARIABLE_RANGE_OVERLAP: UErrorCode = 65566;
+pub const U_VARIABLE_RANGE_EXHAUSTED: UErrorCode = 65565;
+pub const U_ILLEGAL_CHAR_IN_SEGMENT: UErrorCode = 65564;
+pub const U_UNCLOSED_SEGMENT: UErrorCode = 65563;
+pub const U_MALFORMED_PRAGMA: UErrorCode = 65562;
+pub const U_INVALID_PROPERTY_PATTERN: UErrorCode = 65561;
+pub const U_INVALID_RBT_SYNTAX: UErrorCode = 65560;
+pub const U_MULTIPLE_COMPOUND_FILTERS: UErrorCode = 65559;
+pub const U_MISPLACED_COMPOUND_FILTER: UErrorCode = 65558;
+pub const U_RULE_MASK_ERROR: UErrorCode = 65557;
+pub const U_UNTERMINATED_QUOTE: UErrorCode = 65556;
+pub const U_UNQUOTED_SPECIAL: UErrorCode = 65555;
+pub const U_UNDEFINED_VARIABLE: UErrorCode = 65554;
+pub const U_UNDEFINED_SEGMENT_REFERENCE: UErrorCode = 65553;
+pub const U_TRAILING_BACKSLASH: UErrorCode = 65552;
+pub const U_MULTIPLE_POST_CONTEXTS: UErrorCode = 65551;
+pub const U_MULTIPLE_CURSORS: UErrorCode = 65550;
+pub const U_MULTIPLE_ANTE_CONTEXTS: UErrorCode = 65549;
+pub const U_MISSING_SEGMENT_CLOSE: UErrorCode = 65548;
+pub const U_MISSING_OPERATOR: UErrorCode = 65547;
+pub const U_MISPLACED_QUANTIFIER: UErrorCode = 65546;
+pub const U_MISPLACED_CURSOR_OFFSET: UErrorCode = 65545;
+pub const U_MISPLACED_ANCHOR_START: UErrorCode = 65544;
+pub const U_MISMATCHED_SEGMENT_DELIMITERS: UErrorCode = 65543;
+pub const U_MALFORMED_VARIABLE_REFERENCE: UErrorCode = 65542;
+pub const U_MALFORMED_VARIABLE_DEFINITION: UErrorCode = 65541;
+pub const U_MALFORMED_UNICODE_ESCAPE: UErrorCode = 65540;
+pub const U_MALFORMED_SYMBOL_REFERENCE: UErrorCode = 65539;
+pub const U_MALFORMED_SET: UErrorCode = 65538;
+pub const U_MALFORMED_RULE: UErrorCode = 65537;
+pub const U_PARSE_ERROR_START: UErrorCode = 65536;
+pub const U_BAD_VARIABLE_DEFINITION: UErrorCode = 65536;
+pub const U_STANDARD_ERROR_LIMIT: UErrorCode = 31;
+pub const U_NO_WRITE_PERMISSION: UErrorCode = 30;
+pub const U_USELESS_COLLATOR_ERROR: UErrorCode = 29;
+pub const U_COLLATOR_VERSION_MISMATCH: UErrorCode = 28;
+pub const U_INVALID_STATE_ERROR: UErrorCode = 27;
+pub const U_INVARIANT_CONVERSION_ERROR: UErrorCode = 26;
+pub const U_ENUM_OUT_OF_SYNC_ERROR: UErrorCode = 25;
+pub const U_TOO_MANY_ALIASES_ERROR: UErrorCode = 24;
+pub const U_STATE_TOO_OLD_ERROR: UErrorCode = 23;
+pub const U_PRIMARY_TOO_LONG_ERROR: UErrorCode = 22;
+pub const U_CE_NOT_FOUND_ERROR: UErrorCode = 21;
+pub const U_NO_SPACE_AVAILABLE: UErrorCode = 20;
+pub const U_UNSUPPORTED_ESCAPE_SEQUENCE: UErrorCode = 19;
+pub const U_ILLEGAL_ESCAPE_SEQUENCE: UErrorCode = 18;
+pub const U_RESOURCE_TYPE_MISMATCH: UErrorCode = 17;
+pub const U_UNSUPPORTED_ERROR: UErrorCode = 16;
+pub const U_BUFFER_OVERFLOW_ERROR: UErrorCode = 15;
+pub const U_INVALID_TABLE_FILE: UErrorCode = 14;
+pub const U_INVALID_TABLE_FORMAT: UErrorCode = 13;
+pub const U_ILLEGAL_CHAR_FOUND: UErrorCode = 12;
+pub const U_TRUNCATED_CHAR_FOUND: UErrorCode = 11;
+pub const U_INVALID_CHAR_FOUND: UErrorCode = 10;
+pub const U_PARSE_ERROR: UErrorCode = 9;
+pub const U_INDEX_OUTOFBOUNDS_ERROR: UErrorCode = 8;
+pub const U_MEMORY_ALLOCATION_ERROR: UErrorCode = 7;
+pub const U_MESSAGE_PARSE_ERROR: UErrorCode = 6;
+pub const U_INTERNAL_PROGRAM_ERROR: UErrorCode = 5;
+pub const U_FILE_ACCESS_ERROR: UErrorCode = 4;
+pub const U_INVALID_FORMAT_ERROR: UErrorCode = 3;
+pub const U_MISSING_RESOURCE_ERROR: UErrorCode = 2;
+pub const U_ILLEGAL_ARGUMENT_ERROR: UErrorCode = 1;
+pub const U_ZERO_ERROR: UErrorCode = 0;
+pub const U_ERROR_WARNING_LIMIT: UErrorCode = -119;
+pub const U_PLUGIN_CHANGED_LEVEL_WARNING: UErrorCode = -120;
+pub const U_DIFFERENT_UCA_VERSION: UErrorCode = -121;
+pub const U_AMBIGUOUS_ALIAS_WARNING: UErrorCode = -122;
+pub const U_SORT_KEY_TOO_SHORT_WARNING: UErrorCode = -123;
+pub const U_STRING_NOT_TERMINATED_WARNING: UErrorCode = -124;
+pub const U_STATE_OLD_WARNING: UErrorCode = -125;
+pub const U_SAFECLONE_ALLOCATED_WARNING: UErrorCode = -126;
+pub const U_USING_DEFAULT_WARNING: UErrorCode = -127;
+pub const U_ERROR_WARNING_START: UErrorCode = -128;
+pub const U_USING_FALLBACK_WARNING: UErrorCode = -128;
+/* tectonic/xetex-core.h: core XeTeX types and #includes.
+   Copyright 2016 the Tectonic Project
+   Licensed under the MIT License.
+*/
+// defines U_IS_BIG_ENDIAN for us
+/* fontconfig */
+/* freetype */
+/* harfbuzz */
+/* Endianness foo */
+/* our typedefs */
+pub type scaled_t = int32_t;
+pub type UInt32 = libc::c_uint;
+pub type CFIndex = libc::c_long;
+pub type CFTypeRef = *const libc::c_void;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct CFRange {
+    pub location: CFIndex,
+    pub length: CFIndex,
+}
+pub type CFArrayRef = *const __CFArray;
+pub type CFBooleanRef = *const __CFBoolean;
+pub type CFNumberType = CFIndex;
+pub type C2RustUnnamed = libc::c_uint;
+pub const kCFNumberMaxType: C2RustUnnamed = 16;
+pub const kCFNumberCGFloatType: C2RustUnnamed = 16;
+pub const kCFNumberNSIntegerType: C2RustUnnamed = 15;
+pub const kCFNumberCFIndexType: C2RustUnnamed = 14;
+pub const kCFNumberDoubleType: C2RustUnnamed = 13;
+pub const kCFNumberFloatType: C2RustUnnamed = 12;
+pub const kCFNumberLongLongType: C2RustUnnamed = 11;
+pub const kCFNumberLongType: C2RustUnnamed = 10;
+pub const kCFNumberIntType: C2RustUnnamed = 9;
+pub const kCFNumberShortType: C2RustUnnamed = 8;
+pub const kCFNumberCharType: C2RustUnnamed = 7;
+pub const kCFNumberFloat64Type: C2RustUnnamed = 6;
+pub const kCFNumberFloat32Type: C2RustUnnamed = 5;
+pub const kCFNumberSInt64Type: C2RustUnnamed = 4;
+pub const kCFNumberSInt32Type: C2RustUnnamed = 3;
+pub const kCFNumberSInt16Type: C2RustUnnamed = 2;
+pub const kCFNumberSInt8Type: C2RustUnnamed = 1;
+pub type CFNumberRef = *const __CFNumber;
+pub type CGFloat = libc::c_double;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct CGAffineTransform {
+    pub a: CGFloat,
+    pub b: CGFloat,
+    pub c: CGFloat,
+    pub d: CGFloat,
+    pub tx: CGFloat,
+    pub ty: CGFloat,
+}
+pub type CGColorRef = *mut CGColor;
+pub type CTFontDescriptorRef = *const __CTFontDescriptor;
+pub type CTFontRef = *const __CTFont;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct FloatPoint {
+    pub x: libc::c_float,
+    pub y: libc::c_float,
+}
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct GlyphBBox {
+    pub xMin: libc::c_float,
+    pub yMin: libc::c_float,
+    pub xMax: libc::c_float,
+    pub yMax: libc::c_float,
+}
+pub type PlatformFontRef = CTFontDescriptorRef;
+pub type str_number = int32_t;
+pub type UBreakIteratorType = libc::c_uint;
+pub const UBRK_COUNT: UBreakIteratorType = 5;
+pub const UBRK_TITLE: UBreakIteratorType = 4;
+pub const UBRK_SENTENCE: UBreakIteratorType = 3;
+pub const UBRK_LINE: UBreakIteratorType = 2;
+pub const UBRK_WORD: UBreakIteratorType = 1;
+pub const UBRK_CHARACTER: UBreakIteratorType = 0;
 /* tectonic/xetex-xetexd.h -- many, many XeTeX symbol definitions
    Copyright 2016-2018 The Tectonic Project
    Licensed under the MIT License.
 */
+/* include this here to avoid conflict between clang's emmintrin.h and
+ * texmfmem.h. Should be removed once a fixed clang is widely available
+ * http://llvm.org/bugs/show_bug.cgi?id=14964 */
 /* Extra stuff used in various change files for various reasons.  */
 /* Array allocations. Add 1 to size to account for Pascal indexing convention. */
 /*11:*/
 /*18: */
-pub type UTF16_code = u16;
-/*
-    all public functions return a status code
-*/
-pub type TECkit_Status = i64;
+pub type UTF16_code = libc::c_ushort;
 /*------------------------------------------------------------------------
 Copyright (C) 2002-2016 SIL International. All rights reserved.
 
@@ -457,9 +2080,10 @@ History:
     xx-xxx-2002		jk	version 2.0 initial release
 */
 /* 16.16 version number */
-/* these are all predefined if using a Mac prefix */
-pub type UInt16 = u16;
-pub type UInt32 = u32;
+/*
+    all public functions return a status code
+*/
+pub type TECkit_Status = libc::c_long;
 /* The annoying `memory_word` type. We have to make sure the byte-swapping
  * that the (un)dumping routines do suffices to put things in the right place
  * in memory.
@@ -496,27 +2120,31 @@ pub type b32x2 = b32x2_le_t;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct b32x2_le_t {
-    pub s0: i32,
-    pub s1: i32,
+    pub s0: int32_t,
+    pub s1: int32_t,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union memory_word {
     pub b32: b32x2,
     pub b16: b16x4,
-    pub gr: f64,
+    pub gr: libc::c_double,
     pub ptr: *mut libc::c_void,
 }
 pub type b16x4 = b16x4_le_t;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct b16x4_le_t {
-    pub s0: u16,
-    pub s1: u16,
-    pub s2: u16,
-    pub s3: u16,
+    pub s0: uint16_t,
+    pub s1: uint16_t,
+    pub s2: uint16_t,
+    pub s3: uint16_t,
 }
-pub type UniChar = UInt16;
+pub const UBIDI_RTL: UBiDiDirection = 1;
+pub type UBiDiDirection = libc::c_uint;
+pub const UBIDI_NEUTRAL: UBiDiDirection = 3;
+pub const UBIDI_MIXED: UBiDiDirection = 2;
+pub const UBIDI_LTR: UBiDiDirection = 0;
 /* tectonic/core-strutils.h: miscellaneous C string utilities
    Copyright 2016-2018 the Tectonic Project
    Licensed under the MIT License.
@@ -524,6 +2152,34 @@ pub type UniChar = UInt16;
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
+#[inline]
+unsafe extern "C" fn strstartswith(
+    mut s: *const libc::c_char,
+    mut prefix: *const libc::c_char,
+) -> *const libc::c_char {
+    let mut length: size_t = 0;
+    length = strlen(prefix);
+    if strncmp(s, prefix, length) == 0i32 {
+        return s.offset(length as isize);
+    }
+    return 0 as *const libc::c_char;
+}
+#[inline]
+unsafe extern "C" fn streq_ptr(mut s1: *const libc::c_char, mut s2: *const libc::c_char) -> bool {
+    if !s1.is_null() && !s2.is_null() {
+        return strcmp(s1, s2) == 0i32;
+    }
+    return 0i32 != 0;
+}
+/* tectonic/core-memory.h: basic dynamic memory helpers
+   Copyright 2016-2018 the Tectonic Project
+   Licensed under the MIT License.
+*/
+#[inline]
+unsafe extern "C" fn mfree(mut ptr: *mut libc::c_void) -> *mut libc::c_void {
+    free(ptr);
+    return 0 as *mut libc::c_void;
+}
 /* ***************************************************************************\
  Part of the XeTeX typesetting system
  Copyright (c) 1994-2008 by SIL International
@@ -556,72 +2212,37 @@ use or other dealings in this Software without prior written
 authorization from the copyright holders.
 \****************************************************************************/
 #[inline]
-unsafe extern "C" fn SWAP16(p: u16) -> u16 {
-    ((p as i32 >> 8i32) + ((p as i32) << 8i32)) as u16
+unsafe extern "C" fn SWAP16(p: uint16_t) -> uint16_t {
+    return ((p as libc::c_int >> 8i32) + ((p as libc::c_int) << 8i32)) as uint16_t;
 }
 #[inline]
-unsafe extern "C" fn SWAP32(p: u32) -> u32 {
-    (p >> 24i32)
-        .wrapping_add(p >> 8i32 & 0xff00_u32)
-        .wrapping_add(p << 8i32 & 0xff0000_u32)
-        .wrapping_add(p << 24i32)
+unsafe extern "C" fn SWAP32(p: uint32_t) -> uint32_t {
+    return (p >> 24i32)
+        .wrapping_add(p >> 8i32 & 0xff00i32 as libc::c_uint)
+        .wrapping_add(p << 8i32 & 0xff0000i32 as libc::c_uint)
+        .wrapping_add(p << 24i32);
 }
-/* xetex-shipout */
-/* ***************************************************************************\
- Part of the XeTeX typesetting system
- Copyright (c) 1994-2008 by SIL International
- Copyright (c) 2009, 2011 by Jonathan Kew
- Copyright (c) 2012-2015 by Khaled Hosny
- Copyright (c) 2012, 2013 by Jiang Jiang
-
- SIL Author(s): Jonathan Kew
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE
-FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
-CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-Except as contained in this notice, the name of the copyright holders
-shall not be used in advertising or otherwise to promote the sale,
-use or other dealings in this Software without prior written
-authorization from the copyright holders.
-\****************************************************************************/
-/* XeTeX_ext.c
- * additional plain C extensions for XeTeX - mostly platform-neutral
- */
-/* for fabs() */
-/* OT-related constants we need */
-static mut brkIter: *mut icu::UBreakIterator =
-    0 as *const icu::UBreakIterator as *mut icu::UBreakIterator;
-static mut brkLocaleStrNum: i32 = 0i32;
-/* info for each glyph is location (FixedPoint) + glyph ID (u16) */
-/* glyph ID field in a glyph_node */
-/* For Unicode encoding form interpretation... */
+#[inline]
+unsafe extern "C" fn print_c_string(mut str: *const libc::c_char) {
+    while *str != 0 {
+        let fresh0 = str;
+        str = str.offset(1);
+        print_char(*fresh0 as int32_t);
+    }
+}
+static mut brkIter: *mut UBreakIterator = 0 as *const UBreakIterator as *mut UBreakIterator;
+static mut brkLocaleStrNum: libc::c_int = 0i32;
 #[no_mangle]
 pub unsafe extern "C" fn linebreak_start(
-    mut f: i32,
-    mut localeStrNum: i32,
-    mut text: *mut u16,
-    mut textLength: i32,
+    mut f: libc::c_int,
+    mut localeStrNum: int32_t,
+    mut text: *mut uint16_t,
+    mut textLength: int32_t,
 ) {
-    let mut status: icu::UErrorCode = icu::U_ZERO_ERROR;
-    let mut locale: *mut i8 = gettexstring(localeStrNum);
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32
-        && streq_ptr(locale, b"G\x00" as *const u8 as *const i8) as i32 != 0
+    let mut status: UErrorCode = U_ZERO_ERROR;
+    let mut locale: *mut libc::c_char = gettexstring(localeStrNum);
+    if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32
+        && streq_ptr(locale, b"G\x00" as *const u8 as *const libc::c_char) as libc::c_int != 0
     {
         let mut engine: XeTeXLayoutEngine =
             *font_layout_engine.offset(f as isize) as XeTeXLayoutEngine;
@@ -631,36 +2252,33 @@ pub unsafe extern "C" fn linebreak_start(
         }
     }
     if localeStrNum != brkLocaleStrNum && !brkIter.is_null() {
-        icu::ubrk_close(brkIter);
-        brkIter = 0 as *mut icu::UBreakIterator
+        ubrk_close_64(brkIter);
+        brkIter = 0 as *mut UBreakIterator
     }
     if brkIter.is_null() {
-        brkIter = icu::ubrk_open(
-            icu::UBRK_LINE,
-            locale,
-            0 as *const icu::UChar,
-            0i32,
-            &mut status,
-        );
-        if status as i32 > icu::U_ZERO_ERROR as i32 {
+        brkIter = ubrk_open_64(UBRK_LINE, locale, 0 as *const UChar, 0i32, &mut status);
+        if status as libc::c_int > U_ZERO_ERROR as libc::c_int {
             begin_diagnostic();
             print_nl('E' as i32);
-            print_c_string(b"rror \x00" as *const u8 as *const i8);
-            print_int(status as i32);
+            print_c_string(b"rror \x00" as *const u8 as *const libc::c_char);
+            print_int(status as int32_t);
             print_c_string(
-                b" creating linebreak iterator for locale `\x00" as *const u8 as *const i8,
+                b" creating linebreak iterator for locale `\x00" as *const u8
+                    as *const libc::c_char,
             );
             print_c_string(locale);
-            print_c_string(b"\'; trying default locale `en_us\'.\x00" as *const u8 as *const i8);
+            print_c_string(
+                b"\'; trying default locale `en_us\'.\x00" as *const u8 as *const libc::c_char,
+            );
             end_diagnostic(1i32 != 0);
             if !brkIter.is_null() {
-                icu::ubrk_close(brkIter);
+                ubrk_close_64(brkIter);
             }
-            status = icu::U_ZERO_ERROR;
-            brkIter = icu::ubrk_open(
-                icu::UBRK_LINE,
-                b"en_us\x00" as *const u8 as *const i8,
-                0 as *const icu::UChar,
+            status = U_ZERO_ERROR;
+            brkIter = ubrk_open_64(
+                UBRK_LINE,
+                b"en_us\x00" as *const u8 as *const libc::c_char,
+                0 as *const UChar,
                 0i32,
                 &mut status,
             )
@@ -670,66 +2288,91 @@ pub unsafe extern "C" fn linebreak_start(
     }
     if brkIter.is_null() {
         _tt_abort(
-            b"failed to create linebreak iterator, status=%d\x00" as *const u8 as *const i8,
-            status as i32,
+            b"failed to create linebreak iterator, status=%d\x00" as *const u8
+                as *const libc::c_char,
+            status as libc::c_int,
         );
     }
-    icu::ubrk_setText(brkIter, text as *mut icu::UChar, textLength, &mut status);
+    ubrk_setText_64(brkIter, text as *mut UChar, textLength, &mut status);
 }
 #[no_mangle]
-pub unsafe extern "C" fn linebreak_next() -> i32 {
+pub unsafe extern "C" fn linebreak_next() -> libc::c_int {
     if !brkIter.is_null() {
-        icu::ubrk_next(brkIter)
+        return ubrk_next_64(brkIter);
     } else {
-        findNextGraphiteBreak()
-    }
+        return findNextGraphiteBreak();
+    };
 }
 #[no_mangle]
-pub unsafe extern "C" fn get_encoding_mode_and_info(mut info: *mut i32) -> i32 {
+pub unsafe extern "C" fn get_encoding_mode_and_info(mut info: *mut int32_t) -> libc::c_int {
     /* \XeTeXinputencoding "enc-name"
      *   -> name is packed in |nameoffile| as a C string, starting at [1]
      * Check if it's a built-in name; if not, try to open an ICU converter by that name
      */
-    let mut err: icu::UErrorCode = icu::U_ZERO_ERROR;
-    let mut cnv: *mut icu::UConverter = 0 as *mut icu::UConverter;
+    let mut err: UErrorCode = U_ZERO_ERROR;
+    let mut cnv: *mut UConverter = 0 as *mut UConverter;
     *info = 0i32;
-    if strcasecmp(name_of_file, b"auto\x00" as *const u8 as *const i8) == 0i32 {
+    if strcasecmp(
+        name_of_file,
+        b"auto\x00" as *const u8 as *const libc::c_char,
+    ) == 0i32
+    {
         return 0i32;
     }
-    if strcasecmp(name_of_file, b"utf8\x00" as *const u8 as *const i8) == 0i32 {
+    if strcasecmp(
+        name_of_file,
+        b"utf8\x00" as *const u8 as *const libc::c_char,
+    ) == 0i32
+    {
         return 1i32;
     }
-    if strcasecmp(name_of_file, b"utf16\x00" as *const u8 as *const i8) == 0i32 {
+    if strcasecmp(
+        name_of_file,
+        b"utf16\x00" as *const u8 as *const libc::c_char,
+    ) == 0i32
+    {
         /* depends on host platform */
         return 3i32;
     }
-    if strcasecmp(name_of_file, b"utf16be\x00" as *const u8 as *const i8) == 0i32 {
+    if strcasecmp(
+        name_of_file,
+        b"utf16be\x00" as *const u8 as *const libc::c_char,
+    ) == 0i32
+    {
         return 2i32;
     }
-    if strcasecmp(name_of_file, b"utf16le\x00" as *const u8 as *const i8) == 0i32 {
+    if strcasecmp(
+        name_of_file,
+        b"utf16le\x00" as *const u8 as *const libc::c_char,
+    ) == 0i32
+    {
         return 3i32;
     }
-    if strcasecmp(name_of_file, b"bytes\x00" as *const u8 as *const i8) == 0i32 {
+    if strcasecmp(
+        name_of_file,
+        b"bytes\x00" as *const u8 as *const libc::c_char,
+    ) == 0i32
+    {
         return 4i32;
     }
     /* try for an ICU converter */
-    cnv = icu::ucnv_open(name_of_file, &mut err); /* ensure message starts on a new line */
+    cnv = ucnv_open_64(name_of_file, &mut err); /* ensure message starts on a new line */
     if cnv.is_null() {
         begin_diagnostic();
         print_nl('U' as i32);
-        print_c_string(b"nknown encoding `\x00" as *const u8 as *const i8);
+        print_c_string(b"nknown encoding `\x00" as *const u8 as *const libc::c_char);
         print_c_string(name_of_file);
-        print_c_string(b"\'; reading as raw bytes\x00" as *const u8 as *const i8);
+        print_c_string(b"\'; reading as raw bytes\x00" as *const u8 as *const libc::c_char);
         end_diagnostic(1i32 != 0);
-        4i32
+        return 4i32;
     } else {
-        icu::ucnv_close(cnv);
+        ucnv_close_64(cnv);
         *info = maketexstring(name_of_file);
-        5i32
-    }
+        return 5i32;
+    };
 }
 #[no_mangle]
-pub unsafe extern "C" fn print_utf8_str(mut str: *const u8, mut len: i32) {
+pub unsafe extern "C" fn print_utf8_str(mut str: *const libc::c_uchar, mut len: libc::c_int) {
     loop {
         let fresh1 = len;
         len = len - 1;
@@ -738,12 +2381,12 @@ pub unsafe extern "C" fn print_utf8_str(mut str: *const u8, mut len: i32) {
         }
         let fresh2 = str;
         str = str.offset(1);
-        print_raw_char(*fresh2 as UTF16_code, true);
+        print_raw_char(*fresh2 as UTF16_code, 1i32 != 0);
     }
     /* bypass utf-8 encoding done in print_char() */
 }
 #[no_mangle]
-pub unsafe extern "C" fn print_chars(mut str: *const u16, mut len: i32) {
+pub unsafe extern "C" fn print_chars(mut str: *const libc::c_ushort, mut len: libc::c_int) {
     loop {
         let fresh3 = len;
         len = len - 1;
@@ -752,34 +2395,39 @@ pub unsafe extern "C" fn print_chars(mut str: *const u16, mut len: i32) {
         }
         let fresh4 = str;
         str = str.offset(1);
-        print_char(*fresh4 as i32);
+        print_char(*fresh4 as int32_t);
     }
 }
 unsafe extern "C" fn load_mapping_file(
-    mut s: *const i8,
-    mut e: *const i8,
-    mut byteMapping: i8,
+    mut s: *const libc::c_char,
+    mut e: *const libc::c_char,
+    mut byteMapping: libc::c_char,
 ) -> *mut libc::c_void {
     let mut cnv: TECkit_Converter = 0 as TECkit_Converter;
-    let mut buffer: *mut i8 =
-        xmalloc((e.wrapping_offset_from(s) as i64 + 5i32 as i64) as size_t) as *mut i8;
+    let mut buffer: *mut libc::c_char =
+        xmalloc((e.wrapping_offset_from(s) as libc::c_long + 5i32 as libc::c_long) as size_t)
+            as *mut libc::c_char;
     let mut map: rust_input_handle_t = 0 as *mut libc::c_void;
-    strncpy(buffer, s, e.wrapping_offset_from(s) as i64 as u64);
-    *buffer.offset(e.wrapping_offset_from(s) as i64 as isize) = 0_i8;
-    strcat(buffer, b".tec\x00" as *const u8 as *const i8);
-    map = ttstub_input_open(buffer, TTInputFormat::MISCFONTS, 0i32);
+    strncpy(
+        buffer,
+        s,
+        e.wrapping_offset_from(s) as libc::c_long as libc::c_ulong,
+    );
+    *buffer.offset(e.wrapping_offset_from(s) as libc::c_long as isize) = 0i32 as libc::c_char;
+    strcat(buffer, b".tec\x00" as *const u8 as *const libc::c_char);
+    map = ttstub_input_open(buffer, TTIF_MISCFONTS, 0i32);
     if !map.is_null() {
         let mut mappingSize: size_t = ttstub_input_get_size(map);
         let mut mapping: *mut Byte = xmalloc(mappingSize) as *mut Byte;
-        let mut r: ssize_t = ttstub_input_read(map, mapping as *mut i8, mappingSize);
-        if r < 0i32 as i64 || r as size_t != mappingSize {
+        let mut r: ssize_t = ttstub_input_read(map, mapping as *mut libc::c_char, mappingSize);
+        if r < 0i32 as libc::c_long || r as size_t != mappingSize {
             _tt_abort(
-                b"could not read mapping file \"%s\"\x00" as *const u8 as *const i8,
+                b"could not read mapping file \"%s\"\x00" as *const u8 as *const libc::c_char,
                 buffer,
             );
         }
         ttstub_input_close(map);
-        if byteMapping as i32 != 0i32 {
+        if byteMapping as libc::c_int != 0i32 {
             TECkit_CreateConverter(
                 mapping,
                 mappingSize as UInt32,
@@ -800,27 +2448,41 @@ unsafe extern "C" fn load_mapping_file(
         }
         if cnv.is_null() {
             /* tracing */
-            font_mapping_warning(buffer as *const libc::c_void, strlen(buffer) as i32, 2i32);
-        /* not loadable */
+            font_mapping_warning(
+                buffer as *const libc::c_void,
+                strlen(buffer) as int32_t,
+                2i32,
+            ); /* not loadable */
         } else if get_tracing_fonts_state() > 1i32 {
-            font_mapping_warning(buffer as *const libc::c_void, strlen(buffer) as i32, 0i32);
+            font_mapping_warning(
+                buffer as *const libc::c_void,
+                strlen(buffer) as int32_t,
+                0i32,
+            );
         }
     } else {
-        font_mapping_warning(buffer as *const libc::c_void, strlen(buffer) as i32, 1i32);
+        font_mapping_warning(
+            buffer as *const libc::c_void,
+            strlen(buffer) as int32_t,
+            1i32,
+        );
         /* not found */
     }
     free(buffer as *mut libc::c_void);
-    cnv as *mut libc::c_void
+    return cnv as *mut libc::c_void;
 }
-static mut saved_mapping_name: *mut i8 = 0 as *const i8 as *mut i8;
+static mut saved_mapping_name: *mut libc::c_char = 0 as *const libc::c_char as *mut libc::c_char;
 #[no_mangle]
 pub unsafe extern "C" fn check_for_tfm_font_mapping() {
-    let mut cp: *mut i8 = strstr(name_of_file, b":mapping=\x00" as *const u8 as *const i8);
-    saved_mapping_name = mfree(saved_mapping_name as *mut libc::c_void) as *mut i8;
+    let mut cp: *mut libc::c_char = strstr(
+        name_of_file,
+        b":mapping=\x00" as *const u8 as *const libc::c_char,
+    );
+    saved_mapping_name = mfree(saved_mapping_name as *mut libc::c_void) as *mut libc::c_char;
     if !cp.is_null() {
-        *cp = 0_i8;
+        *cp = 0i32 as libc::c_char;
         cp = cp.offset(9);
-        while *cp as i32 != 0 && *cp as i32 <= ' ' as i32 {
+        while *cp as libc::c_int != 0 && *cp as libc::c_int <= ' ' as i32 {
             cp = cp.offset(1)
         }
         if *cp != 0 {
@@ -835,14 +2497,17 @@ pub unsafe extern "C" fn load_tfm_font_mapping() -> *mut libc::c_void {
         rval = load_mapping_file(
             saved_mapping_name,
             saved_mapping_name.offset(strlen(saved_mapping_name) as isize),
-            1_i8,
+            1i32 as libc::c_char,
         );
-        saved_mapping_name = mfree(saved_mapping_name as *mut libc::c_void) as *mut i8
+        saved_mapping_name = mfree(saved_mapping_name as *mut libc::c_void) as *mut libc::c_char
     }
-    rval
+    return rval;
 }
 #[no_mangle]
-pub unsafe extern "C" fn apply_tfm_font_mapping(mut cnv: *mut libc::c_void, mut c: i32) -> i32 {
+pub unsafe extern "C" fn apply_tfm_font_mapping(
+    mut cnv: *mut libc::c_void,
+    mut c: libc::c_int,
+) -> libc::c_int {
     let mut in_0: UniChar = c as UniChar;
     let mut out: [Byte; 2] = [0; 2];
     let mut inUsed: UInt32 = 0;
@@ -852,107 +2517,109 @@ pub unsafe extern "C" fn apply_tfm_font_mapping(mut cnv: *mut libc::c_void, mut 
     TECkit_ConvertBuffer(
         cnv as TECkit_Converter,
         &mut in_0 as *mut UniChar as *const Byte,
-        ::std::mem::size_of::<UniChar>() as u64 as UInt32,
+        ::std::mem::size_of::<UniChar>() as libc::c_ulong as UInt32,
         &mut inUsed,
         out.as_mut_ptr(),
-        ::std::mem::size_of::<[Byte; 2]>() as u64 as UInt32,
+        ::std::mem::size_of::<[Byte; 2]>() as libc::c_ulong as UInt32,
         &mut outUsed,
         1i32 as Byte,
     );
-    if outUsed < 1_u32 {
-        0i32
+    if outUsed < 1i32 as libc::c_uint {
+        return 0i32;
     } else {
-        out[0] as i32
-    }
+        return out[0] as libc::c_int;
+    };
 }
 #[no_mangle]
-pub unsafe extern "C" fn read_double(mut s: *mut *const i8) -> f64 {
-    let mut neg: i32 = 0i32;
-    let mut val: f64 = 0.0f64;
-    let mut cp: *const i8 = *s;
-    while *cp as i32 == ' ' as i32 || *cp as i32 == '\t' as i32 {
+pub unsafe extern "C" fn read_double(mut s: *mut *const libc::c_char) -> libc::c_double {
+    let mut neg: libc::c_int = 0i32;
+    let mut val: libc::c_double = 0.0f64;
+    let mut cp: *const libc::c_char = *s;
+    while *cp as libc::c_int == ' ' as i32 || *cp as libc::c_int == '\t' as i32 {
         cp = cp.offset(1)
     }
-    if *cp as i32 == '-' as i32 {
+    if *cp as libc::c_int == '-' as i32 {
         neg = 1i32;
         cp = cp.offset(1)
-    } else if *cp as i32 == '+' as i32 {
+    } else if *cp as libc::c_int == '+' as i32 {
         cp = cp.offset(1)
     }
-    while *cp as i32 >= '0' as i32 && *cp as i32 <= '9' as i32 {
-        val = val * 10.0f64 + *cp as i32 as f64 - '0' as i32 as f64;
+    while *cp as libc::c_int >= '0' as i32 && *cp as libc::c_int <= '9' as i32 {
+        val = val * 10.0f64 + *cp as libc::c_int as libc::c_double - '0' as i32 as libc::c_double;
         cp = cp.offset(1)
     }
-    if *cp as i32 == '.' as i32 {
-        let mut dec: f64 = 10.0f64;
+    if *cp as libc::c_int == '.' as i32 {
+        let mut dec: libc::c_double = 10.0f64;
         cp = cp.offset(1);
-        while *cp as i32 >= '0' as i32 && *cp as i32 <= '9' as i32 {
-            val = val + (*cp as i32 - '0' as i32) as f64 / dec;
+        while *cp as libc::c_int >= '0' as i32 && *cp as libc::c_int <= '9' as i32 {
+            val = val + (*cp as libc::c_int - '0' as i32) as libc::c_double / dec;
             cp = cp.offset(1);
             dec = dec * 10.0f64
         }
     }
     *s = cp;
-    if neg != 0 {
-        -val
-    } else {
-        val
-    }
+    return if neg != 0 { -val } else { val };
 }
-unsafe extern "C" fn read_tag_with_param(mut cp: *const i8, mut param: *mut i32) -> hb_tag_t {
-    let mut cp2: *const i8 = 0 as *const i8;
+unsafe extern "C" fn read_tag_with_param(
+    mut cp: *const libc::c_char,
+    mut param: *mut libc::c_int,
+) -> hb_tag_t {
+    let mut cp2: *const libc::c_char = 0 as *const libc::c_char;
     let mut tag: hb_tag_t = 0;
     cp2 = cp;
-    while *cp2 as i32 != 0
-        && *cp2 as i32 != ':' as i32
-        && *cp2 as i32 != ';' as i32
-        && *cp2 as i32 != ',' as i32
-        && *cp2 as i32 != '=' as i32
+    while *cp2 as libc::c_int != 0
+        && *cp2 as libc::c_int != ':' as i32
+        && *cp2 as libc::c_int != ';' as i32
+        && *cp2 as libc::c_int != ',' as i32
+        && *cp2 as libc::c_int != '=' as i32
     {
         cp2 = cp2.offset(1)
     }
-    tag = hb_tag_from_string(cp, cp2.wrapping_offset_from(cp) as i64 as i32);
+    tag = hb_tag_from_string(
+        cp,
+        cp2.wrapping_offset_from(cp) as libc::c_long as libc::c_int,
+    );
     cp = cp2;
-    if *cp as i32 == '=' as i32 {
-        let mut neg: i32 = 0i32;
+    if *cp as libc::c_int == '=' as i32 {
+        let mut neg: libc::c_int = 0i32;
         cp = cp.offset(1);
-        if *cp as i32 == '-' as i32 {
+        if *cp as libc::c_int == '-' as i32 {
             neg += 1;
             cp = cp.offset(1)
         }
-        while *cp as i32 >= '0' as i32 && *cp as i32 <= '9' as i32 {
-            *param = *param * 10i32 + *cp as i32 - '0' as i32;
+        while *cp as libc::c_int >= '0' as i32 && *cp as libc::c_int <= '9' as i32 {
+            *param = *param * 10i32 + *cp as libc::c_int - '0' as i32;
             cp = cp.offset(1)
         }
         if neg != 0 {
             *param = -*param
         }
     }
-    tag
+    return tag;
 }
 #[no_mangle]
-pub unsafe extern "C" fn read_rgb_a(mut cp: *mut *const i8) -> u32 {
-    let mut rgbValue: u32 = 0_u32;
-    let mut alpha: u32 = 0_u32;
-    let mut i: i32 = 0;
+pub unsafe extern "C" fn read_rgb_a(mut cp: *mut *const libc::c_char) -> libc::c_uint {
+    let mut rgbValue: uint32_t = 0i32 as uint32_t;
+    let mut alpha: uint32_t = 0i32 as uint32_t;
+    let mut i: libc::c_int = 0;
     i = 0i32;
     while i < 6i32 {
-        if **cp as i32 >= '0' as i32 && **cp as i32 <= '9' as i32 {
+        if **cp as libc::c_int >= '0' as i32 && **cp as libc::c_int <= '9' as i32 {
             rgbValue = (rgbValue << 4i32)
-                .wrapping_add(**cp as u32)
-                .wrapping_sub('0' as i32 as u32)
-        } else if **cp as i32 >= 'A' as i32 && **cp as i32 <= 'F' as i32 {
+                .wrapping_add(**cp as libc::c_uint)
+                .wrapping_sub('0' as i32 as libc::c_uint)
+        } else if **cp as libc::c_int >= 'A' as i32 && **cp as libc::c_int <= 'F' as i32 {
             rgbValue = (rgbValue << 4i32)
-                .wrapping_add(**cp as u32)
-                .wrapping_sub('A' as i32 as u32)
-                .wrapping_add(10_u32)
-        } else if **cp as i32 >= 'a' as i32 && **cp as i32 <= 'f' as i32 {
+                .wrapping_add(**cp as libc::c_uint)
+                .wrapping_sub('A' as i32 as libc::c_uint)
+                .wrapping_add(10i32 as libc::c_uint)
+        } else if **cp as libc::c_int >= 'a' as i32 && **cp as libc::c_int <= 'f' as i32 {
             rgbValue = (rgbValue << 4i32)
-                .wrapping_add(**cp as u32)
-                .wrapping_sub('a' as i32 as u32)
-                .wrapping_add(10_u32)
+                .wrapping_add(**cp as libc::c_uint)
+                .wrapping_sub('a' as i32 as libc::c_uint)
+                .wrapping_add(10i32 as libc::c_uint)
         } else {
-            return 0xff_u32;
+            return 0xffi32 as libc::c_uint;
         }
         *cp = (*cp).offset(1);
         i += 1
@@ -960,199 +2627,202 @@ pub unsafe extern "C" fn read_rgb_a(mut cp: *mut *const i8) -> u32 {
     rgbValue <<= 8i32;
     i = 0i32;
     while i < 2i32 {
-        if **cp as i32 >= '0' as i32 && **cp as i32 <= '9' as i32 {
+        if **cp as libc::c_int >= '0' as i32 && **cp as libc::c_int <= '9' as i32 {
             alpha = (alpha << 4i32)
-                .wrapping_add(**cp as u32)
-                .wrapping_sub('0' as i32 as u32)
-        } else if **cp as i32 >= 'A' as i32 && **cp as i32 <= 'F' as i32 {
+                .wrapping_add(**cp as libc::c_uint)
+                .wrapping_sub('0' as i32 as libc::c_uint)
+        } else if **cp as libc::c_int >= 'A' as i32 && **cp as libc::c_int <= 'F' as i32 {
             alpha = (alpha << 4i32)
-                .wrapping_add(**cp as u32)
-                .wrapping_sub('A' as i32 as u32)
-                .wrapping_add(10_u32)
+                .wrapping_add(**cp as libc::c_uint)
+                .wrapping_sub('A' as i32 as libc::c_uint)
+                .wrapping_add(10i32 as libc::c_uint)
         } else {
-            if !(**cp as i32 >= 'a' as i32 && **cp as i32 <= 'f' as i32) {
+            if !(**cp as libc::c_int >= 'a' as i32 && **cp as libc::c_int <= 'f' as i32) {
                 break;
             }
             alpha = (alpha << 4i32)
-                .wrapping_add(**cp as u32)
-                .wrapping_sub('a' as i32 as u32)
-                .wrapping_add(10_u32)
+                .wrapping_add(**cp as libc::c_uint)
+                .wrapping_sub('a' as i32 as libc::c_uint)
+                .wrapping_add(10i32 as libc::c_uint)
         }
         *cp = (*cp).offset(1);
         i += 1
     }
     if i == 2i32 {
-        rgbValue = (rgbValue as u32).wrapping_add(alpha) as u32
+        rgbValue = (rgbValue as libc::c_uint).wrapping_add(alpha) as uint32_t as uint32_t
     } else {
-        rgbValue = (rgbValue as u32).wrapping_add(0xff_u32) as u32
+        rgbValue =
+            (rgbValue as libc::c_uint).wrapping_add(0xffi32 as libc::c_uint) as uint32_t as uint32_t
     }
-    rgbValue
+    return rgbValue;
 }
 #[no_mangle]
 pub unsafe extern "C" fn readCommonFeatures(
-    mut feat: *const i8,
-    mut end: *const i8,
-    mut extend: *mut f32,
-    mut slant: *mut f32,
-    mut embolden: *mut f32,
-    mut letterspace: *mut f32,
-    mut rgbValue: *mut u32,
-) -> i32
+    mut feat: *const libc::c_char,
+    mut end: *const libc::c_char,
+    mut extend: *mut libc::c_float,
+    mut slant: *mut libc::c_float,
+    mut embolden: *mut libc::c_float,
+    mut letterspace: *mut libc::c_float,
+    mut rgbValue: *mut uint32_t,
+) -> libc::c_int
 // returns 1 to go to next_option, -1 for bad_option, 0 to continue
 {
-    let mut sep: *const i8 = 0 as *const i8;
-    sep = strstartswith(feat, b"mapping\x00" as *const u8 as *const i8);
+    let mut sep: *const libc::c_char = 0 as *const libc::c_char;
+    sep = strstartswith(feat, b"mapping\x00" as *const u8 as *const libc::c_char);
     if !sep.is_null() {
-        if *sep as i32 != '=' as i32 {
+        if *sep as libc::c_int != '=' as i32 {
             return -1i32;
         }
-        loaded_font_mapping = load_mapping_file(sep.offset(1), end, 0_i8);
+        loaded_font_mapping = load_mapping_file(sep.offset(1), end, 0i32 as libc::c_char);
         return 1i32;
     }
-    sep = strstartswith(feat, b"extend\x00" as *const u8 as *const i8);
+    sep = strstartswith(feat, b"extend\x00" as *const u8 as *const libc::c_char);
     if !sep.is_null() {
-        if *sep as i32 != '=' as i32 {
-            return -1i32;
-        }
-        sep = sep.offset(1);
-        *extend = read_double(&mut sep) as f32;
-        return 1i32;
-    }
-    sep = strstartswith(feat, b"slant\x00" as *const u8 as *const i8);
-    if !sep.is_null() {
-        if *sep as i32 != '=' as i32 {
+        if *sep as libc::c_int != '=' as i32 {
             return -1i32;
         }
         sep = sep.offset(1);
-        *slant = read_double(&mut sep) as f32;
+        *extend = read_double(&mut sep) as libc::c_float;
         return 1i32;
     }
-    sep = strstartswith(feat, b"embolden\x00" as *const u8 as *const i8);
+    sep = strstartswith(feat, b"slant\x00" as *const u8 as *const libc::c_char);
     if !sep.is_null() {
-        if *sep as i32 != '=' as i32 {
+        if *sep as libc::c_int != '=' as i32 {
             return -1i32;
         }
         sep = sep.offset(1);
-        *embolden = read_double(&mut sep) as f32;
+        *slant = read_double(&mut sep) as libc::c_float;
         return 1i32;
     }
-    sep = strstartswith(feat, b"letterspace\x00" as *const u8 as *const i8);
+    sep = strstartswith(feat, b"embolden\x00" as *const u8 as *const libc::c_char);
     if !sep.is_null() {
-        if *sep as i32 != '=' as i32 {
+        if *sep as libc::c_int != '=' as i32 {
             return -1i32;
         }
         sep = sep.offset(1);
-        *letterspace = read_double(&mut sep) as f32;
+        *embolden = read_double(&mut sep) as libc::c_float;
         return 1i32;
     }
-    sep = strstartswith(feat, b"color\x00" as *const u8 as *const i8);
+    sep = strstartswith(feat, b"letterspace\x00" as *const u8 as *const libc::c_char);
     if !sep.is_null() {
-        let mut s: *const i8 = 0 as *const i8;
-        if *sep as i32 != '=' as i32 {
+        if *sep as libc::c_int != '=' as i32 {
+            return -1i32;
+        }
+        sep = sep.offset(1);
+        *letterspace = read_double(&mut sep) as libc::c_float;
+        return 1i32;
+    }
+    sep = strstartswith(feat, b"color\x00" as *const u8 as *const libc::c_char);
+    if !sep.is_null() {
+        let mut s: *const libc::c_char = 0 as *const libc::c_char;
+        if *sep as libc::c_int != '=' as i32 {
             return -1i32;
         }
         sep = sep.offset(1);
         s = sep;
         *rgbValue = read_rgb_a(&mut sep);
         if sep == s.offset(6) || sep == s.offset(8) {
-            loaded_font_flags = (loaded_font_flags as i32 | 0x1i32) as i8
+            loaded_font_flags = (loaded_font_flags as libc::c_int | 0x1i32) as libc::c_char
         } else {
             return -1i32;
         }
         return 1i32;
     }
-    0i32
+    return 0i32;
 }
 unsafe extern "C" fn readFeatureNumber(
-    mut s: *const i8,
-    mut e: *const i8,
+    mut s: *const libc::c_char,
+    mut e: *const libc::c_char,
     mut f: *mut hb_tag_t,
-    mut v: *mut i32,
+    mut v: *mut libc::c_int,
 ) -> bool
 /* s...e is a "id=setting" string; */ {
     *f = 0i32 as hb_tag_t;
     *v = 0i32;
-    if (*s as i32) < '0' as i32 || *s as i32 > '9' as i32 {
-        return false;
+    if (*s as libc::c_int) < '0' as i32 || *s as libc::c_int > '9' as i32 {
+        return 0i32 != 0;
     }
-    while *s as i32 >= '0' as i32 && *s as i32 <= '9' as i32 {
+    while *s as libc::c_int >= '0' as i32 && *s as libc::c_int <= '9' as i32 {
         let fresh5 = s;
         s = s.offset(1);
         *f = (*f)
-            .wrapping_mul(10_u32)
-            .wrapping_add(*fresh5 as u32)
-            .wrapping_sub('0' as i32 as u32)
+            .wrapping_mul(10i32 as libc::c_uint)
+            .wrapping_add(*fresh5 as libc::c_uint)
+            .wrapping_sub('0' as i32 as libc::c_uint)
     }
-    while *s as i32 == ' ' as i32 || *s as i32 == '\t' as i32 {
+    while *s as libc::c_int == ' ' as i32 || *s as libc::c_int == '\t' as i32 {
         s = s.offset(1)
     }
     let fresh6 = s;
     s = s.offset(1);
-    if *fresh6 as i32 != '=' as i32 {
+    if *fresh6 as libc::c_int != '=' as i32 {
         /* no setting was specified */
-        return false;
+        return 0i32 != 0;
     } /* NULL-terminated array */
-    if (*s as i32) < '0' as i32 || *s as i32 > '9' as i32 {
-        return false;
+    if (*s as libc::c_int) < '0' as i32 || *s as libc::c_int > '9' as i32 {
+        return 0i32 != 0;
     }
-    while *s as i32 >= '0' as i32 && *s as i32 <= '9' as i32 {
+    while *s as libc::c_int >= '0' as i32 && *s as libc::c_int <= '9' as i32 {
         let fresh7 = s;
         s = s.offset(1);
-        *v = *v * 10i32 + *fresh7 as i32 - '0' as i32
+        *v = *v * 10i32 + *fresh7 as libc::c_int - '0' as i32
     }
-    while *s as i32 == ' ' as i32 || *s as i32 == '\t' as i32 {
+    while *s as libc::c_int == ' ' as i32 || *s as libc::c_int == '\t' as i32 {
         s = s.offset(1)
     }
     if s != e {
-        return false;
+        return 0i32 != 0;
     }
-    true
+    return 1i32 != 0;
 }
 unsafe extern "C" fn loadOTfont(
     mut fontRef: PlatformFontRef,
     mut font: XeTeXFont,
     mut scaled_size: Fixed,
-    mut cp1: *mut i8,
+    mut cp1: *mut libc::c_char,
 ) -> *mut libc::c_void {
     let mut current_block: u64;
     let mut engine: XeTeXLayoutEngine = 0 as XeTeXLayoutEngine;
-    let mut script: hb_tag_t = (0_u32 & 0xff_u32) << 24i32
-        | (0_u32 & 0xff_u32) << 16i32
-        | (0_u32 & 0xff_u32) << 8i32
-        | 0_u32 & 0xff_u32;
-    let mut language: *mut i8 = 0 as *mut i8;
+    let mut script: hb_tag_t = (0i32 as uint32_t & 0xffi32 as libc::c_uint) << 24i32
+        | (0i32 as uint32_t & 0xffi32 as libc::c_uint) << 16i32
+        | (0i32 as uint32_t & 0xffi32 as libc::c_uint) << 8i32
+        | 0i32 as uint32_t & 0xffi32 as libc::c_uint;
+    let mut language: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut features: *mut hb_feature_t = 0 as *mut hb_feature_t;
-    let mut shapers: *mut *mut i8 = 0 as *mut *mut i8;
-    let mut nFeatures: i32 = 0i32;
-    let mut nShapers: i32 = 0i32;
-    let mut cp2: *mut i8 = 0 as *mut i8;
-    let mut cp3: *const i8 = 0 as *const i8;
+    let mut shapers: *mut *mut libc::c_char = 0 as *mut *mut libc::c_char;
+    let mut nFeatures: libc::c_int = 0i32;
+    let mut nShapers: libc::c_int = 0i32;
+    let mut cp2: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut cp3: *const libc::c_char = 0 as *const libc::c_char;
     let mut tag: hb_tag_t = 0;
-    let mut rgbValue: u32 = 0xff_u32;
-    let mut extend: f32 = 1.0f64 as f32;
-    let mut slant: f32 = 0.0f64 as f32;
-    let mut embolden: f32 = 0.0f64 as f32;
-    let mut letterspace: f32 = 0.0f64 as f32;
-    let mut i: i32 = 0;
-    let mut reqEngine: i8 = getReqEngine();
-    if reqEngine as i32 == 'O' as i32 || reqEngine as i32 == 'G' as i32 {
+    let mut rgbValue: uint32_t = 0xffi32 as uint32_t;
+    let mut extend: libc::c_float = 1.0f64 as libc::c_float;
+    let mut slant: libc::c_float = 0.0f64 as libc::c_float;
+    let mut embolden: libc::c_float = 0.0f64 as libc::c_float;
+    let mut letterspace: libc::c_float = 0.0f64 as libc::c_float;
+    let mut i: libc::c_int = 0;
+    let mut reqEngine: libc::c_char = getReqEngine();
+    if reqEngine as libc::c_int == 'O' as i32 || reqEngine as libc::c_int == 'G' as i32 {
         shapers = xrealloc(
             shapers as *mut libc::c_void,
-            ((nShapers + 1i32) as u64).wrapping_mul(::std::mem::size_of::<*mut i8>() as u64),
-        ) as *mut *mut i8;
-        if reqEngine as i32 == 'O' as i32 {
-            static mut ot_const: [i8; 3] = [111, 116, 0];
+            ((nShapers + 1i32) as libc::c_ulong)
+                .wrapping_mul(::std::mem::size_of::<*mut libc::c_char>() as libc::c_ulong),
+        ) as *mut *mut libc::c_char;
+        if reqEngine as libc::c_int == 'O' as i32 {
+            static mut ot_const: [libc::c_char; 3] = [111, 116, 0];
             let ref mut fresh8 = *shapers.offset(nShapers as isize);
             *fresh8 = ot_const.as_mut_ptr()
-        } else if reqEngine as i32 == 'G' as i32 {
-            static mut graphite2_const: [i8; 10] = [103, 114, 97, 112, 104, 105, 116, 101, 50, 0];
+        } else if reqEngine as libc::c_int == 'G' as i32 {
+            static mut graphite2_const: [libc::c_char; 10] =
+                [103, 114, 97, 112, 104, 105, 116, 101, 50, 0];
             let ref mut fresh9 = *shapers.offset(nShapers as isize);
             *fresh9 = graphite2_const.as_mut_ptr()
         }
         nShapers += 1
     }
-    if reqEngine as i32 == 'G' as i32 {
-        let mut tmpShapers: [*mut i8; 1] = [*shapers.offset(0)];
+    if reqEngine as libc::c_int == 'G' as i32 {
+        let mut tmpShapers: [*mut libc::c_char; 1] = [*shapers.offset(0)];
         /* create a default engine so we can query the font for Graphite features;
          * because of font caching, it's cheap to discard this and create the real one later */
         engine = createLayoutEngine(
@@ -1175,72 +2845,80 @@ unsafe extern "C" fn loadOTfont(
     /* scan the feature string (if any) */
     if !cp1.is_null() {
         while *cp1 != 0 {
-            if *cp1 as i32 == ':' as i32 || *cp1 as i32 == ';' as i32 || *cp1 as i32 == ',' as i32 {
+            if *cp1 as libc::c_int == ':' as i32
+                || *cp1 as libc::c_int == ';' as i32
+                || *cp1 as libc::c_int == ',' as i32
+            {
                 cp1 = cp1.offset(1)
             }
-            while *cp1 as i32 == ' ' as i32 || *cp1 as i32 == '\t' as i32 {
+            while *cp1 as libc::c_int == ' ' as i32 || *cp1 as libc::c_int == '\t' as i32 {
                 /* skip leading whitespace */
                 cp1 = cp1.offset(1)
             }
-            if *cp1 as i32 == 0i32 {
+            if *cp1 as libc::c_int == 0i32 {
                 break;
             }
             cp2 = cp1;
-            while *cp2 as i32 != 0
-                && *cp2 as i32 != ':' as i32
-                && *cp2 as i32 != ';' as i32
-                && *cp2 as i32 != ',' as i32
+            while *cp2 as libc::c_int != 0
+                && *cp2 as libc::c_int != ':' as i32
+                && *cp2 as libc::c_int != ';' as i32
+                && *cp2 as libc::c_int != ',' as i32
             {
                 cp2 = cp2.offset(1)
             }
-            cp3 = strstartswith(cp1, b"script\x00" as *const u8 as *const i8);
+            cp3 = strstartswith(cp1, b"script\x00" as *const u8 as *const libc::c_char);
             if !cp3.is_null() {
-                if *cp3 as i32 != '=' as i32 {
-                    current_block = 10622493848381539643;
+                if *cp3 as libc::c_int != '=' as i32 {
+                    current_block = 8329762136643326403;
                 } else {
                     cp3 = cp3.offset(1);
-                    script = hb_tag_from_string(cp3, cp2.wrapping_offset_from(cp3) as i64 as i32);
-                    current_block = 13857423536159756434;
+                    script = hb_tag_from_string(
+                        cp3,
+                        cp2.wrapping_offset_from(cp3) as libc::c_long as libc::c_int,
+                    );
+                    current_block = 7725042370488302866;
                 }
             } else {
-                cp3 = strstartswith(cp1, b"language\x00" as *const u8 as *const i8);
+                cp3 = strstartswith(cp1, b"language\x00" as *const u8 as *const libc::c_char);
                 if !cp3.is_null() {
-                    if *cp3 as i32 != '=' as i32 {
-                        current_block = 10622493848381539643;
+                    if *cp3 as libc::c_int != '=' as i32 {
+                        current_block = 8329762136643326403;
                     } else {
                         cp3 = cp3.offset(1);
-                        language =
-                            xmalloc((cp2.wrapping_offset_from(cp3) as i64 + 1i32 as i64) as size_t)
-                                as *mut i8;
-                        *language.offset(cp2.wrapping_offset_from(cp3) as i64 as isize) =
-                            '\u{0}' as i32 as i8;
+                        language = xmalloc(
+                            (cp2.wrapping_offset_from(cp3) as libc::c_long + 1i32 as libc::c_long)
+                                as size_t,
+                        ) as *mut libc::c_char;
+                        *language.offset(cp2.wrapping_offset_from(cp3) as libc::c_long as isize) =
+                            '\u{0}' as i32 as libc::c_char;
                         memcpy(
                             language as *mut libc::c_void,
                             cp3 as *const libc::c_void,
-                            cp2.wrapping_offset_from(cp3) as i64 as u64,
+                            cp2.wrapping_offset_from(cp3) as libc::c_long as libc::c_ulong,
                         );
-                        current_block = 13857423536159756434;
+                        current_block = 7725042370488302866;
                     }
                 } else {
-                    cp3 = strstartswith(cp1, b"shaper\x00" as *const u8 as *const i8);
+                    cp3 = strstartswith(cp1, b"shaper\x00" as *const u8 as *const libc::c_char);
                     if !cp3.is_null() {
-                        if *cp3 as i32 != '=' as i32 {
-                            current_block = 10622493848381539643;
+                        if *cp3 as libc::c_int != '=' as i32 {
+                            current_block = 8329762136643326403;
                         } else {
                             cp3 = cp3.offset(1);
                             shapers = xrealloc(
                                 shapers as *mut libc::c_void,
-                                ((nShapers + 1i32) as u64)
-                                    .wrapping_mul(::std::mem::size_of::<*mut i8>() as u64),
-                            ) as *mut *mut i8;
+                                ((nShapers + 1i32) as libc::c_ulong).wrapping_mul(
+                                    ::std::mem::size_of::<*mut libc::c_char>() as libc::c_ulong,
+                                ),
+                            ) as *mut *mut libc::c_char;
                             /* some dumb systems have no strndup() */
                             let ref mut fresh10 = *shapers.offset(nShapers as isize);
                             *fresh10 = strdup(cp3);
                             *(*shapers.offset(nShapers as isize))
-                                .offset(cp2.wrapping_offset_from(cp3) as i64 as isize) =
-                                '\u{0}' as i32 as i8;
+                                .offset(cp2.wrapping_offset_from(cp3) as libc::c_long as isize) =
+                                '\u{0}' as i32 as libc::c_char;
                             nShapers += 1;
-                            current_block = 13857423536159756434;
+                            current_block = 7725042370488302866;
                         }
                     } else {
                         i = readCommonFeatures(
@@ -1253,30 +2931,34 @@ unsafe extern "C" fn loadOTfont(
                             &mut rgbValue,
                         );
                         if i == 1i32 {
-                            current_block = 13857423536159756434;
+                            current_block = 7725042370488302866;
                         } else if i == -1i32 {
-                            current_block = 10622493848381539643;
+                            current_block = 8329762136643326403;
                         } else {
-                            if reqEngine as i32 == 'G' as i32 {
-                                let mut value: i32 = 0i32;
-                                if readFeatureNumber(cp1, cp2, &mut tag, &mut value) as i32 != 0
+                            if reqEngine as libc::c_int == 'G' as i32 {
+                                let mut value: libc::c_int = 0i32;
+                                if readFeatureNumber(cp1, cp2, &mut tag, &mut value) as libc::c_int
+                                    != 0
                                     || findGraphiteFeature(engine, cp1, cp2, &mut tag, &mut value)
-                                        as i32
+                                        as libc::c_int
                                         != 0
                                 {
                                     features = xrealloc(
                                         features as *mut libc::c_void,
-                                        ((nFeatures + 1i32) as u64).wrapping_mul(
-                                            ::std::mem::size_of::<hb_feature_t>() as u64,
-                                        ),
+                                        ((nFeatures + 1i32) as libc::c_ulong)
+                                            .wrapping_mul(::std::mem::size_of::<hb_feature_t>()
+                                                as libc::c_ulong),
                                     )
                                         as *mut hb_feature_t;
                                     (*features.offset(nFeatures as isize)).tag = tag;
-                                    (*features.offset(nFeatures as isize)).value = value as u32;
-                                    (*features.offset(nFeatures as isize)).start = 0_u32;
-                                    (*features.offset(nFeatures as isize)).end = -1i32 as u32;
+                                    (*features.offset(nFeatures as isize)).value =
+                                        value as uint32_t;
+                                    (*features.offset(nFeatures as isize)).start =
+                                        0i32 as libc::c_uint;
+                                    (*features.offset(nFeatures as isize)).end =
+                                        -1i32 as libc::c_uint;
                                     nFeatures += 1;
-                                    current_block = 13857423536159756434;
+                                    current_block = 7725042370488302866;
                                 } else {
                                     current_block = 15669289850109000831;
                                 }
@@ -1284,79 +2966,89 @@ unsafe extern "C" fn loadOTfont(
                                 current_block = 15669289850109000831;
                             }
                             match current_block {
-                                13857423536159756434 => {}
+                                7725042370488302866 => {}
                                 _ => {
-                                    if *cp1 as i32 == '+' as i32 {
-                                        let mut param: i32 = 0i32;
+                                    if *cp1 as libc::c_int == '+' as i32 {
+                                        let mut param: libc::c_int = 0i32;
                                         tag = read_tag_with_param(cp1.offset(1), &mut param);
                                         features = xrealloc(
                                             features as *mut libc::c_void,
-                                            ((nFeatures + 1i32) as u64).wrapping_mul(
-                                                ::std::mem::size_of::<hb_feature_t>() as u64,
+                                            ((nFeatures + 1i32) as libc::c_ulong).wrapping_mul(
+                                                ::std::mem::size_of::<hb_feature_t>()
+                                                    as libc::c_ulong,
                                             ),
                                         )
                                             as *mut hb_feature_t;
                                         (*features.offset(nFeatures as isize)).tag = tag;
-                                        (*features.offset(nFeatures as isize)).start = 0_u32;
-                                        (*features.offset(nFeatures as isize)).end = -1i32 as u32;
+                                        (*features.offset(nFeatures as isize)).start =
+                                            0i32 as libc::c_uint;
+                                        (*features.offset(nFeatures as isize)).end =
+                                            -1i32 as libc::c_uint;
                                         // for backward compatibility with pre-0.9999 where feature
                                         // indices started from 0
                                         if param >= 0i32 {
                                             param += 1
                                         }
-                                        (*features.offset(nFeatures as isize)).value = param as u32;
+                                        (*features.offset(nFeatures as isize)).value =
+                                            param as uint32_t;
                                         nFeatures += 1;
-                                        current_block = 13857423536159756434;
-                                    } else if *cp1 as i32 == '-' as i32 {
+                                        current_block = 7725042370488302866;
+                                    } else if *cp1 as libc::c_int == '-' as i32 {
                                         cp1 = cp1.offset(1);
                                         tag = hb_tag_from_string(
                                             cp1,
-                                            cp2.wrapping_offset_from(cp1) as i64 as i32,
+                                            cp2.wrapping_offset_from(cp1) as libc::c_long
+                                                as libc::c_int,
                                         );
                                         features = xrealloc(
                                             features as *mut libc::c_void,
-                                            ((nFeatures + 1i32) as u64).wrapping_mul(
-                                                ::std::mem::size_of::<hb_feature_t>() as u64,
+                                            ((nFeatures + 1i32) as libc::c_ulong).wrapping_mul(
+                                                ::std::mem::size_of::<hb_feature_t>()
+                                                    as libc::c_ulong,
                                             ),
                                         )
                                             as *mut hb_feature_t;
                                         (*features.offset(nFeatures as isize)).tag = tag;
-                                        (*features.offset(nFeatures as isize)).start = 0_u32;
-                                        (*features.offset(nFeatures as isize)).end = -1i32 as u32;
-                                        (*features.offset(nFeatures as isize)).value = 0_u32;
+                                        (*features.offset(nFeatures as isize)).start =
+                                            0i32 as libc::c_uint;
+                                        (*features.offset(nFeatures as isize)).end =
+                                            -1i32 as libc::c_uint;
+                                        (*features.offset(nFeatures as isize)).value =
+                                            0i32 as uint32_t;
                                         nFeatures += 1;
-                                        current_block = 13857423536159756434;
+                                        current_block = 7725042370488302866;
                                     } else if !strstartswith(
                                         cp1,
-                                        b"vertical\x00" as *const u8 as *const i8,
+                                        b"vertical\x00" as *const u8 as *const libc::c_char,
                                     )
                                     .is_null()
                                     {
                                         cp3 = cp2;
-                                        if *cp3 as i32 == ';' as i32
-                                            || *cp3 as i32 == ':' as i32
-                                            || *cp3 as i32 == ',' as i32
+                                        if *cp3 as libc::c_int == ';' as i32
+                                            || *cp3 as libc::c_int == ':' as i32
+                                            || *cp3 as libc::c_int == ',' as i32
                                         {
                                             cp3 = cp3.offset(-1)
                                         }
-                                        while *cp3 as i32 == '\u{0}' as i32
-                                            || *cp3 as i32 == ' ' as i32
-                                            || *cp3 as i32 == '\t' as i32
+                                        while *cp3 as libc::c_int == '\u{0}' as i32
+                                            || *cp3 as libc::c_int == ' ' as i32
+                                            || *cp3 as libc::c_int == '\t' as i32
                                         {
                                             cp3 = cp3.offset(-1)
                                         }
                                         if *cp3 != 0 {
                                             cp3 = cp3.offset(1)
                                         }
-                                        if cp3 == cp1.offset(8) as *const i8 {
-                                            loaded_font_flags =
-                                                (loaded_font_flags as i32 | 0x2i32) as i8;
-                                            current_block = 13857423536159756434;
+                                        if cp3 == cp1.offset(8) as *const libc::c_char {
+                                            loaded_font_flags = (loaded_font_flags as libc::c_int
+                                                | 0x2i32)
+                                                as libc::c_char;
+                                            current_block = 7725042370488302866;
                                         } else {
-                                            current_block = 10622493848381539643;
+                                            current_block = 8329762136643326403;
                                         }
                                     } else {
-                                        current_block = 10622493848381539643;
+                                        current_block = 8329762136643326403;
                                     }
                                 }
                             }
@@ -1365,10 +3057,10 @@ unsafe extern "C" fn loadOTfont(
                 }
             }
             match current_block {
-                10622493848381539643 => {
+                8329762136643326403 => {
                     font_feature_warning(
                         cp1 as *mut libc::c_void,
-                        cp2.wrapping_offset_from(cp1) as i64 as i32,
+                        cp2.wrapping_offset_from(cp1) as libc::c_long as int32_t,
                         0 as *const libc::c_void,
                         0i32,
                     );
@@ -1382,21 +3074,23 @@ unsafe extern "C" fn loadOTfont(
     if !shapers.is_null() {
         shapers = xrealloc(
             shapers as *mut libc::c_void,
-            ((nShapers + 1i32) as u64).wrapping_mul(::std::mem::size_of::<*mut i8>() as u64),
-        ) as *mut *mut i8;
+            ((nShapers + 1i32) as libc::c_ulong)
+                .wrapping_mul(::std::mem::size_of::<*mut libc::c_char>() as libc::c_ulong),
+        ) as *mut *mut libc::c_char;
         let ref mut fresh11 = *shapers.offset(nShapers as isize);
-        *fresh11 = 0 as *mut i8
+        *fresh11 = 0 as *mut libc::c_char
     }
-    if embolden as f64 != 0.0f64 {
-        embolden = (embolden as f64 * Fix2D(scaled_size) / 100.0f64) as f32
+    if embolden as libc::c_double != 0.0f64 {
+        embolden = (embolden as libc::c_double * Fix2D(scaled_size) / 100.0f64) as libc::c_float
     }
-    if letterspace as f64 != 0.0f64 {
-        loaded_font_letter_space = (letterspace as f64 / 100.0f64 * scaled_size as f64) as scaled_t
+    if letterspace as libc::c_double != 0.0f64 {
+        loaded_font_letter_space =
+            (letterspace as libc::c_double / 100.0f64 * scaled_size as libc::c_double) as scaled_t
     }
-    if loaded_font_flags as i32 & 0x1i32 == 0i32 {
-        rgbValue = 0xff_u32
+    if loaded_font_flags as libc::c_int & 0x1i32 == 0i32 {
+        rgbValue = 0xffi32 as uint32_t
     }
-    if loaded_font_flags as i32 & 0x2i32 != 0i32 {
+    if loaded_font_flags as libc::c_int & 0x2i32 != 0i32 {
         setFontLayoutDir(font, 1i32);
     }
     engine = createLayoutEngine(
@@ -1408,37 +3102,47 @@ unsafe extern "C" fn loadOTfont(
         free(features as *mut libc::c_void);
         free(shapers as *mut libc::c_void);
     } else {
-        native_font_type_flag = 0xfffeu32 as i32
+        native_font_type_flag = 0xfffeu32 as int32_t
     }
-    engine as *mut libc::c_void
+    return engine as *mut libc::c_void;
+}
+#[inline(always)]
+unsafe extern "C" fn CFRangeMake(mut loc: CFIndex, mut len: CFIndex) -> CFRange {
+    let mut range: CFRange = CFRange {
+        location: 0,
+        length: 0,
+    };
+    range.location = loc;
+    range.length = len;
+    return range;
 }
 unsafe extern "C" fn splitFontName(
-    mut name: *mut i8,
-    mut var: *mut *mut i8,
-    mut feat: *mut *mut i8,
-    mut end: *mut *mut i8,
-    mut index: *mut i32,
+    mut name: *mut libc::c_char,
+    mut var: *mut *mut libc::c_char,
+    mut feat: *mut *mut libc::c_char,
+    mut end: *mut *mut libc::c_char,
+    mut index: *mut libc::c_int,
 ) {
-    *var = 0 as *mut i8;
-    *feat = 0 as *mut i8;
+    *var = 0 as *mut libc::c_char;
+    *feat = 0 as *mut libc::c_char;
     *index = 0i32;
-    if *name as i32 == '[' as i32 {
-        let mut withinFileName: i32 = 1i32;
+    if *name as libc::c_int == '[' as i32 {
+        let mut withinFileName: libc::c_int = 1i32;
         name = name.offset(1);
         while *name != 0 {
-            if withinFileName != 0 && *name as i32 == ']' as i32 {
+            if withinFileName != 0 && *name as libc::c_int == ']' as i32 {
                 withinFileName = 0i32;
                 if (*var).is_null() {
                     *var = name
                 }
-            } else if *name as i32 == ':' as i32 {
+            } else if *name as libc::c_int == ':' as i32 {
                 if withinFileName != 0 && (*var).is_null() {
                     *var = name;
                     name = name.offset(1);
-                    while *name as i32 >= '0' as i32 && *name as i32 <= '9' as i32 {
+                    while *name as libc::c_int >= '0' as i32 && *name as libc::c_int <= '9' as i32 {
                         let fresh12 = name;
                         name = name.offset(1);
-                        *index = *index * 10i32 + *fresh12 as i32 - '0' as i32
+                        *index = *index * 10i32 + *fresh12 as libc::c_int - '0' as i32
                     }
                     name = name.offset(-1)
                 } else if withinFileName == 0 && (*feat).is_null() {
@@ -1450,9 +3154,9 @@ unsafe extern "C" fn splitFontName(
         *end = name
     } else {
         while *name != 0 {
-            if *name as i32 == '/' as i32 && (*var).is_null() && (*feat).is_null() {
+            if *name as libc::c_int == '/' as i32 && (*var).is_null() && (*feat).is_null() {
                 *var = name
-            } else if *name as i32 == ':' as i32 && (*feat).is_null() {
+            } else if *name as libc::c_int == ':' as i32 && (*feat).is_null() {
                 *feat = name
             }
             name = name.offset(1)
@@ -1468,53 +3172,63 @@ unsafe extern "C" fn splitFontName(
 }
 #[no_mangle]
 pub unsafe extern "C" fn find_native_font(
-    mut uname: *mut i8,
-    mut scaled_size: i32,
+    mut uname: *mut libc::c_char,
+    mut scaled_size: int32_t,
 ) -> *mut libc::c_void
 /* scaled_size here is in TeX points, or is a negative integer for 'scaled_t' */ {
     let mut rval: *mut libc::c_void = 0 as *mut libc::c_void;
-    let mut nameString: *mut i8 = 0 as *mut i8;
-    let mut var: *mut i8 = 0 as *mut i8;
-    let mut feat: *mut i8 = 0 as *mut i8;
-    let mut end: *mut i8 = 0 as *mut i8;
-    let mut name: *mut i8 = uname;
-    let mut varString: *mut i8 = 0 as *mut i8;
-    let mut featString: *mut i8 = 0 as *mut i8;
-    let mut fontRef: PlatformFontRef = 0 as *mut FcPattern;
+    let mut nameString: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut var: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut feat: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut end: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut name: *mut libc::c_char = uname;
+    let mut varString: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut featString: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut fontRef: PlatformFontRef = 0 as *const __CTFontDescriptor;
     let mut font: XeTeXFont = 0 as XeTeXFont;
-    let mut index: i32 = 0i32;
+    let mut index: libc::c_int = 0i32;
     loaded_font_mapping = 0 as *mut libc::c_void;
-    loaded_font_flags = 0_i8;
+    loaded_font_flags = 0i32 as libc::c_char;
     loaded_font_letter_space = 0i32;
     splitFontName(name, &mut var, &mut feat, &mut end, &mut index);
     nameString =
-        xmalloc((var.wrapping_offset_from(name) as i64 + 1i32 as i64) as size_t) as *mut i8;
+        xmalloc((var.wrapping_offset_from(name) as libc::c_long + 1i32 as libc::c_long) as size_t)
+            as *mut libc::c_char;
     strncpy(
         nameString,
         name,
-        var.wrapping_offset_from(name) as i64 as u64,
+        var.wrapping_offset_from(name) as libc::c_long as libc::c_ulong,
     );
-    *nameString.offset(var.wrapping_offset_from(name) as i64 as isize) = 0_i8;
+    *nameString.offset(var.wrapping_offset_from(name) as libc::c_long as isize) =
+        0i32 as libc::c_char;
     if feat > var {
-        varString = xmalloc(feat.wrapping_offset_from(var) as i64 as size_t) as *mut i8;
+        varString =
+            xmalloc(feat.wrapping_offset_from(var) as libc::c_long as size_t) as *mut libc::c_char;
         strncpy(
             varString,
             var.offset(1),
-            (feat.wrapping_offset_from(var) as i64 - 1i32 as i64) as u64,
+            (feat.wrapping_offset_from(var) as libc::c_long - 1i32 as libc::c_long)
+                as libc::c_ulong,
         );
-        *varString.offset((feat.wrapping_offset_from(var) as i64 - 1i32 as i64) as isize) = 0_i8
+        *varString.offset(
+            (feat.wrapping_offset_from(var) as libc::c_long - 1i32 as libc::c_long) as isize,
+        ) = 0i32 as libc::c_char
     }
     if end > feat {
-        featString = xmalloc(end.wrapping_offset_from(feat) as i64 as size_t) as *mut i8;
+        featString =
+            xmalloc(end.wrapping_offset_from(feat) as libc::c_long as size_t) as *mut libc::c_char;
         strncpy(
             featString,
             feat.offset(1),
-            (end.wrapping_offset_from(feat) as i64 - 1i32 as i64) as u64,
+            (end.wrapping_offset_from(feat) as libc::c_long - 1i32 as libc::c_long)
+                as libc::c_ulong,
         );
-        *featString.offset((end.wrapping_offset_from(feat) as i64 - 1i32 as i64) as isize) = 0_i8
+        *featString.offset(
+            (end.wrapping_offset_from(feat) as libc::c_long - 1i32 as libc::c_long) as isize,
+        ) = 0i32 as libc::c_char
     }
     // check for "[filename]" form, don't search maps in this case
-    if *nameString.offset(0) as i32 == '[' as i32 {
+    if *nameString.offset(0) as libc::c_int == '[' as i32 {
         if scaled_size < 0i32 {
             font = createFontFromFile(nameString.offset(1), index, 655360i64 as Fixed);
             if !font.is_null() {
@@ -1531,17 +3245,22 @@ pub unsafe extern "C" fn find_native_font(
         if !font.is_null() {
             loaded_font_design_size = D2Fix(getDesignSize(font));
             /* This is duplicated in XeTeXFontMgr::findFont! */
-            setReqEngine(0_i8);
+            setReqEngine(0i32 as libc::c_char);
             if !varString.is_null() {
-                if !strstartswith(varString, b"/AAT\x00" as *const u8 as *const i8).is_null() {
-                    setReqEngine('A' as i32 as i8);
-                } else if !strstartswith(varString, b"/OT\x00" as *const u8 as *const i8).is_null()
-                    || !strstartswith(varString, b"/ICU\x00" as *const u8 as *const i8).is_null()
+                if !strstartswith(varString, b"/AAT\x00" as *const u8 as *const libc::c_char)
+                    .is_null()
                 {
-                    setReqEngine('O' as i32 as i8);
-                } else if !strstartswith(varString, b"/GR\x00" as *const u8 as *const i8).is_null()
+                    setReqEngine('A' as i32 as libc::c_char);
+                } else if !strstartswith(varString, b"/OT\x00" as *const u8 as *const libc::c_char)
+                    .is_null()
+                    || !strstartswith(varString, b"/ICU\x00" as *const u8 as *const libc::c_char)
+                        .is_null()
                 {
-                    setReqEngine('G' as i32 as i8);
+                    setReqEngine('O' as i32 as libc::c_char);
+                } else if !strstartswith(varString, b"/GR\x00" as *const u8 as *const libc::c_char)
+                    .is_null()
+                {
+                    setReqEngine('G' as i32 as libc::c_char);
                 }
             }
             rval = loadOTfont(0 as PlatformFontRef, font, scaled_size, featString);
@@ -1551,7 +3270,7 @@ pub unsafe extern "C" fn find_native_font(
             if !rval.is_null() && get_tracing_fonts_state() > 0i32 {
                 begin_diagnostic();
                 print_nl(' ' as i32);
-                print_c_string(b"-> \x00" as *const u8 as *const i8);
+                print_c_string(b"-> \x00" as *const u8 as *const libc::c_char);
                 print_c_string(nameString.offset(1));
                 end_diagnostic(0i32 != 0);
             }
@@ -1560,20 +3279,20 @@ pub unsafe extern "C" fn find_native_font(
         fontRef = findFontByName(nameString, varString, Fix2D(scaled_size));
         if !fontRef.is_null() {
             /* update name_of_file to the full name of the font, for error messages during font loading */
-            let mut fullName: *const i8 = getFullName(fontRef);
-            name_length = strlen(fullName) as i32;
+            let mut fullName: *const libc::c_char = getFullName(fontRef);
+            name_length = strlen(fullName) as int32_t;
             if !featString.is_null() {
-                name_length = (name_length as u64)
-                    .wrapping_add(strlen(featString).wrapping_add(1i32 as u64))
-                    as i32 as i32
+                name_length = (name_length as libc::c_ulong)
+                    .wrapping_add(strlen(featString).wrapping_add(1i32 as libc::c_ulong))
+                    as int32_t as int32_t
             }
             if !varString.is_null() {
-                name_length = (name_length as u64)
-                    .wrapping_add(strlen(varString).wrapping_add(1i32 as u64))
-                    as i32 as i32
+                name_length = (name_length as libc::c_ulong)
+                    .wrapping_add(strlen(varString).wrapping_add(1i32 as libc::c_ulong))
+                    as int32_t as int32_t
             }
             free(name_of_file as *mut libc::c_void);
-            name_of_file = xmalloc((name_length + 1i32) as size_t) as *mut i8;
+            name_of_file = xmalloc((name_length + 1i32) as size_t) as *mut libc::c_char;
             strcpy(name_of_file, fullName);
             if scaled_size < 0i32 {
                 font = createFont(fontRef, scaled_size);
@@ -1589,31 +3308,68 @@ pub unsafe extern "C" fn find_native_font(
             }
             font = createFont(fontRef, scaled_size);
             if !font.is_null() {
-                rval = loadOTfont(fontRef, font, scaled_size, featString);
-                if rval.is_null() {
-                    deleteFont(font);
+                /* decide whether to use AAT or OpenType rendering with this font */
+                if getReqEngine() as libc::c_int == 'A' as i32 {
+                    rval = loadAATfont(fontRef, scaled_size, featString);
+                    if rval.is_null() {
+                        deleteFont(font);
+                    }
+                } else {
+                    if getReqEngine() as libc::c_int == 'O' as i32
+                        || getReqEngine() as libc::c_int == 'G' as i32
+                        || !getFontTablePtr(
+                            font,
+                            ('G' as i32 as uint32_t & 0xffi32 as libc::c_uint) << 24i32
+                                | ('S' as i32 as uint32_t & 0xffi32 as libc::c_uint) << 16i32
+                                | ('U' as i32 as uint32_t & 0xffi32 as libc::c_uint) << 8i32
+                                | 'B' as i32 as uint32_t & 0xffi32 as libc::c_uint,
+                        )
+                        .is_null()
+                        || !getFontTablePtr(
+                            font,
+                            ('G' as i32 as uint32_t & 0xffi32 as libc::c_uint) << 24i32
+                                | ('P' as i32 as uint32_t & 0xffi32 as libc::c_uint) << 16i32
+                                | ('O' as i32 as uint32_t & 0xffi32 as libc::c_uint) << 8i32
+                                | 'S' as i32 as uint32_t & 0xffi32 as libc::c_uint,
+                        )
+                        .is_null()
+                    {
+                        rval = loadOTfont(fontRef, font, scaled_size, featString)
+                    }
+                    /* loadOTfont failed or the above check was false */
+                    if rval.is_null() {
+                        rval = loadAATfont(fontRef, scaled_size, featString)
+                    }
+                    if rval.is_null() {
+                        deleteFont(font);
+                    }
                 }
             }
             /* append the style and feature strings, so that \show\fontID will give a full result */
-            if !varString.is_null() && *varString as i32 != 0i32 {
-                strcat(name_of_file, b"/\x00" as *const u8 as *const i8);
+            if !varString.is_null() && *varString as libc::c_int != 0i32 {
+                strcat(name_of_file, b"/\x00" as *const u8 as *const libc::c_char);
                 strcat(name_of_file, varString);
             }
-            if !featString.is_null() && *featString as i32 != 0i32 {
-                strcat(name_of_file, b":\x00" as *const u8 as *const i8);
+            if !featString.is_null() && *featString as libc::c_int != 0i32 {
+                strcat(name_of_file, b":\x00" as *const u8 as *const libc::c_char);
                 strcat(name_of_file, featString);
             }
-            name_length = strlen(name_of_file) as i32
+            name_length = strlen(name_of_file) as int32_t
         }
     }
     free(varString as *mut libc::c_void);
     free(featString as *mut libc::c_void);
     free(nameString as *mut libc::c_void);
-    rval
+    return rval;
 }
 #[no_mangle]
-pub unsafe extern "C" fn release_font_engine(mut engine: *mut libc::c_void, mut type_flag: i32) {
-    if type_flag as u32 == 0xfffeu32 {
+pub unsafe extern "C" fn release_font_engine(
+    mut engine: *mut libc::c_void,
+    mut type_flag: libc::c_int,
+) {
+    if type_flag as libc::c_uint == 0xffffu32 {
+        CFRelease(engine as CFDictionaryRef as CFTypeRef);
+    } else if type_flag as libc::c_uint == 0xfffeu32 {
         deleteLayoutEngine(engine as XeTeXLayoutEngine);
     };
 }
@@ -1627,35 +3383,37 @@ pub unsafe extern "C" fn ot_get_font_metrics(
     mut slant: *mut scaled_t,
 ) {
     let mut engine: XeTeXLayoutEngine = pEngine as XeTeXLayoutEngine;
-    let mut a: f32 = 0.;
-    let mut d: f32 = 0.;
+    let mut a: libc::c_float = 0.;
+    let mut d: libc::c_float = 0.;
     getAscentAndDescent(engine, &mut a, &mut d);
-    *ascent = D2Fix(a as f64);
-    *descent = D2Fix(d as f64);
+    *ascent = D2Fix(a as libc::c_double);
+    *descent = D2Fix(d as libc::c_double);
     *slant = D2Fix(
-        Fix2D(getSlant(getFont(engine))) * getExtendFactor(engine) as f64
-            + getSlantFactor(engine) as f64,
+        Fix2D(getSlant(getFont(engine))) * getExtendFactor(engine) as libc::c_double
+            + getSlantFactor(engine) as libc::c_double,
     );
     /* get cap and x height from OS/2 table */
     getCapAndXHeight(engine, &mut a, &mut d);
-    *capheight = D2Fix(a as f64);
-    *xheight = D2Fix(d as f64);
+    *capheight = D2Fix(a as libc::c_double);
+    *xheight = D2Fix(d as libc::c_double);
     /* fallback in case the font does not have OS/2 table */
     if *xheight == 0i32 {
-        let mut glyphID: i32 = mapCharToGlyph(engine, 'x' as i32 as u32) as i32;
+        let mut glyphID: libc::c_int =
+            mapCharToGlyph(engine, 'x' as i32 as uint32_t) as libc::c_int;
         if glyphID != 0i32 {
-            getGlyphHeightDepth(engine, glyphID as u32, &mut a, &mut d);
-            *xheight = D2Fix(a as f64)
+            getGlyphHeightDepth(engine, glyphID as uint32_t, &mut a, &mut d);
+            *xheight = D2Fix(a as libc::c_double)
         } else {
             *xheight = *ascent / 2i32
             /* arbitrary figure if there's no 'x' in the font */
         }
     }
     if *capheight == 0i32 {
-        let mut glyphID_0: i32 = mapCharToGlyph(engine, 'X' as i32 as u32) as i32;
+        let mut glyphID_0: libc::c_int =
+            mapCharToGlyph(engine, 'X' as i32 as uint32_t) as libc::c_int;
         if glyphID_0 != 0i32 {
-            getGlyphHeightDepth(engine, glyphID_0 as u32, &mut a, &mut d);
-            *capheight = D2Fix(a as f64)
+            getGlyphHeightDepth(engine, glyphID_0 as uint32_t, &mut a, &mut d);
+            *capheight = D2Fix(a as libc::c_double)
         } else {
             *capheight = *ascent
             /* arbitrary figure if there's no 'X' in the font */
@@ -1663,73 +3421,76 @@ pub unsafe extern "C" fn ot_get_font_metrics(
     };
 }
 #[no_mangle]
-pub unsafe extern "C" fn ot_font_get(mut what: i32, mut pEngine: *mut libc::c_void) -> i32 {
+pub unsafe extern "C" fn ot_font_get(mut what: int32_t, mut pEngine: *mut libc::c_void) -> int32_t {
     let mut engine: XeTeXLayoutEngine = pEngine as XeTeXLayoutEngine;
     let mut fontInst: XeTeXFont = getFont(engine);
     match what {
-        1 => return countGlyphs(fontInst) as i32,
+        1 => return countGlyphs(fontInst) as int32_t,
         8 => {
             /* ie Graphite features */
-            return countGraphiteFeatures(engine) as i32;
+            return countGraphiteFeatures(engine) as int32_t;
         }
-        16 => return countScripts(fontInst) as i32,
+        16 => return countScripts(fontInst) as int32_t,
         _ => {}
     }
-    0i32
+    return 0i32;
 }
 #[no_mangle]
 pub unsafe extern "C" fn ot_font_get_1(
-    mut what: i32,
+    mut what: int32_t,
     mut pEngine: *mut libc::c_void,
-    mut param: i32,
-) -> i32 {
+    mut param: int32_t,
+) -> int32_t {
     let mut engine: XeTeXLayoutEngine = pEngine as XeTeXLayoutEngine;
     let mut fontInst: XeTeXFont = getFont(engine);
     match what {
-        17 => return countLanguages(fontInst, param as hb_tag_t) as i32,
-        19 => return getIndScript(fontInst, param as u32) as i32,
+        17 => return countLanguages(fontInst, param as hb_tag_t) as int32_t,
+        19 => return getIndScript(fontInst, param as libc::c_uint) as int32_t,
         9 => {
             /* for graphite fonts...*/
-            return getGraphiteFeatureCode(engine, param as u32) as i32;
+            return getGraphiteFeatureCode(engine, param as uint32_t) as int32_t;
         }
         11 => return 1i32,
-        12 => return countGraphiteFeatureSettings(engine, param as u32) as i32,
+        12 => return countGraphiteFeatureSettings(engine, param as uint32_t) as int32_t,
         _ => {}
     }
-    0i32
+    return 0i32;
 }
 #[no_mangle]
 pub unsafe extern "C" fn ot_font_get_2(
-    mut what: i32,
+    mut what: int32_t,
     mut pEngine: *mut libc::c_void,
-    mut param1: i32,
-    mut param2: i32,
-) -> i32 {
+    mut param1: int32_t,
+    mut param2: int32_t,
+) -> int32_t {
     let mut engine: XeTeXLayoutEngine = pEngine as XeTeXLayoutEngine;
     let mut fontInst: XeTeXFont = getFont(engine);
     match what {
-        20 => return getIndLanguage(fontInst, param1 as hb_tag_t, param2 as u32) as i32,
-        18 => return countFeatures(fontInst, param1 as hb_tag_t, param2 as hb_tag_t) as i32,
+        20 => {
+            return getIndLanguage(fontInst, param1 as hb_tag_t, param2 as libc::c_uint) as int32_t
+        }
+        18 => return countFeatures(fontInst, param1 as hb_tag_t, param2 as hb_tag_t) as int32_t,
         13 => {
             /* for graphite fonts */
-            return getGraphiteFeatureSettingCode(engine, param1 as u32, param2 as u32) as i32;
+            return getGraphiteFeatureSettingCode(engine, param1 as uint32_t, param2 as uint32_t)
+                as int32_t;
         }
         15 => {
-            return (getGraphiteFeatureDefaultSetting(engine, param1 as u32) == param2 as u32)
-                as i32
+            return (getGraphiteFeatureDefaultSetting(engine, param1 as uint32_t)
+                == param2 as libc::c_uint) as libc::c_int
         }
         _ => {}
     } /* to guarantee enough space in the buffer */
-    0i32
+    return 0i32;
 }
 #[no_mangle]
 pub unsafe extern "C" fn ot_font_get_3(
-    mut what: i32,
+    mut what: int32_t,
     mut pEngine: *mut libc::c_void,
-    mut param1: i32,
-    mut param2: i32,
-    mut param3: i32,
-) -> i32 {
+    mut param1: int32_t,
+    mut param2: int32_t,
+    mut param3: int32_t,
+) -> int32_t {
     let mut engine: XeTeXLayoutEngine = pEngine as XeTeXLayoutEngine;
     let mut fontInst: XeTeXFont = getFont(engine);
     match what {
@@ -1738,25 +3499,25 @@ pub unsafe extern "C" fn ot_font_get_3(
                 fontInst,
                 param1 as hb_tag_t,
                 param2 as hb_tag_t,
-                param3 as u32,
-            ) as i32
+                param3 as libc::c_uint,
+            ) as int32_t
         }
         _ => {}
     }
-    0i32
+    return 0i32;
 }
 #[no_mangle]
 pub unsafe extern "C" fn gr_print_font_name(
-    mut what: i32,
+    mut what: int32_t,
     mut pEngine: *mut libc::c_void,
-    mut param1: i32,
-    mut param2: i32,
+    mut param1: int32_t,
+    mut param2: int32_t,
 ) {
-    let mut name: *mut i8 = 0 as *mut i8;
+    let mut name: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut engine: XeTeXLayoutEngine = pEngine as XeTeXLayoutEngine;
     match what {
-        8 => name = getGraphiteFeatureLabel(engine, param1 as u32),
-        9 => name = getGraphiteFeatureSettingLabel(engine, param1 as u32, param2 as u32),
+        8 => name = getGraphiteFeatureLabel(engine, param1 as uint32_t),
+        9 => name = getGraphiteFeatureSettingLabel(engine, param1 as uint32_t, param2 as uint32_t),
         _ => {}
     }
     if !name.is_null() {
@@ -1765,146 +3526,242 @@ pub unsafe extern "C" fn gr_print_font_name(
     };
 }
 #[no_mangle]
-pub unsafe extern "C" fn gr_font_get_named(mut what: i32, mut pEngine: *mut libc::c_void) -> i32 {
-    let mut rval: i64 = -1i32 as i64;
+pub unsafe extern "C" fn gr_font_get_named(
+    mut what: int32_t,
+    mut pEngine: *mut libc::c_void,
+) -> int32_t {
+    let mut rval: libc::c_long = -1i32 as libc::c_long;
     let mut engine: XeTeXLayoutEngine = pEngine as XeTeXLayoutEngine;
     match what {
         10 => rval = findGraphiteFeatureNamed(engine, name_of_file, name_length),
         _ => {}
     }
-    rval as i32
+    return rval as int32_t;
 }
 #[no_mangle]
 pub unsafe extern "C" fn gr_font_get_named_1(
-    mut what: i32,
+    mut what: int32_t,
     mut pEngine: *mut libc::c_void,
-    mut param: i32,
-) -> i32 {
-    let mut rval: i64 = -1i32 as i64;
+    mut param: int32_t,
+) -> int32_t {
+    let mut rval: libc::c_long = -1i32 as libc::c_long;
     let mut engine: XeTeXLayoutEngine = pEngine as XeTeXLayoutEngine;
     match what {
         14 => {
-            rval = findGraphiteFeatureSettingNamed(engine, param as u32, name_of_file, name_length)
+            rval = findGraphiteFeatureSettingNamed(
+                engine,
+                param as uint32_t,
+                name_of_file,
+                name_length,
+            )
         }
         _ => {}
     }
-    rval as i32
+    return rval as int32_t;
 }
-static mut xdvBufSize: i32 = 0i32;
+unsafe extern "C" fn cgColorToRGBA32(mut color: CGColorRef) -> UInt32 {
+    let mut components: *const CGFloat = CGColorGetComponents(color);
+    let mut rval: UInt32 = (*components.offset(0) * 255.0f64 + 0.5f64) as UInt8 as UInt32;
+    rval <<= 8i32;
+    rval = (rval as libc::c_uint)
+        .wrapping_add((*components.offset(1) * 255.0f64 + 0.5f64) as UInt8 as libc::c_uint)
+        as UInt32 as UInt32;
+    rval <<= 8i32;
+    rval = (rval as libc::c_uint)
+        .wrapping_add((*components.offset(2) * 255.0f64 + 0.5f64) as UInt8 as libc::c_uint)
+        as UInt32 as UInt32;
+    rval <<= 8i32;
+    rval = (rval as libc::c_uint)
+        .wrapping_add((*components.offset(3) * 255.0f64 + 0.5f64) as UInt8 as libc::c_uint)
+        as UInt32 as UInt32;
+    return rval;
+}
+static mut xdvBufSize: libc::c_int = 0i32;
 #[no_mangle]
-pub unsafe extern "C" fn makeXDVGlyphArrayData(mut pNode: *mut libc::c_void) -> i32 {
-    let mut cp: *mut u8 = 0 as *mut u8;
-    let mut glyphIDs: *mut u16 = 0 as *mut u16;
+pub unsafe extern "C" fn makeXDVGlyphArrayData(mut pNode: *mut libc::c_void) -> libc::c_int {
+    let mut cp: *mut libc::c_uchar = 0 as *mut libc::c_uchar;
+    let mut glyphIDs: *mut uint16_t = 0 as *mut uint16_t;
     let mut p: *mut memory_word = pNode as *mut memory_word;
     let mut glyph_info: *mut libc::c_void = 0 as *mut libc::c_void;
     let mut locations: *mut FixedPoint = 0 as *mut FixedPoint;
     let mut width: Fixed = 0;
-    let mut glyphCount: u16 = (*p.offset(4)).b16.s0;
-    let mut i: i32 = glyphCount as i32 * 10i32 + 8i32;
+    let mut glyphCount: uint16_t = (*p.offset(4)).b16.s0;
+    let mut i: libc::c_int = glyphCount as libc::c_int * 10i32 + 8i32;
     if i > xdvBufSize {
         free(xdv_buffer as *mut libc::c_void);
         xdvBufSize = (i / 1024i32 + 1i32) * 1024i32;
-        xdv_buffer = xmalloc(xdvBufSize as size_t) as *mut i8
+        xdv_buffer = xmalloc(xdvBufSize as size_t) as *mut libc::c_char
     }
     glyph_info = (*p.offset(5)).ptr;
     locations = glyph_info as *mut FixedPoint;
-    glyphIDs = locations.offset(glyphCount as i32 as isize) as *mut u16;
-    cp = xdv_buffer as *mut u8;
+    glyphIDs = locations.offset(glyphCount as libc::c_int as isize) as *mut uint16_t;
+    cp = xdv_buffer as *mut libc::c_uchar;
     width = (*p.offset(1)).b32.s1;
     let fresh13 = cp;
     cp = cp.offset(1);
-    *fresh13 = (width >> 24i32 & 0xffi32) as u8;
+    *fresh13 = (width >> 24i32 & 0xffi32) as libc::c_uchar;
     let fresh14 = cp;
     cp = cp.offset(1);
-    *fresh14 = (width >> 16i32 & 0xffi32) as u8;
+    *fresh14 = (width >> 16i32 & 0xffi32) as libc::c_uchar;
     let fresh15 = cp;
     cp = cp.offset(1);
-    *fresh15 = (width >> 8i32 & 0xffi32) as u8;
+    *fresh15 = (width >> 8i32 & 0xffi32) as libc::c_uchar;
     let fresh16 = cp;
     cp = cp.offset(1);
-    *fresh16 = (width & 0xffi32) as u8;
+    *fresh16 = (width & 0xffi32) as libc::c_uchar;
     let fresh17 = cp;
     cp = cp.offset(1);
-    *fresh17 = (glyphCount as i32 >> 8i32 & 0xffi32) as u8;
+    *fresh17 = (glyphCount as libc::c_int >> 8i32 & 0xffi32) as libc::c_uchar;
     let fresh18 = cp;
     cp = cp.offset(1);
-    *fresh18 = (glyphCount as i32 & 0xffi32) as u8;
+    *fresh18 = (glyphCount as libc::c_int & 0xffi32) as libc::c_uchar;
     i = 0i32;
-    while i < glyphCount as i32 {
+    while i < glyphCount as libc::c_int {
         let mut x: Fixed = (*locations.offset(i as isize)).x;
         let mut y: Fixed = (*locations.offset(i as isize)).y;
         let fresh19 = cp;
         cp = cp.offset(1);
-        *fresh19 = (x >> 24i32 & 0xffi32) as u8;
+        *fresh19 = (x >> 24i32 & 0xffi32) as libc::c_uchar;
         let fresh20 = cp;
         cp = cp.offset(1);
-        *fresh20 = (x >> 16i32 & 0xffi32) as u8;
+        *fresh20 = (x >> 16i32 & 0xffi32) as libc::c_uchar;
         let fresh21 = cp;
         cp = cp.offset(1);
-        *fresh21 = (x >> 8i32 & 0xffi32) as u8;
+        *fresh21 = (x >> 8i32 & 0xffi32) as libc::c_uchar;
         let fresh22 = cp;
         cp = cp.offset(1);
-        *fresh22 = (x & 0xffi32) as u8;
+        *fresh22 = (x & 0xffi32) as libc::c_uchar;
         let fresh23 = cp;
         cp = cp.offset(1);
-        *fresh23 = (y >> 24i32 & 0xffi32) as u8;
+        *fresh23 = (y >> 24i32 & 0xffi32) as libc::c_uchar;
         let fresh24 = cp;
         cp = cp.offset(1);
-        *fresh24 = (y >> 16i32 & 0xffi32) as u8;
+        *fresh24 = (y >> 16i32 & 0xffi32) as libc::c_uchar;
         let fresh25 = cp;
         cp = cp.offset(1);
-        *fresh25 = (y >> 8i32 & 0xffi32) as u8;
+        *fresh25 = (y >> 8i32 & 0xffi32) as libc::c_uchar;
         let fresh26 = cp;
         cp = cp.offset(1);
-        *fresh26 = (y & 0xffi32) as u8;
+        *fresh26 = (y & 0xffi32) as libc::c_uchar;
         i += 1
     }
     i = 0i32;
-    while i < glyphCount as i32 {
-        let mut g: u16 = *glyphIDs.offset(i as isize);
+    while i < glyphCount as libc::c_int {
+        let mut g: uint16_t = *glyphIDs.offset(i as isize);
         let fresh27 = cp;
         cp = cp.offset(1);
-        *fresh27 = (g as i32 >> 8i32 & 0xffi32) as u8;
+        *fresh27 = (g as libc::c_int >> 8i32 & 0xffi32) as libc::c_uchar;
         let fresh28 = cp;
         cp = cp.offset(1);
-        *fresh28 = (g as i32 & 0xffi32) as u8;
+        *fresh28 = (g as libc::c_int & 0xffi32) as libc::c_uchar;
         i += 1
     }
-    (cp as *mut i8).wrapping_offset_from(xdv_buffer) as i64 as i32
+    return (cp as *mut libc::c_char).wrapping_offset_from(xdv_buffer) as libc::c_long
+        as libc::c_int;
 }
 #[no_mangle]
-pub unsafe extern "C" fn make_font_def(mut f: i32) -> i32 {
-    let mut flags: u16 = 0_u16;
-    let mut rgba: u32 = 0;
+pub unsafe extern "C" fn make_font_def(mut f: int32_t) -> libc::c_int {
+    let mut flags: uint16_t = 0i32 as uint16_t;
+    let mut rgba: uint32_t = 0;
     let mut size: Fixed = 0;
-    let mut filename: *mut i8 = 0 as *mut i8;
-    let mut index: u32 = 0;
-    let mut filenameLen: u8 = 0;
-    let mut fontDefLength: i32 = 0;
-    let mut cp: *mut i8 = 0 as *mut i8;
+    let mut filename: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut index: uint32_t = 0;
+    let mut filenameLen: uint8_t = 0;
+    let mut fontDefLength: libc::c_int = 0;
+    let mut cp: *mut libc::c_char = 0 as *mut libc::c_char;
     /* PlatformFontRef fontRef = 0; */
-    let mut extend: f32 = 1.0f64 as f32;
-    let mut slant: f32 = 0.0f64 as f32;
-    let mut embolden: f32 = 0.0f64 as f32;
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32 {
+    let mut extend: libc::c_float = 1.0f64 as libc::c_float;
+    let mut slant: libc::c_float = 0.0f64 as libc::c_float;
+    let mut embolden: libc::c_float = 0.0f64 as libc::c_float;
+    let mut attributes: CFDictionaryRef = 0 as CFDictionaryRef;
+    if *font_area.offset(f as isize) as libc::c_uint == 0xffffu32 {
+        let mut font: CTFontRef = 0 as *const __CTFont;
+        let mut color: CGColorRef = 0 as *mut CGColor;
+        let mut t: CGAffineTransform = CGAffineTransform {
+            a: 0.,
+            b: 0.,
+            c: 0.,
+            d: 0.,
+            tx: 0.,
+            ty: 0.,
+        };
+        let mut emboldenNumber: CFNumberRef = 0 as *const __CFNumber;
+        let mut fSize: CGFloat = 0.;
+        attributes = *font_layout_engine.offset(f as isize) as CFDictionaryRef;
+        font = CFDictionaryGetValue(attributes, kCTFontAttributeName as *const libc::c_void)
+            as CTFontRef;
+        filename = getFileNameFromCTFont(font, &mut index);
+        if filename.is_null() as libc::c_int as libc::c_long != 0 {
+            __assert_rtn(
+                (*::std::mem::transmute::<&[u8; 14], &[libc::c_char; 14]>(b"make_font_def\x00"))
+                    .as_ptr(),
+                b"tectonic/xetex-ext.c\x00" as *const u8 as *const libc::c_char,
+                1163i32,
+                b"filename\x00" as *const u8 as *const libc::c_char,
+            );
+        } else {
+        };
+        if !CFDictionaryGetValue(
+            attributes,
+            kCTVerticalFormsAttributeName as *const libc::c_void,
+        )
+        .is_null()
+        {
+            flags = (flags as libc::c_int | 0x100i32) as uint16_t
+        }
+        color = CFDictionaryGetValue(
+            attributes,
+            kCTForegroundColorAttributeName as *const libc::c_void,
+        ) as CGColorRef;
+        if !color.is_null() {
+            rgba = cgColorToRGBA32(color)
+        }
+        t = CTFontGetMatrix(font);
+        extend = t.a as libc::c_float;
+        slant = t.c as libc::c_float;
+        emboldenNumber = CFDictionaryGetValue(
+            attributes,
+            getkXeTeXEmboldenAttributeName() as *const libc::c_void,
+        ) as CFNumberRef;
+        if !emboldenNumber.is_null() {
+            CFNumberGetValue(
+                emboldenNumber,
+                kCFNumberFloatType as libc::c_int as CFNumberType,
+                &mut embolden as *mut libc::c_float as *mut libc::c_void,
+            );
+        }
+        fSize = CTFontGetSize(font);
+        size = D2Fix(fSize)
+    } else if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
         let mut engine: XeTeXLayoutEngine = 0 as *mut XeTeXLayoutEngine_rec;
         engine = *font_layout_engine.offset(f as isize) as XeTeXLayoutEngine;
         /* fontRef = */
         getFontRef(engine);
         filename = getFontFilename(engine, &mut index);
-        assert!(!filename.is_null());
+        if filename.is_null() as libc::c_int as libc::c_long != 0 {
+            __assert_rtn(
+                (*::std::mem::transmute::<&[u8; 14], &[libc::c_char; 14]>(b"make_font_def\x00"))
+                    .as_ptr(),
+                b"tectonic/xetex-ext.c\x00" as *const u8 as *const libc::c_char,
+                1190i32,
+                b"filename\x00" as *const u8 as *const libc::c_char,
+            );
+        } else {
+        };
         rgba = getRgbValue(engine);
-        if *font_flags.offset(f as isize) as i32 & 0x2i32 != 0i32 {
-            flags = (flags as i32 | 0x100i32) as u16
+        if *font_flags.offset(f as isize) as libc::c_int & 0x2i32 != 0i32 {
+            flags = (flags as libc::c_int | 0x100i32) as uint16_t
         }
         extend = getExtendFactor(engine);
         slant = getSlantFactor(engine);
         embolden = getEmboldenFactor(engine);
-        size = D2Fix(getPointSize(engine) as f64)
+        size = D2Fix(getPointSize(engine) as libc::c_double)
     } else {
-        _tt_abort(b"bad native font flag in `make_font_def`\x00" as *const u8 as *const i8);
+        _tt_abort(
+            b"bad native font flag in `make_font_def`\x00" as *const u8 as *const libc::c_char,
+        );
     }
-    filenameLen = strlen(filename) as u8;
+    filenameLen = strlen(filename) as uint8_t;
     /* parameters after internal font ID:
     //  size[4]
     //  flags[2]
@@ -1912,86 +3769,86 @@ pub unsafe extern "C" fn make_font_def(mut f: i32) -> i32 {
     //  if flags & COLORED:
     //      c[4]
      */
-    fontDefLength = 4i32 + 2i32 + 1i32 + filenameLen as i32 + 4i32; /* face index */
-    if *font_flags.offset(f as isize) as i32 & 0x1i32 != 0i32 {
+    fontDefLength = 4i32 + 2i32 + 1i32 + filenameLen as libc::c_int + 4i32; /* face index */
+    if *font_flags.offset(f as isize) as libc::c_int & 0x1i32 != 0i32 {
         fontDefLength += 4i32; /* 32-bit RGBA value */
-        flags = (flags as i32 | 0x200i32) as u16
+        flags = (flags as libc::c_int | 0x200i32) as uint16_t
     }
-    if extend as f64 != 1.0f64 {
+    if extend as libc::c_double != 1.0f64 {
         fontDefLength += 4i32;
-        flags = (flags as i32 | 0x1000i32) as u16
+        flags = (flags as libc::c_int | 0x1000i32) as uint16_t
     }
-    if slant as f64 != 0.0f64 {
+    if slant as libc::c_double != 0.0f64 {
         fontDefLength += 4i32;
-        flags = (flags as i32 | 0x2000i32) as u16
+        flags = (flags as libc::c_int | 0x2000i32) as uint16_t
     }
-    if embolden as f64 != 0.0f64 {
+    if embolden as libc::c_double != 0.0f64 {
         fontDefLength += 4i32;
-        flags = (flags as i32 | 0x4000i32) as u16
+        flags = (flags as libc::c_int | 0x4000i32) as uint16_t
     }
     if fontDefLength > xdvBufSize {
         free(xdv_buffer as *mut libc::c_void);
         xdvBufSize = (fontDefLength / 1024i32 + 1i32) * 1024i32;
-        xdv_buffer = xmalloc(xdvBufSize as size_t) as *mut i8
+        xdv_buffer = xmalloc(xdvBufSize as size_t) as *mut libc::c_char
     }
     cp = xdv_buffer;
-    *(cp as *mut Fixed) = SWAP32(size as u32) as Fixed;
+    *(cp as *mut Fixed) = SWAP32(size as uint32_t) as Fixed;
     cp = cp.offset(4);
-    *(cp as *mut u16) = SWAP16(flags);
+    *(cp as *mut uint16_t) = SWAP16(flags);
     cp = cp.offset(2);
-    *(cp as *mut u8) = filenameLen;
+    *(cp as *mut uint8_t) = filenameLen;
     cp = cp.offset(1);
     memcpy(
         cp as *mut libc::c_void,
         filename as *const libc::c_void,
-        filenameLen as u64,
+        filenameLen as libc::c_ulong,
     );
-    cp = cp.offset(filenameLen as i32 as isize);
-    *(cp as *mut u32) = SWAP32(index);
+    cp = cp.offset(filenameLen as libc::c_int as isize);
+    *(cp as *mut uint32_t) = SWAP32(index);
     cp = cp.offset(4);
-    if *font_flags.offset(f as isize) as i32 & 0x1i32 != 0i32 {
-        *(cp as *mut u32) = SWAP32(rgba);
+    if *font_flags.offset(f as isize) as libc::c_int & 0x1i32 != 0i32 {
+        *(cp as *mut uint32_t) = SWAP32(rgba);
         cp = cp.offset(4)
     }
-    if flags as i32 & 0x1000i32 != 0 {
-        let mut f_0: Fixed = D2Fix(extend as f64);
-        *(cp as *mut u32) = SWAP32(f_0 as u32);
+    if flags as libc::c_int & 0x1000i32 != 0 {
+        let mut f_0: Fixed = D2Fix(extend as libc::c_double);
+        *(cp as *mut uint32_t) = SWAP32(f_0 as uint32_t);
         cp = cp.offset(4)
     }
-    if flags as i32 & 0x2000i32 != 0 {
-        let mut f_1: Fixed = D2Fix(slant as f64);
-        *(cp as *mut u32) = SWAP32(f_1 as u32);
+    if flags as libc::c_int & 0x2000i32 != 0 {
+        let mut f_1: Fixed = D2Fix(slant as libc::c_double);
+        *(cp as *mut uint32_t) = SWAP32(f_1 as uint32_t);
         cp = cp.offset(4)
     }
-    if flags as i32 & 0x4000i32 != 0 {
-        let mut f_2: Fixed = D2Fix(embolden as f64);
-        *(cp as *mut u32) = SWAP32(f_2 as u32);
+    if flags as libc::c_int & 0x4000i32 != 0 {
+        let mut f_2: Fixed = D2Fix(embolden as libc::c_double);
+        *(cp as *mut uint32_t) = SWAP32(f_2 as uint32_t);
         cp = cp.offset(4)
     }
     free(filename as *mut libc::c_void);
-    fontDefLength
+    return fontDefLength;
 }
 #[no_mangle]
 pub unsafe extern "C" fn apply_mapping(
     mut pCnv: *mut libc::c_void,
-    mut txtPtr: *mut u16,
-    mut txtLen: i32,
-) -> i32 {
+    mut txtPtr: *mut uint16_t,
+    mut txtLen: libc::c_int,
+) -> libc::c_int {
     let mut cnv: TECkit_Converter = pCnv as TECkit_Converter;
     let mut inUsed: UInt32 = 0;
     let mut outUsed: UInt32 = 0;
     let mut status: TECkit_Status = 0;
     static mut outLength: UInt32 = 0i32 as UInt32;
     /* allocate outBuffer if not big enough */
-    if (outLength as u64)
-        < (txtLen as u64)
-            .wrapping_mul(::std::mem::size_of::<UniChar>() as u64)
-            .wrapping_add(32i32 as u64)
+    if (outLength as libc::c_ulong)
+        < (txtLen as libc::c_ulong)
+            .wrapping_mul(::std::mem::size_of::<UniChar>() as libc::c_ulong)
+            .wrapping_add(32i32 as libc::c_ulong)
     {
         free(mapped_text as *mut libc::c_void);
-        outLength = (txtLen as u64)
-            .wrapping_mul(::std::mem::size_of::<UniChar>() as u64)
-            .wrapping_add(32i32 as u64) as UInt32;
+        outLength = (txtLen as libc::c_ulong)
+            .wrapping_mul(::std::mem::size_of::<UniChar>() as libc::c_ulong)
+            .wrapping_add(32i32 as libc::c_ulong) as UInt32;
         mapped_text = xmalloc(outLength as size_t) as *mut UTF16_code
     }
     loop
@@ -2000,7 +3857,9 @@ pub unsafe extern "C" fn apply_mapping(
         status = TECkit_ConvertBuffer(
             cnv,
             txtPtr as *mut Byte,
-            (txtLen as u64).wrapping_mul(::std::mem::size_of::<UniChar>() as u64) as UInt32,
+            (txtLen as libc::c_ulong)
+                .wrapping_mul(::std::mem::size_of::<UniChar>() as libc::c_ulong)
+                as UInt32,
             &mut inUsed,
             mapped_text as *mut Byte,
             outLength,
@@ -2010,14 +3869,15 @@ pub unsafe extern "C" fn apply_mapping(
         match status {
             0 => {
                 txtPtr = mapped_text as *mut UniChar;
-                return (outUsed as u64).wrapping_div(::std::mem::size_of::<UniChar>() as u64)
-                    as i32;
+                return (outUsed as libc::c_ulong)
+                    .wrapping_div(::std::mem::size_of::<UniChar>() as libc::c_ulong)
+                    as libc::c_int;
             }
             1 => {
-                outLength = (outLength as u64).wrapping_add(
-                    (txtLen as u64)
-                        .wrapping_mul(::std::mem::size_of::<UniChar>() as u64)
-                        .wrapping_add(32i32 as u64),
+                outLength = (outLength as libc::c_ulong).wrapping_add(
+                    (txtLen as libc::c_ulong)
+                        .wrapping_mul(::std::mem::size_of::<UniChar>() as libc::c_ulong)
+                        .wrapping_add(32i32 as libc::c_ulong),
                 ) as UInt32 as UInt32;
                 free(mapped_text as *mut libc::c_void);
                 mapped_text = xmalloc(outLength as size_t) as *mut UTF16_code
@@ -2038,26 +3898,32 @@ unsafe extern "C" fn snap_zone(
 }
 #[no_mangle]
 pub unsafe extern "C" fn get_native_char_height_depth(
-    mut font: i32,
-    mut ch: i32,
+    mut font: int32_t,
+    mut ch: int32_t,
     mut height: *mut scaled_t,
     mut depth: *mut scaled_t,
 ) {
-    let mut ht: f32 = 0.0f64 as f32;
-    let mut dp: f32 = 0.0f64 as f32;
+    let mut ht: libc::c_float = 0.0f64 as libc::c_float;
+    let mut dp: libc::c_float = 0.0f64 as libc::c_float;
     let mut fuzz: Fixed = 0;
-    if *font_area.offset(font as isize) as u32 == 0xfffeu32 {
+    if *font_area.offset(font as isize) as libc::c_uint == 0xffffu32 {
+        let mut attributes: CFDictionaryRef =
+            *font_layout_engine.offset(font as isize) as CFDictionaryRef;
+        let mut gid: libc::c_int = MapCharToGlyph_AAT(attributes, ch as UInt32);
+        GetGlyphHeightDepth_AAT(attributes, gid as uint16_t, &mut ht, &mut dp);
+    } else if *font_area.offset(font as isize) as libc::c_uint == 0xfffeu32 {
         let mut engine: XeTeXLayoutEngine =
             *font_layout_engine.offset(font as isize) as XeTeXLayoutEngine;
-        let mut gid: i32 = mapCharToGlyph(engine, ch as u32) as i32;
-        getGlyphHeightDepth(engine, gid as u32, &mut ht, &mut dp);
+        let mut gid_0: libc::c_int = mapCharToGlyph(engine, ch as uint32_t) as libc::c_int;
+        getGlyphHeightDepth(engine, gid_0 as uint32_t, &mut ht, &mut dp);
     } else {
         _tt_abort(
-            b"bad native font flag in `get_native_char_height_depth`\x00" as *const u8 as *const i8,
+            b"bad native font flag in `get_native_char_height_depth`\x00" as *const u8
+                as *const libc::c_char,
         );
     }
-    *height = D2Fix(ht as f64);
-    *depth = D2Fix(dp as f64);
+    *height = D2Fix(ht as libc::c_double);
+    *depth = D2Fix(dp as libc::c_double);
     /* snap to "known" zones for baseline, x-height, cap-height if within 4% of em-size */
     fuzz = (*font_info.offset((6i32 + *param_base.offset(font as isize)) as isize))
         .b32
@@ -2081,136 +3947,167 @@ pub unsafe extern "C" fn get_native_char_height_depth(
     );
 }
 #[no_mangle]
-pub unsafe extern "C" fn getnativecharht(mut f: i32, mut c: i32) -> scaled_t {
+pub unsafe extern "C" fn getnativecharht(mut f: int32_t, mut c: int32_t) -> scaled_t {
     let mut h: scaled_t = 0;
     let mut d: scaled_t = 0;
     get_native_char_height_depth(f, c, &mut h, &mut d);
-    h
+    return h;
 }
 #[no_mangle]
-pub unsafe extern "C" fn getnativechardp(mut f: i32, mut c: i32) -> scaled_t {
+pub unsafe extern "C" fn getnativechardp(mut f: int32_t, mut c: int32_t) -> scaled_t {
     let mut h: scaled_t = 0;
     let mut d: scaled_t = 0;
     get_native_char_height_depth(f, c, &mut h, &mut d);
-    d
+    return d;
 }
 #[no_mangle]
 pub unsafe extern "C" fn get_native_char_sidebearings(
-    mut font: i32,
-    mut ch: i32,
+    mut font: int32_t,
+    mut ch: int32_t,
     mut lsb: *mut scaled_t,
     mut rsb: *mut scaled_t,
 ) {
-    let mut l: f32 = 0.;
-    let mut r: f32 = 0.;
-    if *font_area.offset(font as isize) as u32 == 0xfffeu32 {
+    let mut l: libc::c_float = 0.;
+    let mut r: libc::c_float = 0.;
+    if *font_area.offset(font as isize) as libc::c_uint == 0xffffu32 {
+        let mut attributes: CFDictionaryRef =
+            *font_layout_engine.offset(font as isize) as CFDictionaryRef;
+        let mut gid: libc::c_int = MapCharToGlyph_AAT(attributes, ch as UInt32);
+        GetGlyphSidebearings_AAT(attributes, gid as uint16_t, &mut l, &mut r);
+    } else if *font_area.offset(font as isize) as libc::c_uint == 0xfffeu32 {
         let mut engine: XeTeXLayoutEngine =
             *font_layout_engine.offset(font as isize) as XeTeXLayoutEngine;
-        let mut gid: i32 = mapCharToGlyph(engine, ch as u32) as i32;
-        getGlyphSidebearings(engine, gid as u32, &mut l, &mut r);
+        let mut gid_0: libc::c_int = mapCharToGlyph(engine, ch as uint32_t) as libc::c_int;
+        getGlyphSidebearings(engine, gid_0 as uint32_t, &mut l, &mut r);
     } else {
         _tt_abort(
             b"bad native font flag in `get_native_char_side_bearings`\x00" as *const u8
-                as *const i8,
+                as *const libc::c_char,
         );
     }
-    *lsb = D2Fix(l as f64);
-    *rsb = D2Fix(r as f64);
+    *lsb = D2Fix(l as libc::c_double);
+    *rsb = D2Fix(r as libc::c_double);
 }
 #[no_mangle]
-pub unsafe extern "C" fn get_glyph_bounds(mut font: i32, mut edge: i32, mut gid: i32) -> scaled_t {
+pub unsafe extern "C" fn get_glyph_bounds(
+    mut font: int32_t,
+    mut edge: int32_t,
+    mut gid: int32_t,
+) -> scaled_t {
     /* edge codes 1,2,3,4 => L T R B */
-    let mut a: f32 = 0.;
-    let mut b: f32 = 0.;
-    if *font_area.offset(font as isize) as u32 == 0xfffeu32 {
+    let mut a: libc::c_float = 0.;
+    let mut b: libc::c_float = 0.;
+    if *font_area.offset(font as isize) as libc::c_uint == 0xffffu32 {
+        let mut attributes: CFDictionaryRef =
+            *font_layout_engine.offset(font as isize) as CFDictionaryRef;
+        if edge & 1i32 != 0 {
+            GetGlyphSidebearings_AAT(attributes, gid as uint16_t, &mut a, &mut b);
+        } else {
+            GetGlyphHeightDepth_AAT(attributes, gid as uint16_t, &mut a, &mut b);
+        }
+    } else if *font_area.offset(font as isize) as libc::c_uint == 0xfffeu32 {
         let mut engine: XeTeXLayoutEngine =
             *font_layout_engine.offset(font as isize) as XeTeXLayoutEngine;
         if edge & 1i32 != 0 {
-            getGlyphSidebearings(engine, gid as u32, &mut a, &mut b);
+            getGlyphSidebearings(engine, gid as uint32_t, &mut a, &mut b);
         } else {
-            getGlyphHeightDepth(engine, gid as u32, &mut a, &mut b);
+            getGlyphHeightDepth(engine, gid as uint32_t, &mut a, &mut b);
         }
     } else {
-        _tt_abort(b"bad native font flag in `get_glyph_bounds`\x00" as *const u8 as *const i8);
+        _tt_abort(
+            b"bad native font flag in `get_glyph_bounds`\x00" as *const u8 as *const libc::c_char,
+        );
     }
-    D2Fix((if edge <= 2i32 { a } else { b }) as f64)
+    return D2Fix((if edge <= 2i32 { a } else { b }) as libc::c_double);
 }
 #[no_mangle]
-pub unsafe extern "C" fn getnativecharic(mut f: i32, mut c: i32) -> scaled_t {
+pub unsafe extern "C" fn getnativecharic(mut f: int32_t, mut c: int32_t) -> scaled_t {
     let mut lsb: scaled_t = 0;
     let mut rsb: scaled_t = 0;
     get_native_char_sidebearings(f, c, &mut lsb, &mut rsb);
     if rsb < 0i32 {
-        *font_letter_space.offset(f as isize) - rsb
+        return *font_letter_space.offset(f as isize) - rsb;
     } else {
-        *font_letter_space.offset(f as isize)
-    }
+        return *font_letter_space.offset(f as isize);
+    };
 }
 /* single-purpose metrics accessors */
 #[no_mangle]
-pub unsafe extern "C" fn getnativecharwd(mut f: i32, mut c: i32) -> scaled_t {
+pub unsafe extern "C" fn getnativecharwd(mut f: int32_t, mut c: int32_t) -> scaled_t {
     let mut wd: scaled_t = 0i32;
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32 {
+    if *font_area.offset(f as isize) as libc::c_uint == 0xffffu32 {
+        let mut attributes: CFDictionaryRef =
+            *font_layout_engine.offset(f as isize) as CFDictionaryRef;
+        let mut gid: libc::c_int = MapCharToGlyph_AAT(attributes, c as UInt32);
+        wd = D2Fix(GetGlyphWidth_AAT(attributes, gid as uint16_t))
+    } else if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
         let mut engine: XeTeXLayoutEngine =
             *font_layout_engine.offset(f as isize) as XeTeXLayoutEngine;
-        let mut gid: i32 = mapCharToGlyph(engine, c as u32) as i32;
-        wd = D2Fix(getGlyphWidthFromEngine(engine, gid as u32) as f64)
+        let mut gid_0: libc::c_int = mapCharToGlyph(engine, c as uint32_t) as libc::c_int;
+        wd = D2Fix(getGlyphWidthFromEngine(engine, gid_0 as uint32_t) as libc::c_double)
     } else {
-        _tt_abort(b"bad native font flag in `get_native_char_wd`\x00" as *const u8 as *const i8);
+        _tt_abort(
+            b"bad native font flag in `get_native_char_wd`\x00" as *const u8 as *const libc::c_char,
+        );
     }
-    wd
+    return wd;
 }
 #[no_mangle]
 pub unsafe extern "C" fn real_get_native_glyph(
     mut pNode: *mut libc::c_void,
-    mut index: u32,
-) -> u16 {
+    mut index: libc::c_uint,
+) -> uint16_t {
     let mut node: *mut memory_word = pNode as *mut memory_word;
     let mut locations: *mut FixedPoint = (*node.offset(5)).ptr as *mut FixedPoint;
-    let mut glyphIDs: *mut u16 =
-        locations.offset((*node.offset(4)).b16.s0 as i32 as isize) as *mut u16;
-    if index >= (*node.offset(4)).b16.s0 as u32 {
-        0_u16
+    let mut glyphIDs: *mut uint16_t =
+        locations.offset((*node.offset(4)).b16.s0 as libc::c_int as isize) as *mut uint16_t;
+    if index >= (*node.offset(4)).b16.s0 as libc::c_uint {
+        return 0i32 as uint16_t;
     } else {
-        *glyphIDs.offset(index as isize)
-    }
+        return *glyphIDs.offset(index as isize);
+    };
 }
 #[no_mangle]
 pub unsafe extern "C" fn store_justified_native_glyphs(mut pNode: *mut libc::c_void) {
     let mut node: *mut memory_word = pNode as *mut memory_word;
-    let mut f: u32 = (*node.offset(4)).b16.s2 as u32;
+    let mut f: libc::c_uint = (*node.offset(4)).b16.s2 as libc::c_uint;
     /* separate Mac-only codepath for AAT fonts */
+    if *font_area.offset(f as isize) as libc::c_uint == 0xffffu32 {
+        DoAATLayout(node as *mut libc::c_void, 1i32);
+        return;
+    }
     /* save desired width */
-    let mut savedWidth: i32 = (*node.offset(1)).b32.s1;
+    let mut savedWidth: libc::c_int = (*node.offset(1)).b32.s1;
     measure_native_node(node as *mut libc::c_void, 0i32);
     if (*node.offset(1)).b32.s1 != savedWidth {
         /* see how much adjustment is needed overall */
-        let mut justAmount: f64 = Fix2D(savedWidth - (*node.offset(1)).b32.s1);
+        let mut justAmount: libc::c_double = Fix2D(savedWidth - (*node.offset(1)).b32.s1);
         /* apply justification to spaces (or if there are none, distribute it to all glyphs as a last resort) */
         let mut locations: *mut FixedPoint = (*node.offset(5)).ptr as *mut FixedPoint;
-        let mut glyphIDs: *mut u16 =
-            locations.offset((*node.offset(4)).b16.s0 as i32 as isize) as *mut u16;
-        let mut glyphCount: i32 = (*node.offset(4)).b16.s0 as i32;
-        let mut spaceCount: i32 = 0i32;
-        let mut i: i32 = 0;
-        let mut spaceGlyph: i32 = map_char_to_glyph(f as i32, ' ' as i32);
+        let mut glyphIDs: *mut uint16_t =
+            locations.offset((*node.offset(4)).b16.s0 as libc::c_int as isize) as *mut uint16_t;
+        let mut glyphCount: libc::c_int = (*node.offset(4)).b16.s0 as libc::c_int;
+        let mut spaceCount: libc::c_int = 0i32;
+        let mut i: libc::c_int = 0;
+        let mut spaceGlyph: libc::c_int = map_char_to_glyph(f as int32_t, ' ' as i32);
         i = 0i32;
         while i < glyphCount {
-            if *glyphIDs.offset(i as isize) as i32 == spaceGlyph {
+            if *glyphIDs.offset(i as isize) as libc::c_int == spaceGlyph {
                 spaceCount += 1
             }
             i += 1
         }
         if spaceCount > 0i32 {
-            let mut adjustment: f64 = 0i32 as f64;
-            let mut spaceIndex: i32 = 0i32;
+            let mut adjustment: libc::c_double = 0i32 as libc::c_double;
+            let mut spaceIndex: libc::c_int = 0i32;
             i = 0i32;
             while i < glyphCount {
                 (*locations.offset(i as isize)).x =
                     D2Fix(Fix2D((*locations.offset(i as isize)).x) + adjustment);
-                if *glyphIDs.offset(i as isize) as i32 == spaceGlyph {
+                if *glyphIDs.offset(i as isize) as libc::c_int == spaceGlyph {
                     spaceIndex += 1;
-                    adjustment = justAmount * spaceIndex as f64 / spaceCount as f64
+                    adjustment =
+                        justAmount * spaceIndex as libc::c_double / spaceCount as libc::c_double
                 }
                 i += 1
             }
@@ -2219,7 +4116,7 @@ pub unsafe extern "C" fn store_justified_native_glyphs(mut pNode: *mut libc::c_v
             while i < glyphCount {
                 (*locations.offset(i as isize)).x = D2Fix(
                     Fix2D((*locations.offset(i as isize)).x)
-                        + justAmount * i as f64 / (glyphCount - 1i32) as f64,
+                        + justAmount * i as libc::c_double / (glyphCount - 1i32) as libc::c_double,
                 );
                 i += 1
             }
@@ -2230,112 +4127,119 @@ pub unsafe extern "C" fn store_justified_native_glyphs(mut pNode: *mut libc::c_v
 #[no_mangle]
 pub unsafe extern "C" fn measure_native_node(
     mut pNode: *mut libc::c_void,
-    mut use_glyph_metrics: i32,
+    mut use_glyph_metrics: libc::c_int,
 ) {
     let mut node: *mut memory_word = pNode as *mut memory_word;
-    let mut txtLen: i32 = (*node.offset(4)).b16.s1 as i32;
-    let mut txtPtr: *mut u16 = node.offset(6) as *mut u16;
-    let mut f: u32 = (*node.offset(4)).b16.s2 as u32;
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32 {
+    let mut txtLen: libc::c_int = (*node.offset(4)).b16.s1 as libc::c_int;
+    let mut txtPtr: *mut uint16_t = node.offset(6) as *mut uint16_t;
+    let mut f: libc::c_uint = (*node.offset(4)).b16.s2 as libc::c_uint;
+    if *font_area.offset(f as isize) as libc::c_uint == 0xffffu32 {
+        /* we're using this font in AAT mode, so font_layout_engine[f] is actually a CFDictionaryRef */
+        DoAATLayout(node as *mut libc::c_void, 0i32);
+    } else if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
         /* using this font in OT Layout mode, so font_layout_engine[f] is actually a XeTeXLayoutEngine */
         let mut engine: XeTeXLayoutEngine =
             *font_layout_engine.offset(f as isize) as XeTeXLayoutEngine;
         let mut locations: *mut FixedPoint = 0 as *mut FixedPoint;
-        let mut glyphIDs: *mut u16 = 0 as *mut u16;
+        let mut glyphIDs: *mut uint16_t = 0 as *mut uint16_t;
         let mut glyphAdvances: *mut Fixed = 0 as *mut Fixed;
-        let mut totalGlyphCount: i32 = 0i32;
+        let mut totalGlyphCount: libc::c_int = 0i32;
         /* need to find direction runs within the text, and call layoutChars separately for each */
-        let mut dir: icu::UBiDiDirection = icu::UBIDI_LTR;
+        let mut dir: UBiDiDirection = UBIDI_LTR;
         let mut glyph_info: *mut libc::c_void = 0 as *mut libc::c_void;
         static mut positions: *mut FloatPoint = 0 as *const FloatPoint as *mut FloatPoint;
-        static mut advances: *mut f32 = 0 as *const f32 as *mut f32;
-        static mut glyphs: *mut u32 = 0 as *const u32 as *mut u32;
-        let mut pBiDi: *mut icu::UBiDi = icu::ubidi_open();
-        let mut errorCode: icu::UErrorCode = icu::U_ZERO_ERROR;
-        icu::ubidi_setPara(
+        static mut advances: *mut libc::c_float = 0 as *const libc::c_float as *mut libc::c_float;
+        static mut glyphs: *mut uint32_t = 0 as *const uint32_t as *mut uint32_t;
+        let mut pBiDi: *mut UBiDi = ubidi_open_64();
+        let mut errorCode: UErrorCode = U_ZERO_ERROR;
+        ubidi_setPara_64(
             pBiDi,
-            txtPtr as *const icu::UChar,
+            txtPtr as *const UChar,
             txtLen,
-            getDefaultDirection(engine) as icu::UBiDiLevel,
-            0 as *mut icu::UBiDiLevel,
+            getDefaultDirection(engine) as UBiDiLevel,
+            0 as *mut UBiDiLevel,
             &mut errorCode,
         );
-        dir = icu::ubidi_getDirection(pBiDi);
-        if dir as u32 == icu::UBIDI_MIXED as i32 as u32 {
+        dir = ubidi_getDirection_64(pBiDi);
+        if dir as libc::c_uint == UBIDI_MIXED as libc::c_int as libc::c_uint {
             /* we actually do the layout twice here, once to count glyphs and then again to get them;
                which is inefficient, but i figure that MIXED is a relatively rare occurrence, so i can't be
                bothered to deal with the memory reallocation headache of doing it differently
             */
-            let mut nRuns: i32 = icu::ubidi_countRuns(pBiDi, &mut errorCode);
-            let mut width: f64 = 0i32 as f64;
-            let mut i: i32 = 0;
-            let mut runIndex: i32 = 0;
-            let mut logicalStart: i32 = 0;
-            let mut length: i32 = 0;
+            let mut nRuns: libc::c_int = ubidi_countRuns_64(pBiDi, &mut errorCode);
+            let mut width: libc::c_double = 0i32 as libc::c_double;
+            let mut i: libc::c_int = 0;
+            let mut runIndex: libc::c_int = 0;
+            let mut logicalStart: int32_t = 0;
+            let mut length: int32_t = 0;
             runIndex = 0i32;
             while runIndex < nRuns {
-                dir = icu::ubidi_getVisualRun(pBiDi, runIndex, &mut logicalStart, &mut length);
+                dir = ubidi_getVisualRun_64(pBiDi, runIndex, &mut logicalStart, &mut length);
                 totalGlyphCount += layoutChars(
                     engine,
                     txtPtr,
                     logicalStart,
                     length,
                     txtLen,
-                    dir as u32 == icu::UBIDI_RTL as i32 as u32,
+                    dir as libc::c_uint == UBIDI_RTL as libc::c_int as libc::c_uint,
                 );
                 runIndex += 1
             }
             if totalGlyphCount > 0i32 {
-                let mut x: f64 = 0.;
-                let mut y: f64 = 0.;
+                let mut x: libc::c_double = 0.;
+                let mut y: libc::c_double = 0.;
                 glyph_info = xcalloc(totalGlyphCount as size_t, 10i32 as size_t);
                 locations = glyph_info as *mut FixedPoint;
-                glyphIDs = locations.offset(totalGlyphCount as isize) as *mut u16;
+                glyphIDs = locations.offset(totalGlyphCount as isize) as *mut uint16_t;
                 glyphAdvances = xcalloc(
                     totalGlyphCount as size_t,
-                    ::std::mem::size_of::<Fixed>() as u64,
+                    ::std::mem::size_of::<Fixed>() as libc::c_ulong,
                 ) as *mut Fixed;
                 totalGlyphCount = 0i32;
                 y = 0.0f64;
                 x = y;
                 runIndex = 0i32;
                 while runIndex < nRuns {
-                    let mut nGlyphs: i32 = 0;
-                    dir = icu::ubidi_getVisualRun(pBiDi, runIndex, &mut logicalStart, &mut length);
+                    let mut nGlyphs: libc::c_int = 0;
+                    dir = ubidi_getVisualRun_64(pBiDi, runIndex, &mut logicalStart, &mut length);
                     nGlyphs = layoutChars(
                         engine,
                         txtPtr,
                         logicalStart,
                         length,
                         txtLen,
-                        dir as u32 == icu::UBIDI_RTL as i32 as u32,
+                        dir as libc::c_uint == UBIDI_RTL as libc::c_int as libc::c_uint,
                     );
-                    glyphs =
-                        xcalloc(nGlyphs as size_t, ::std::mem::size_of::<u32>() as u64) as *mut u32;
+                    glyphs = xcalloc(
+                        nGlyphs as size_t,
+                        ::std::mem::size_of::<uint32_t>() as libc::c_ulong,
+                    ) as *mut uint32_t;
                     positions = xcalloc(
                         (nGlyphs + 1i32) as size_t,
-                        ::std::mem::size_of::<FloatPoint>() as u64,
+                        ::std::mem::size_of::<FloatPoint>() as libc::c_ulong,
                     ) as *mut FloatPoint;
-                    advances =
-                        xcalloc(nGlyphs as size_t, ::std::mem::size_of::<f32>() as u64) as *mut f32;
+                    advances = xcalloc(
+                        nGlyphs as size_t,
+                        ::std::mem::size_of::<libc::c_float>() as libc::c_ulong,
+                    ) as *mut libc::c_float;
                     getGlyphs(engine, glyphs);
                     getGlyphAdvances(engine, advances);
                     getGlyphPositions(engine, positions);
                     i = 0i32;
                     while i < nGlyphs {
                         *glyphIDs.offset(totalGlyphCount as isize) =
-                            *glyphs.offset(i as isize) as u16;
+                            *glyphs.offset(i as isize) as uint16_t;
                         (*locations.offset(totalGlyphCount as isize)).x =
-                            D2Fix((*positions.offset(i as isize)).x as f64 + x);
+                            D2Fix((*positions.offset(i as isize)).x as libc::c_double + x);
                         (*locations.offset(totalGlyphCount as isize)).y =
-                            D2Fix((*positions.offset(i as isize)).y as f64 + y);
+                            D2Fix((*positions.offset(i as isize)).y as libc::c_double + y);
                         *glyphAdvances.offset(totalGlyphCount as isize) =
-                            D2Fix(*advances.offset(i as isize) as f64);
+                            D2Fix(*advances.offset(i as isize) as libc::c_double);
                         totalGlyphCount += 1;
                         i += 1
                     }
-                    x += (*positions.offset(nGlyphs as isize)).x as f64;
-                    y += (*positions.offset(nGlyphs as isize)).y as f64;
+                    x += (*positions.offset(nGlyphs as isize)).x as libc::c_double;
+                    y += (*positions.offset(nGlyphs as isize)).y as libc::c_double;
                     free(glyphs as *mut libc::c_void);
                     free(positions as *mut libc::c_void);
                     free(advances as *mut libc::c_void);
@@ -2344,69 +4248,69 @@ pub unsafe extern "C" fn measure_native_node(
                 width = x
             }
             (*node.offset(1)).b32.s1 = D2Fix(width);
-            (*node.offset(4)).b16.s0 = totalGlyphCount as u16;
+            (*node.offset(4)).b16.s0 = totalGlyphCount as uint16_t;
             let ref mut fresh29 = (*node.offset(5)).ptr;
             *fresh29 = glyph_info
         } else {
-            let mut width_0: f64 = 0i32 as f64;
+            let mut width_0: libc::c_double = 0i32 as libc::c_double;
             totalGlyphCount = layoutChars(
                 engine,
                 txtPtr,
                 0i32,
                 txtLen,
                 txtLen,
-                dir as u32 == icu::UBIDI_RTL as i32 as u32,
+                dir as libc::c_uint == UBIDI_RTL as libc::c_int as libc::c_uint,
             );
             glyphs = xcalloc(
                 totalGlyphCount as size_t,
-                ::std::mem::size_of::<u32>() as u64,
-            ) as *mut u32;
+                ::std::mem::size_of::<uint32_t>() as libc::c_ulong,
+            ) as *mut uint32_t;
             positions = xcalloc(
                 (totalGlyphCount + 1i32) as size_t,
-                ::std::mem::size_of::<FloatPoint>() as u64,
+                ::std::mem::size_of::<FloatPoint>() as libc::c_ulong,
             ) as *mut FloatPoint;
             advances = xcalloc(
                 totalGlyphCount as size_t,
-                ::std::mem::size_of::<f32>() as u64,
-            ) as *mut f32;
+                ::std::mem::size_of::<libc::c_float>() as libc::c_ulong,
+            ) as *mut libc::c_float;
             getGlyphs(engine, glyphs);
             getGlyphAdvances(engine, advances);
             getGlyphPositions(engine, positions);
             if totalGlyphCount > 0i32 {
-                let mut i_0: i32 = 0;
+                let mut i_0: libc::c_int = 0;
                 glyph_info = xcalloc(totalGlyphCount as size_t, 10i32 as size_t);
                 locations = glyph_info as *mut FixedPoint;
-                glyphIDs = locations.offset(totalGlyphCount as isize) as *mut u16;
+                glyphIDs = locations.offset(totalGlyphCount as isize) as *mut uint16_t;
                 glyphAdvances = xcalloc(
                     totalGlyphCount as size_t,
-                    ::std::mem::size_of::<Fixed>() as u64,
+                    ::std::mem::size_of::<Fixed>() as libc::c_ulong,
                 ) as *mut Fixed;
                 i_0 = 0i32;
                 while i_0 < totalGlyphCount {
-                    *glyphIDs.offset(i_0 as isize) = *glyphs.offset(i_0 as isize) as u16;
+                    *glyphIDs.offset(i_0 as isize) = *glyphs.offset(i_0 as isize) as uint16_t;
                     *glyphAdvances.offset(i_0 as isize) =
-                        D2Fix(*advances.offset(i_0 as isize) as f64);
+                        D2Fix(*advances.offset(i_0 as isize) as libc::c_double);
                     (*locations.offset(i_0 as isize)).x =
-                        D2Fix((*positions.offset(i_0 as isize)).x as f64);
+                        D2Fix((*positions.offset(i_0 as isize)).x as libc::c_double);
                     (*locations.offset(i_0 as isize)).y =
-                        D2Fix((*positions.offset(i_0 as isize)).y as f64);
+                        D2Fix((*positions.offset(i_0 as isize)).y as libc::c_double);
                     i_0 += 1
                 }
-                width_0 = (*positions.offset(totalGlyphCount as isize)).x as f64
+                width_0 = (*positions.offset(totalGlyphCount as isize)).x as libc::c_double
             }
             (*node.offset(1)).b32.s1 = D2Fix(width_0);
-            (*node.offset(4)).b16.s0 = totalGlyphCount as u16;
+            (*node.offset(4)).b16.s0 = totalGlyphCount as uint16_t;
             let ref mut fresh30 = (*node.offset(5)).ptr;
             *fresh30 = glyph_info;
             free(glyphs as *mut libc::c_void);
             free(positions as *mut libc::c_void);
             free(advances as *mut libc::c_void);
         }
-        icu::ubidi_close(pBiDi);
+        ubidi_close_64(pBiDi);
         if *font_letter_space.offset(f as isize) != 0i32 {
             let mut lsDelta: Fixed = 0i32;
             let mut lsUnit: Fixed = *font_letter_space.offset(f as isize);
-            let mut i_1: i32 = 0;
+            let mut i_1: libc::c_int = 0;
             i_1 = 0i32;
             while i_1 < totalGlyphCount {
                 if *glyphAdvances.offset(i_1 as isize) == 0i32 && lsDelta != 0i32 {
@@ -2425,9 +4329,12 @@ pub unsafe extern "C" fn measure_native_node(
         }
         free(glyphAdvances as *mut libc::c_void);
     } else {
-        _tt_abort(b"bad native font flag in `measure_native_node`\x00" as *const u8 as *const i8);
+        _tt_abort(
+            b"bad native font flag in `measure_native_node`\x00" as *const u8
+                as *const libc::c_char,
+        );
     }
-    if use_glyph_metrics == 0i32 || (*node.offset(4)).b16.s0 as i32 == 0i32 {
+    if use_glyph_metrics == 0i32 || (*node.offset(4)).b16.s0 as libc::c_int == 0i32 {
         /* for efficiency, height and depth are the font's ascent/descent,
         not true values based on the actual content of the word,
         unless use_glyph_metrics is non-zero */
@@ -2436,31 +4343,40 @@ pub unsafe extern "C" fn measure_native_node(
     } else {
         /* this iterates over the glyph data whether it comes from AAT or OT layout */
         let mut locations_0: *mut FixedPoint = (*node.offset(5)).ptr as *mut FixedPoint; /* NB negative is upwards in locations[].y! */
-        let mut glyphIDs_0: *mut u16 =
-            locations_0.offset((*node.offset(4)).b16.s0 as i32 as isize) as *mut u16;
-        let mut yMin: f32 = 65536.0f64 as f32;
-        let mut yMax: f32 = -65536.0f64 as f32;
-        let mut i_2: i32 = 0;
+        let mut glyphIDs_0: *mut uint16_t =
+            locations_0.offset((*node.offset(4)).b16.s0 as libc::c_int as isize) as *mut uint16_t;
+        let mut yMin: libc::c_float = 65536.0f64 as libc::c_float;
+        let mut yMax: libc::c_float = -65536.0f64 as libc::c_float;
+        let mut i_2: libc::c_int = 0;
         i_2 = 0i32;
-        while i_2 < (*node.offset(4)).b16.s0 as i32 {
-            let mut ht: f32 = 0.;
-            let mut dp: f32 = 0.;
-            let mut y_0: f32 = Fix2D(-(*locations_0.offset(i_2 as isize)).y) as f32;
+        while i_2 < (*node.offset(4)).b16.s0 as libc::c_int {
+            let mut ht: libc::c_float = 0.;
+            let mut dp: libc::c_float = 0.;
+            let mut y_0: libc::c_float =
+                Fix2D(-(*locations_0.offset(i_2 as isize)).y) as libc::c_float;
             let mut bbox: GlyphBBox = GlyphBBox {
                 xMin: 0.,
                 yMin: 0.,
                 xMax: 0.,
                 yMax: 0.,
             };
-            if getCachedGlyphBBox(f as u16, *glyphIDs_0.offset(i_2 as isize), &mut bbox) == 0i32 {
-                if *font_area.offset(f as isize) as u32 == 0xfffeu32 {
+            if getCachedGlyphBBox(f as uint16_t, *glyphIDs_0.offset(i_2 as isize), &mut bbox)
+                == 0i32
+            {
+                if *font_area.offset(f as isize) as libc::c_uint == 0xffffu32 {
+                    GetGlyphBBox_AAT(
+                        *font_layout_engine.offset(f as isize) as CFDictionaryRef,
+                        *glyphIDs_0.offset(i_2 as isize),
+                        &mut bbox,
+                    );
+                } else if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
                     getGlyphBounds(
                         *font_layout_engine.offset(f as isize) as XeTeXLayoutEngine,
-                        *glyphIDs_0.offset(i_2 as isize) as u32,
+                        *glyphIDs_0.offset(i_2 as isize) as uint32_t,
                         &mut bbox,
                     );
                 }
-                cacheGlyphBBox(f as u16, *glyphIDs_0.offset(i_2 as isize), &mut bbox);
+                cacheGlyphBBox(f as uint16_t, *glyphIDs_0.offset(i_2 as isize), &mut bbox);
             }
             ht = bbox.yMax;
             dp = -bbox.yMin;
@@ -2472,182 +4388,481 @@ pub unsafe extern "C" fn measure_native_node(
             }
             i_2 += 1
         }
-        (*node.offset(3)).b32.s1 = D2Fix(yMax as f64);
-        (*node.offset(2)).b32.s1 = -D2Fix(yMin as f64)
+        (*node.offset(3)).b32.s1 = D2Fix(yMax as libc::c_double);
+        (*node.offset(2)).b32.s1 = -D2Fix(yMin as libc::c_double)
     };
 }
 #[no_mangle]
 pub unsafe extern "C" fn real_get_native_italic_correction(mut pNode: *mut libc::c_void) -> Fixed {
     let mut node: *mut memory_word = pNode as *mut memory_word;
-    let mut f: u32 = (*node.offset(4)).b16.s2 as u32;
-    let mut n: u32 = (*node.offset(4)).b16.s0 as u32;
-    if n > 0_u32 {
+    let mut f: libc::c_uint = (*node.offset(4)).b16.s2 as libc::c_uint;
+    let mut n: libc::c_uint = (*node.offset(4)).b16.s0 as libc::c_uint;
+    if n > 0i32 as libc::c_uint {
         let mut locations: *mut FixedPoint = (*node.offset(5)).ptr as *mut FixedPoint;
-        let mut glyphIDs: *mut u16 = locations.offset(n as isize) as *mut u16;
-        if *font_area.offset(f as isize) as u32 == 0xfffeu32 {
+        let mut glyphIDs: *mut uint16_t = locations.offset(n as isize) as *mut uint16_t;
+        if *font_area.offset(f as isize) as libc::c_uint == 0xffffu32 {
+            return D2Fix(GetGlyphItalCorr_AAT(
+                *font_layout_engine.offset(f as isize) as CFDictionaryRef,
+                *glyphIDs.offset(n.wrapping_sub(1i32 as libc::c_uint) as isize),
+            )) + *font_letter_space.offset(f as isize);
+        }
+        if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
             return D2Fix(getGlyphItalCorr(
                 *font_layout_engine.offset(f as isize) as XeTeXLayoutEngine,
-                *glyphIDs.offset(n.wrapping_sub(1_u32) as isize) as u32,
-            ) as f64)
+                *glyphIDs.offset(n.wrapping_sub(1i32 as libc::c_uint) as isize) as uint32_t,
+            ) as libc::c_double)
                 + *font_letter_space.offset(f as isize);
         }
     }
-    0i32
+    return 0i32;
 }
 #[no_mangle]
 pub unsafe extern "C" fn real_get_native_glyph_italic_correction(
     mut pNode: *mut libc::c_void,
 ) -> Fixed {
     let mut node: *mut memory_word = pNode as *mut memory_word;
-    let mut gid: u16 = (*node.offset(4)).b16.s1;
-    let mut f: u32 = (*node.offset(4)).b16.s2 as u32;
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32 {
+    let mut gid: uint16_t = (*node.offset(4)).b16.s1;
+    let mut f: libc::c_uint = (*node.offset(4)).b16.s2 as libc::c_uint;
+    if *font_area.offset(f as isize) as libc::c_uint == 0xffffu32 {
+        return D2Fix(GetGlyphItalCorr_AAT(
+            *font_layout_engine.offset(f as isize) as CFDictionaryRef,
+            gid,
+        ));
+    }
+    if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
         return D2Fix(getGlyphItalCorr(
             *font_layout_engine.offset(f as isize) as XeTeXLayoutEngine,
-            gid as u32,
-        ) as f64);
+            gid as uint32_t,
+        ) as libc::c_double);
     }
-    0i32
+    return 0i32;
     /* can't actually happen */
 }
 #[no_mangle]
 pub unsafe extern "C" fn measure_native_glyph(
     mut pNode: *mut libc::c_void,
-    mut use_glyph_metrics: i32,
+    mut use_glyph_metrics: libc::c_int,
 ) {
     let mut node: *mut memory_word = pNode as *mut memory_word;
-    let mut gid: u16 = (*node.offset(4)).b16.s1;
-    let mut f: u32 = (*node.offset(4)).b16.s2 as u32;
-    let mut ht: f32 = 0.0f64 as f32;
-    let mut dp: f32 = 0.0f64 as f32;
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32 {
+    let mut gid: uint16_t = (*node.offset(4)).b16.s1;
+    let mut f: libc::c_uint = (*node.offset(4)).b16.s2 as libc::c_uint;
+    let mut ht: libc::c_float = 0.0f64 as libc::c_float;
+    let mut dp: libc::c_float = 0.0f64 as libc::c_float;
+    if *font_area.offset(f as isize) as libc::c_uint == 0xffffu32 {
+        let mut attributes: CFDictionaryRef =
+            *font_layout_engine.offset(f as isize) as CFDictionaryRef;
+        (*node.offset(1)).b32.s1 = D2Fix(GetGlyphWidth_AAT(attributes, gid));
+        if use_glyph_metrics != 0 {
+            GetGlyphHeightDepth_AAT(attributes, gid, &mut ht, &mut dp);
+        }
+    } else if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
         let mut engine: XeTeXLayoutEngine =
             *font_layout_engine.offset(f as isize) as XeTeXLayoutEngine;
         let mut fontInst: XeTeXFont = getFont(engine);
-        (*node.offset(1)).b32.s1 = D2Fix(getGlyphWidth(fontInst, gid as u32) as f64);
+        (*node.offset(1)).b32.s1 =
+            D2Fix(getGlyphWidth(fontInst, gid as uint32_t) as libc::c_double);
         if use_glyph_metrics != 0 {
-            getGlyphHeightDepth(engine, gid as u32, &mut ht, &mut dp);
+            getGlyphHeightDepth(engine, gid as uint32_t, &mut ht, &mut dp);
         }
     } else {
-        _tt_abort(b"bad native font flag in `measure_native_glyph`\x00" as *const u8 as *const i8);
+        _tt_abort(
+            b"bad native font flag in `measure_native_glyph`\x00" as *const u8
+                as *const libc::c_char,
+        );
     }
     if use_glyph_metrics != 0 {
-        (*node.offset(3)).b32.s1 = D2Fix(ht as f64);
-        (*node.offset(2)).b32.s1 = D2Fix(dp as f64)
+        (*node.offset(3)).b32.s1 = D2Fix(ht as libc::c_double);
+        (*node.offset(2)).b32.s1 = D2Fix(dp as libc::c_double)
     } else {
         (*node.offset(3)).b32.s1 = *height_base.offset(f as isize);
         (*node.offset(2)).b32.s1 = *depth_base.offset(f as isize)
     };
 }
 #[no_mangle]
-pub unsafe extern "C" fn map_char_to_glyph(mut font: i32, mut ch: i32) -> i32 {
+pub unsafe extern "C" fn map_char_to_glyph(mut font: int32_t, mut ch: int32_t) -> int32_t {
     if ch > 0x10ffffi32 || ch >= 0xd800i32 && ch <= 0xdfffi32 {
         return 0i32;
     }
-    if *font_area.offset(font as isize) as u32 == 0xfffeu32 {
+    if *font_area.offset(font as isize) as libc::c_uint == 0xffffu32 {
+        return MapCharToGlyph_AAT(
+            *font_layout_engine.offset(font as isize) as CFDictionaryRef,
+            ch as UInt32,
+        );
+    } else if *font_area.offset(font as isize) as libc::c_uint == 0xfffeu32 {
         return mapCharToGlyph(
             *font_layout_engine.offset(font as isize) as XeTeXLayoutEngine,
-            ch as u32,
-        ) as i32;
+            ch as uint32_t,
+        ) as int32_t;
     } else {
-        _tt_abort(b"bad native font flag in `map_char_to_glyph`\x00" as *const u8 as *const i8);
+        _tt_abort(
+            b"bad native font flag in `map_char_to_glyph`\x00" as *const u8 as *const libc::c_char,
+        );
     };
 }
 #[no_mangle]
-pub unsafe extern "C" fn map_glyph_to_index(mut font: i32) -> i32
+pub unsafe extern "C" fn map_glyph_to_index(mut font: int32_t) -> int32_t
 /* glyph name is at name_of_file */ {
-    if *font_area.offset(font as isize) as u32 == 0xfffeu32 {
+    if *font_area.offset(font as isize) as libc::c_uint == 0xffffu32 {
+        return MapGlyphToIndex_AAT(
+            *font_layout_engine.offset(font as isize) as CFDictionaryRef,
+            name_of_file,
+        );
+    } else if *font_area.offset(font as isize) as libc::c_uint == 0xfffeu32 {
         return mapGlyphToIndex(
             *font_layout_engine.offset(font as isize) as XeTeXLayoutEngine,
             name_of_file,
         );
     } else {
-        _tt_abort(b"bad native font flag in `map_glyph_to_index`\x00" as *const u8 as *const i8);
+        _tt_abort(
+            b"bad native font flag in `map_glyph_to_index`\x00" as *const u8 as *const libc::c_char,
+        );
     };
 }
 #[no_mangle]
-pub unsafe extern "C" fn get_font_char_range(mut font: i32, mut first: i32) -> i32 {
-    if *font_area.offset(font as isize) as u32 == 0xfffeu32 {
+pub unsafe extern "C" fn get_font_char_range(mut font: int32_t, mut first: libc::c_int) -> int32_t {
+    if *font_area.offset(font as isize) as libc::c_uint == 0xffffu32 {
+        return GetFontCharRange_AAT(
+            *font_layout_engine.offset(font as isize) as CFDictionaryRef,
+            first,
+        );
+    } else if *font_area.offset(font as isize) as libc::c_uint == 0xfffeu32 {
         return getFontCharRange(
             *font_layout_engine.offset(font as isize) as XeTeXLayoutEngine,
             first,
         );
     } else {
-        _tt_abort(b"bad native font flag in `get_font_char_range\'`\x00" as *const u8 as *const i8);
+        _tt_abort(
+            b"bad native font flag in `get_font_char_range\'`\x00" as *const u8
+                as *const libc::c_char,
+        );
     };
 }
 #[no_mangle]
-pub unsafe extern "C" fn D2Fix(mut d: f64) -> Fixed {
-    let rval: Fixed = (d * 65536.0f64 + 0.5f64) as i32;
-    rval
+pub unsafe extern "C" fn D2Fix(mut d: libc::c_double) -> Fixed {
+    let mut rval: Fixed = (d * 65536.0f64 + 0.5f64) as libc::c_int;
+    return rval;
 }
 #[no_mangle]
-pub unsafe extern "C" fn Fix2D(mut f: Fixed) -> f64 {
-    f as f64 / 65536.
+pub unsafe extern "C" fn Fix2D(mut f: Fixed) -> libc::c_double {
+    let mut rval: libc::c_double = f as libc::c_double / 65536.0f64;
+    return rval;
 }
 /* the metrics params here are really TeX 'scaled' (or MacOS 'Fixed') values, but that typedef isn't available every place this is included */
 /* these are here, not XeTeX_mac.c, because we need stubs on other platforms */
 #[no_mangle]
 pub unsafe extern "C" fn aat_get_font_metrics(
     mut attributes: CFDictionaryRef,
-    mut ascent: *mut i32,
-    mut descent: *mut i32,
-    mut xheight: *mut i32,
-    mut capheight: *mut i32,
-    mut slant: *mut i32,
+    mut ascent: *mut int32_t,
+    mut descent: *mut int32_t,
+    mut xheight: *mut int32_t,
+    mut capheight: *mut int32_t,
+    mut slant: *mut int32_t,
 ) {
+    let mut font: CTFontRef = fontFromAttributes(attributes);
+    *ascent = D2Fix(CTFontGetAscent(font));
+    *descent = D2Fix(CTFontGetDescent(font));
+    *xheight = D2Fix(CTFontGetXHeight(font));
+    *capheight = D2Fix(CTFontGetCapHeight(font));
+    *slant = D2Fix(tan(-CTFontGetSlantAngle(font)
+        * 3.14159265358979323846264338327950288f64
+        / 180.0f64));
 }
 #[no_mangle]
-pub unsafe extern "C" fn aat_font_get(mut what: i32, mut attributes: CFDictionaryRef) -> i32 {
-    -1
+pub unsafe extern "C" fn aat_font_get(
+    mut what: libc::c_int,
+    mut attributes: CFDictionaryRef,
+) -> libc::c_int {
+    let mut rval: libc::c_int = -1i32;
+    let mut font: CTFontRef = fontFromAttributes(attributes);
+    let mut list: CFArrayRef = 0 as *const __CFArray;
+    match what {
+        1 => rval = CTFontGetGlyphCount(font) as libc::c_int,
+        8 => {
+            list = CTFontCopyFeatures(font);
+            if !list.is_null() {
+                rval = CFArrayGetCount(list) as libc::c_int;
+                CFRelease(list as CFTypeRef);
+            }
+        }
+        _ => {}
+    }
+    return rval;
 }
 #[no_mangle]
 pub unsafe extern "C" fn aat_font_get_1(
-    mut what: i32,
+    mut what: libc::c_int,
     mut attributes: CFDictionaryRef,
-    mut param: i32,
-) -> i32 {
-    -1
+    mut param: libc::c_int,
+) -> libc::c_int {
+    let mut rval: libc::c_int = -1i32;
+    let mut font: CTFontRef = fontFromAttributes(attributes);
+    match what {
+        9 => {
+            let mut features: CFArrayRef = CTFontCopyFeatures(font);
+            if !features.is_null() {
+                if CFArrayGetCount(features) > param as libc::c_long {
+                    let mut feature: CFDictionaryRef =
+                        CFArrayGetValueAtIndex(features, param as CFIndex) as CFDictionaryRef;
+                    let mut identifier: CFNumberRef = CFDictionaryGetValue(
+                        feature,
+                        kCTFontFeatureTypeIdentifierKey as *const libc::c_void,
+                    ) as CFNumberRef;
+                    if !identifier.is_null() {
+                        CFNumberGetValue(
+                            identifier,
+                            kCFNumberIntType as libc::c_int as CFNumberType,
+                            &mut rval as *mut libc::c_int as *mut libc::c_void,
+                        );
+                    }
+                }
+                CFRelease(features as CFTypeRef);
+            }
+        }
+        11 => {
+            let mut features_0: CFArrayRef = CTFontCopyFeatures(font);
+            if !features_0.is_null() {
+                let mut value: CFBooleanRef = 0 as *const __CFBoolean;
+                let mut feature_0: CFDictionaryRef = findDictionaryInArrayWithIdentifier(
+                    features_0,
+                    kCTFontFeatureTypeIdentifierKey as *const libc::c_void,
+                    param,
+                );
+                let mut found: Boolean = CFDictionaryGetValueIfPresent(
+                    feature_0,
+                    kCTFontFeatureTypeExclusiveKey as *const libc::c_void,
+                    &mut value as *mut CFBooleanRef as *mut *const libc::c_void,
+                );
+                if found != 0 {
+                    rval = CFBooleanGetValue(value) as libc::c_int
+                }
+                CFRelease(features_0 as CFTypeRef);
+            }
+        }
+        12 => {
+            let mut features_1: CFArrayRef = CTFontCopyFeatures(font);
+            if !features_1.is_null() {
+                let mut feature_1: CFDictionaryRef = findDictionaryInArrayWithIdentifier(
+                    features_1,
+                    kCTFontFeatureTypeIdentifierKey as *const libc::c_void,
+                    param,
+                );
+                if !feature_1.is_null() {
+                    let mut selectors: CFArrayRef = CFDictionaryGetValue(
+                        feature_1,
+                        kCTFontFeatureTypeSelectorsKey as *const libc::c_void,
+                    ) as CFArrayRef;
+                    if !selectors.is_null() {
+                        rval = CFArrayGetCount(selectors) as libc::c_int
+                    }
+                }
+                CFRelease(features_1 as CFTypeRef);
+            }
+        }
+        _ => {}
+    }
+    return rval;
 }
 #[no_mangle]
 pub unsafe extern "C" fn aat_font_get_2(
-    mut what: i32,
+    mut what: libc::c_int,
     mut attributes: CFDictionaryRef,
-    mut param1: i32,
-    mut param2: i32,
-) -> i32 {
-    -1
+    mut param1: libc::c_int,
+    mut param2: libc::c_int,
+) -> libc::c_int {
+    let mut rval: libc::c_int = -1i32;
+    let mut font: CTFontRef = fontFromAttributes(attributes);
+    let mut features: CFArrayRef = CTFontCopyFeatures(font);
+    if !features.is_null() {
+        let mut feature: CFDictionaryRef = findDictionaryInArrayWithIdentifier(
+            features,
+            kCTFontFeatureTypeIdentifierKey as *const libc::c_void,
+            param1,
+        );
+        if !feature.is_null() {
+            let mut selectors: CFArrayRef = CFDictionaryGetValue(
+                feature,
+                kCTFontFeatureTypeSelectorsKey as *const libc::c_void,
+            ) as CFArrayRef;
+            if !selectors.is_null() {
+                let mut selector: CFDictionaryRef = 0 as *const __CFDictionary;
+                match what {
+                    13 => {
+                        if CFArrayGetCount(selectors) > param2 as libc::c_long {
+                            let mut identifier: CFNumberRef = 0 as *const __CFNumber;
+                            selector = CFArrayGetValueAtIndex(selectors, param2 as CFIndex)
+                                as CFDictionaryRef;
+                            identifier = CFDictionaryGetValue(
+                                selector,
+                                kCTFontFeatureSelectorIdentifierKey as *const libc::c_void,
+                            ) as CFNumberRef;
+                            if !identifier.is_null() {
+                                CFNumberGetValue(
+                                    identifier,
+                                    kCFNumberIntType as libc::c_int as CFNumberType,
+                                    &mut rval as *mut libc::c_int as *mut libc::c_void,
+                                );
+                            }
+                        }
+                    }
+                    15 => {
+                        selector = findDictionaryInArrayWithIdentifier(
+                            selectors,
+                            kCTFontFeatureSelectorIdentifierKey as *const libc::c_void,
+                            param2,
+                        );
+                        if !selector.is_null() {
+                            let mut isDefault: CFBooleanRef = 0 as *const __CFBoolean;
+                            let mut found: Boolean = CFDictionaryGetValueIfPresent(
+                                selector,
+                                kCTFontFeatureSelectorDefaultKey as *const libc::c_void,
+                                &mut isDefault as *mut CFBooleanRef as *mut *const libc::c_void,
+                            );
+                            if found != 0 {
+                                rval = CFBooleanGetValue(isDefault) as libc::c_int
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        CFRelease(features as CFTypeRef);
+    }
+    return rval;
 }
 #[no_mangle]
-pub unsafe extern "C" fn aat_font_get_named(mut what: i32, mut attributes: CFDictionaryRef) -> i32 {
-    -1
+pub unsafe extern "C" fn aat_font_get_named(
+    mut what: libc::c_int,
+    mut attributes: CFDictionaryRef,
+) -> libc::c_int {
+    let mut rval: libc::c_int = -1i32;
+    if what == 10i32 {
+        let mut font: CTFontRef = fontFromAttributes(attributes);
+        let mut features: CFArrayRef = CTFontCopyFeatures(font);
+        if !features.is_null() {
+            let mut feature: CFDictionaryRef = findDictionaryInArray(
+                features,
+                kCTFontFeatureTypeNameKey as *const libc::c_void,
+                name_of_file,
+                name_length,
+            );
+            if !feature.is_null() {
+                let mut identifier: CFNumberRef = CFDictionaryGetValue(
+                    feature,
+                    kCTFontFeatureTypeIdentifierKey as *const libc::c_void,
+                ) as CFNumberRef;
+                CFNumberGetValue(
+                    identifier,
+                    kCFNumberIntType as libc::c_int as CFNumberType,
+                    &mut rval as *mut libc::c_int as *mut libc::c_void,
+                );
+            }
+            CFRelease(features as CFTypeRef);
+        }
+    }
+    return rval;
 }
 #[no_mangle]
 pub unsafe extern "C" fn aat_font_get_named_1(
-    mut what: i32,
+    mut what: libc::c_int,
     mut attributes: CFDictionaryRef,
-    mut param: i32,
-) -> i32 {
-    -1
+    mut param: libc::c_int,
+) -> libc::c_int {
+    let mut rval: libc::c_int = -1i32;
+    let mut font: CTFontRef = fontFromAttributes(attributes);
+    if what == 14i32 {
+        let mut features: CFArrayRef = CTFontCopyFeatures(font);
+        if !features.is_null() {
+            let mut feature: CFDictionaryRef = findDictionaryInArrayWithIdentifier(
+                features,
+                kCTFontFeatureTypeIdentifierKey as *const libc::c_void,
+                param,
+            );
+            if !feature.is_null() {
+                let mut selector: CFNumberRef =
+                    findSelectorByName(feature, name_of_file, name_length);
+                if !selector.is_null() {
+                    CFNumberGetValue(
+                        selector,
+                        kCFNumberIntType as libc::c_int as CFNumberType,
+                        &mut rval as *mut libc::c_int as *mut libc::c_void,
+                    );
+                }
+            }
+            CFRelease(features as CFTypeRef);
+        }
+    }
+    return rval;
 }
 #[no_mangle]
 pub unsafe extern "C" fn aat_print_font_name(
-    mut what: i32,
+    mut what: libc::c_int,
     mut attributes: CFDictionaryRef,
-    mut param1: i32,
-    mut param2: i32,
+    mut param1: libc::c_int,
+    mut param2: libc::c_int,
 ) {
+    let mut name: CFStringRef = 0 as CFStringRef;
+    if what == 8i32 || what == 9i32 {
+        let mut font: CTFontRef = fontFromAttributes(attributes);
+        let mut features: CFArrayRef = CTFontCopyFeatures(font);
+        if !features.is_null() {
+            let mut feature: CFDictionaryRef = findDictionaryInArrayWithIdentifier(
+                features,
+                kCTFontFeatureTypeIdentifierKey as *const libc::c_void,
+                param1,
+            );
+            if !feature.is_null() {
+                if what == 8i32 {
+                    name = CFDictionaryGetValue(
+                        feature,
+                        kCTFontFeatureTypeNameKey as *const libc::c_void,
+                    ) as CFStringRef
+                } else {
+                    let mut selectors: CFArrayRef = CFDictionaryGetValue(
+                        feature,
+                        kCTFontFeatureTypeSelectorsKey as *const libc::c_void,
+                    ) as CFArrayRef;
+                    let mut selector: CFDictionaryRef = findDictionaryInArrayWithIdentifier(
+                        selectors,
+                        kCTFontFeatureSelectorIdentifierKey as *const libc::c_void,
+                        param2,
+                    );
+                    if !selector.is_null() {
+                        name = CFDictionaryGetValue(
+                            selector,
+                            kCTFontFeatureSelectorNameKey as *const libc::c_void,
+                        ) as CFStringRef
+                    }
+                }
+            }
+            CFRelease(features as CFTypeRef);
+        }
+    }
+    if !name.is_null() {
+        let mut len: CFIndex = CFStringGetLength(name);
+        let mut buf: *mut UniChar = xcalloc(
+            len as size_t,
+            ::std::mem::size_of::<UniChar>() as libc::c_ulong,
+        ) as *mut UniChar;
+        CFStringGetCharacters(name, CFRangeMake(0i32 as CFIndex, len), buf);
+        print_chars(buf, len as libc::c_int);
+        free(buf as *mut libc::c_void);
+    };
 }
 #[no_mangle]
-pub unsafe extern "C" fn print_glyph_name(mut font: i32, mut gid: i32) {
-    let mut s: *const i8 = 0 as *const i8;
-    let mut len: i32 = 0i32;
-    if *font_area.offset(font as isize) as u32 == 0xfffeu32 {
+pub unsafe extern "C" fn print_glyph_name(mut font: int32_t, mut gid: int32_t) {
+    let mut s: *const libc::c_char = 0 as *const libc::c_char;
+    let mut len: libc::c_int = 0i32;
+    if *font_area.offset(font as isize) as libc::c_uint == 0xffffu32 {
+        s = GetGlyphNameFromCTFont(fontFromInteger(font), gid as uint16_t, &mut len)
+    } else if *font_area.offset(font as isize) as libc::c_uint == 0xfffeu32 {
         let mut engine: XeTeXLayoutEngine =
             *font_layout_engine.offset(font as isize) as XeTeXLayoutEngine;
-        s = getGlyphName(getFont(engine), gid as u16, &mut len)
+        s = getGlyphName(getFont(engine), gid as uint16_t, &mut len)
     } else {
-        _tt_abort(b"bad native font flag in `print_glyph_name`\x00" as *const u8 as *const i8);
+        _tt_abort(
+            b"bad native font flag in `print_glyph_name`\x00" as *const u8 as *const libc::c_char,
+        );
     }
     loop {
         let fresh33 = len;
@@ -2657,22 +4872,22 @@ pub unsafe extern "C" fn print_glyph_name(mut font: i32, mut gid: i32) {
         }
         let fresh34 = s;
         s = s.offset(1);
-        print_char(*fresh34 as i32);
+        print_char(*fresh34 as int32_t);
     }
 }
 #[no_mangle]
 pub unsafe extern "C" fn real_get_native_word_cp(
     mut pNode: *mut libc::c_void,
-    mut side: i32,
-) -> i32 {
+    mut side: libc::c_int,
+) -> int32_t {
     let mut node: *mut memory_word = pNode as *mut memory_word;
     let mut locations: *mut FixedPoint = (*node.offset(5)).ptr as *mut FixedPoint;
-    let mut glyphIDs: *mut u16 =
-        locations.offset((*node.offset(4)).b16.s0 as i32 as isize) as *mut u16;
-    let mut glyphCount: u16 = (*node.offset(4)).b16.s0;
-    let mut f: i32 = (*node.offset(4)).b16.s2 as i32;
-    let mut actual_glyph: u16 = 0;
-    if glyphCount as i32 == 0i32 {
+    let mut glyphIDs: *mut uint16_t =
+        locations.offset((*node.offset(4)).b16.s0 as libc::c_int as isize) as *mut uint16_t;
+    let mut glyphCount: uint16_t = (*node.offset(4)).b16.s0;
+    let mut f: int32_t = (*node.offset(4)).b16.s2 as int32_t;
+    let mut actual_glyph: uint16_t = 0;
+    if glyphCount as libc::c_int == 0i32 {
         return 0i32;
     }
     match side {
@@ -2680,8 +4895,21 @@ pub unsafe extern "C" fn real_get_native_word_cp(
             actual_glyph = *glyphIDs
             // we should not reach this point
         }
-        1 => actual_glyph = *glyphIDs.offset((glyphCount as i32 - 1i32) as isize),
-        _ => unreachable!(),
+        1 => actual_glyph = *glyphIDs.offset((glyphCount as libc::c_int - 1i32) as isize),
+        _ => {
+            if (0i32 == 0) as libc::c_int as libc::c_long != 0 {
+                __assert_rtn(
+                    (*::std::mem::transmute::<&[u8; 24], &[libc::c_char; 24]>(
+                        b"real_get_native_word_cp\x00",
+                    ))
+                    .as_ptr(),
+                    b"tectonic/xetex-ext.c\x00" as *const u8 as *const libc::c_char,
+                    2136i32,
+                    b"0\x00" as *const u8 as *const libc::c_char,
+                );
+            } else {
+            };
+        }
     }
-    get_cp_code(f, actual_glyph as u32, side)
+    return get_cp_code(f, actual_glyph as libc::c_uint, side);
 }

--- a/engine/src/xetex_macos.rs
+++ b/engine/src/xetex_macos.rs
@@ -1,0 +1,3865 @@
+#![allow(dead_code,
+         mutable_transmutes,
+         non_camel_case_types,
+         non_snake_case,
+         non_upper_case_globals,
+         unused_assignments,
+         unused_mut)]
+#![feature(const_raw_ptr_to_usize_cast,
+           extern_types,
+           ptr_wrapping_offset_from)]
+extern crate libc;
+extern "C" {
+    pub type __CFString;
+    pub type __CFAllocator;
+    pub type __CFURL;
+    pub type __CFDictionary;
+    pub type __CFNumber;
+    pub type FT_LibraryRec_;
+    pub type FT_DriverRec_;
+    pub type FT_Face_InternalRec_;
+    pub type FT_Size_InternalRec_;
+    pub type FT_Slot_InternalRec_;
+    pub type FT_SubGlyphRec_;
+    pub type __CFArray;
+    pub type __CFBoolean;
+    pub type __CFAttributedString;
+    pub type CGColor;
+    pub type CGFont;
+    pub type __CTFontDescriptor;
+    pub type __CTFont;
+    pub type __CTLine;
+    pub type __CTTypesetter;
+    pub type __CTRun;
+    #[no_mangle]
+    static kCFBooleanTrue: CFBooleanRef;
+    #[no_mangle]
+    static CGAffineTransformIdentity: CGAffineTransform;
+    #[no_mangle]
+    fn CGColorCreateGenericRGB(
+        red: CGFloat,
+        green: CGFloat,
+        blue: CGFloat,
+        alpha: CGFloat,
+    ) -> CGColorRef;
+    #[no_mangle]
+    static kCTFontAttributeName: CFStringRef;
+    #[no_mangle]
+    fn strcmp(_: *const libc::c_char, _: *const libc::c_char) -> libc::c_int;
+    #[no_mangle]
+    fn strlen(_: *const libc::c_char) -> libc::c_ulong;
+    #[no_mangle]
+    fn strncmp(_: *const libc::c_char, _: *const libc::c_char, _: libc::c_ulong) -> libc::c_int;
+    #[no_mangle]
+    fn strdup(_: *const libc::c_char) -> *mut libc::c_char;
+    #[no_mangle]
+    fn free(_: *mut libc::c_void);
+    /* The internal, C/C++ interface: */
+    #[no_mangle]
+    fn _tt_abort(format: *const libc::c_char, _: ...) -> !;
+    /* Macs provide Fixed and FixedPoint */
+    /* Misc */
+    /* gFreeTypeLibrary is defined in xetex-XeTeXFontInst_FT2.cpp,
+     * also used in xetex-XeTeXFontMgr_FC.cpp and xetex-ext.c.  */
+    #[no_mangle]
+    static mut gFreeTypeLibrary: FT_Library;
+    #[no_mangle]
+    fn xmalloc(size: size_t) -> *mut libc::c_void;
+    #[no_mangle]
+    fn FT_Get_Postscript_Name(face: FT_Face) -> *const libc::c_char;
+    #[no_mangle]
+    fn FT_Done_Face(face: FT_Face) -> FT_Error;
+    #[no_mangle]
+    fn FT_New_Face(
+        library: FT_Library,
+        filepathname: *const libc::c_char,
+        face_index: FT_Long,
+        aface: *mut FT_Face,
+    ) -> FT_Error;
+    #[no_mangle]
+    fn FT_Init_FreeType(alibrary: *mut FT_Library) -> FT_Error;
+    #[no_mangle]
+    static mut font_area: *mut str_number;
+    #[no_mangle]
+    static mut font_layout_engine: *mut *mut libc::c_void;
+    #[no_mangle]
+    static mut font_letter_space: *mut scaled_t;
+    #[no_mangle]
+    static mut loaded_font_flags: libc::c_char;
+    #[no_mangle]
+    static mut loaded_font_letter_space: scaled_t;
+    #[no_mangle]
+    static mut native_font_type_flag: int32_t;
+    /* ***************************************************************************\
+     Part of the XeTeX typesetting system
+     Copyright (c) 1994-2008 by SIL International
+     Copyright (c) 2009, 2011 by Jonathan Kew
+     Copyright (c) 2012, 2013 by Jiang Jiang
+     Copyright (c) 2012-2015 by Khaled Hosny
+
+     SIL Author(s): Jonathan Kew
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE
+    FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+    CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+    Except as contained in this notice, the name of the copyright holders
+    shall not be used in advertising or otherwise to promote the sale,
+    use or other dealings in this Software without prior written
+    authorization from the copyright holders.
+    \****************************************************************************/
+    /* some typedefs that XeTeX uses - on Mac OS, we get these from Apple headers,
+    but otherwise we'll need these substitute definitions */
+    /* command codes for XeTeX extension commands */
+    /* accessing info in a native_word_node */
+    /* info for each glyph is location (FixedPoint) + glyph ID (uint16_t) */
+    /* glyph ID field in a glyph_node */
+    /* For Unicode encoding form interpretation... */
+    #[no_mangle]
+    fn readCommonFeatures(
+        feat: *const libc::c_char,
+        end: *const libc::c_char,
+        extend: *mut libc::c_float,
+        slant: *mut libc::c_float,
+        embolden: *mut libc::c_float,
+        letterspace: *mut libc::c_float,
+        rgbValue: *mut uint32_t,
+    ) -> libc::c_int;
+    #[no_mangle]
+    fn font_feature_warning(
+        featureNameP: *const libc::c_void,
+        featLen: int32_t,
+        settingNameP: *const libc::c_void,
+        setLen: int32_t,
+    );
+    #[no_mangle]
+    fn read_double(s: *mut *const libc::c_char) -> libc::c_double;
+    #[no_mangle]
+    fn Fix2D(f: Fixed) -> libc::c_double;
+    #[no_mangle]
+    fn D2Fix(d: libc::c_double) -> Fixed;
+    #[no_mangle]
+    fn CFAttributedStringCreate(
+        alloc: CFAllocatorRef,
+        str: CFStringRef,
+        attributes: CFDictionaryRef,
+    ) -> CFAttributedStringRef;
+    #[no_mangle]
+    static kCTFontURLAttribute: CFStringRef;
+    #[no_mangle]
+    static kCTKernAttributeName: CFStringRef;
+    #[no_mangle]
+    fn CFNumberCreate(
+        allocator: CFAllocatorRef,
+        theType: CFNumberType,
+        valuePtr: *const libc::c_void,
+    ) -> CFNumberRef;
+    #[no_mangle]
+    fn CGColorRelease(color: CGColorRef);
+    #[no_mangle]
+    fn CTRunGetGlyphCount(run: CTRunRef) -> CFIndex;
+    #[no_mangle]
+    static kCFTypeArrayCallBacks: CFArrayCallBacks;
+    #[no_mangle]
+    static kCTFontPostScriptNameKey: CFStringRef;
+    #[no_mangle]
+    fn CTTypesetterCreateWithAttributedString(string: CFAttributedStringRef) -> CTTypesetterRef;
+    #[no_mangle]
+    fn CFNumberGetValue(
+        number: CFNumberRef,
+        theType: CFNumberType,
+        valuePtr: *mut libc::c_void,
+    ) -> Boolean;
+    #[no_mangle]
+    fn CGFontRelease(font: CGFontRef);
+    #[no_mangle]
+    static kCTForegroundColorAttributeName: CFStringRef;
+    #[no_mangle]
+    fn CGFontGetNumberOfGlyphs(font: CGFontRef) -> size_t;
+    #[no_mangle]
+    fn CTRunGetAttributes(run: CTRunRef) -> CFDictionaryRef;
+    #[no_mangle]
+    static kCTFontCascadeListAttribute: CFStringRef;
+    #[no_mangle]
+    fn CFURLGetFileSystemRepresentation(
+        url: CFURLRef,
+        resolveAgainstBase: Boolean,
+        buffer: *mut UInt8,
+        maxBufLen: CFIndex,
+    ) -> Boolean;
+    #[no_mangle]
+    static kCFTypeDictionaryKeyCallBacks: CFDictionaryKeyCallBacks;
+    #[no_mangle]
+    fn CFNumberCompare(
+        number: CFNumberRef,
+        otherNumber: CFNumberRef,
+        context: *mut libc::c_void,
+    ) -> CFComparisonResult;
+    #[no_mangle]
+    static kCTFontFeatureSettingsAttribute: CFStringRef;
+    #[no_mangle]
+    static kCTFontOrientationAttribute: CFStringRef;
+    #[no_mangle]
+    static kCFTypeDictionaryValueCallBacks: CFDictionaryValueCallBacks;
+    #[no_mangle]
+    fn CGRectIsNull(rect: CGRect) -> bool;
+    #[no_mangle]
+    fn CTTypesetterCreateLine(typesetter: CTTypesetterRef, stringRange: CFRange) -> CTLineRef;
+    #[no_mangle]
+    fn CTRunGetGlyphs(run: CTRunRef, range: CFRange, buffer: *mut CGGlyph);
+    #[no_mangle]
+    fn CTFontCreateWithFontDescriptor(
+        descriptor: CTFontDescriptorRef,
+        size: CGFloat,
+        matrix: *const CGAffineTransform,
+    ) -> CTFontRef;
+    #[no_mangle]
+    fn CTLineCreateJustifiedLine(
+        line: CTLineRef,
+        justificationFactor: CGFloat,
+        justificationWidth: libc::c_double,
+    ) -> CTLineRef;
+    #[no_mangle]
+    static kCTVerticalFormsAttributeName: CFStringRef;
+    #[no_mangle]
+    fn CFStringCreateWithCString(
+        alloc: CFAllocatorRef,
+        cStr: *const libc::c_char,
+        encoding: CFStringEncoding,
+    ) -> CFStringRef;
+    #[no_mangle]
+    fn CFStringCreateWithBytes(
+        alloc: CFAllocatorRef,
+        bytes: *const UInt8,
+        numBytes: CFIndex,
+        encoding: CFStringEncoding,
+        isExternalRepresentation: Boolean,
+    ) -> CFStringRef;
+    #[no_mangle]
+    fn CTLineGetGlyphCount(line: CTLineRef) -> CFIndex;
+    #[no_mangle]
+    fn CGFontCopyGlyphNameForGlyph(font: CGFontRef, glyph: CGGlyph) -> CFStringRef;
+    #[no_mangle]
+    fn CTRunGetPositions(run: CTRunRef, range: CFRange, buffer: *mut CGPoint);
+    #[no_mangle]
+    fn CTLineGetGlyphRuns(line: CTLineRef) -> CFArrayRef;
+    #[no_mangle]
+    fn CFArrayCreateMutable(
+        allocator: CFAllocatorRef,
+        capacity: CFIndex,
+        callBacks: *const CFArrayCallBacks,
+    ) -> CFMutableArrayRef;
+    #[no_mangle]
+    fn CFStringCreateWithCStringNoCopy(
+        alloc: CFAllocatorRef,
+        cStr: *const libc::c_char,
+        encoding: CFStringEncoding,
+        contentsDeallocator: CFAllocatorRef,
+    ) -> CFStringRef;
+    #[no_mangle]
+    fn CFStringCreateWithCharactersNoCopy(
+        alloc: CFAllocatorRef,
+        chars: *const UniChar,
+        numChars: CFIndex,
+        contentsDeallocator: CFAllocatorRef,
+    ) -> CFStringRef;
+    #[no_mangle]
+    fn CFArrayGetCount(theArray: CFArrayRef) -> CFIndex;
+    #[no_mangle]
+    fn CTRunGetAdvances(run: CTRunRef, range: CFRange, buffer: *mut CGSize);
+    #[no_mangle]
+    fn CFDictionaryCreate(
+        allocator: CFAllocatorRef,
+        keys: *mut *const libc::c_void,
+        values: *mut *const libc::c_void,
+        numValues: CFIndex,
+        keyCallBacks: *const CFDictionaryKeyCallBacks,
+        valueCallBacks: *const CFDictionaryValueCallBacks,
+    ) -> CFDictionaryRef;
+    #[no_mangle]
+    fn CTFontDescriptorCreateWithNameAndSize(
+        name: CFStringRef,
+        size: CGFloat,
+    ) -> CTFontDescriptorRef;
+    #[no_mangle]
+    fn CFStringGetLength(theString: CFStringRef) -> CFIndex;
+    #[no_mangle]
+    fn CTFontDescriptorCreateWithAttributes(attributes: CFDictionaryRef) -> CTFontDescriptorRef;
+    #[no_mangle]
+    fn CFStringGetCString(
+        theString: CFStringRef,
+        buffer: *mut libc::c_char,
+        bufferSize: CFIndex,
+        encoding: CFStringEncoding,
+    ) -> Boolean;
+    #[no_mangle]
+    fn CFArrayGetValueAtIndex(theArray: CFArrayRef, idx: CFIndex) -> *const libc::c_void;
+    #[no_mangle]
+    fn CFDictionaryCreateMutable(
+        allocator: CFAllocatorRef,
+        capacity: CFIndex,
+        keyCallBacks: *const CFDictionaryKeyCallBacks,
+        valueCallBacks: *const CFDictionaryValueCallBacks,
+    ) -> CFMutableDictionaryRef;
+    #[no_mangle]
+    fn CTRunGetTypographicBounds(
+        run: CTRunRef,
+        range: CFRange,
+        ascent: *mut CGFloat,
+        descent: *mut CGFloat,
+        leading: *mut CGFloat,
+    ) -> libc::c_double;
+    #[no_mangle]
+    fn CTFontCreateCopyWithAttributes(
+        font: CTFontRef,
+        size: CGFloat,
+        matrix: *const CGAffineTransform,
+        attributes: CTFontDescriptorRef,
+    ) -> CTFontRef;
+    #[no_mangle]
+    fn CFStringCompare(
+        theString1: CFStringRef,
+        theString2: CFStringRef,
+        compareOptions: CFStringCompareFlags,
+    ) -> CFComparisonResult;
+    #[no_mangle]
+    fn CFArrayAppendValue(theArray: CFMutableArrayRef, value: *const libc::c_void);
+    #[no_mangle]
+    fn CTFontCopyAttribute(font: CTFontRef, attribute: CFStringRef) -> CFTypeRef;
+    #[no_mangle]
+    fn CFDictionaryGetValue(
+        theDict: CFDictionaryRef,
+        key: *const libc::c_void,
+    ) -> *const libc::c_void;
+    #[no_mangle]
+    static kCFAllocatorDefault: CFAllocatorRef;
+    #[no_mangle]
+    static kCFAllocatorNull: CFAllocatorRef;
+    #[no_mangle]
+    fn CFDictionaryAddValue(
+        theDict: CFMutableDictionaryRef,
+        key: *const libc::c_void,
+        value: *const libc::c_void,
+    );
+    #[no_mangle]
+    fn CTFontCopyName(font: CTFontRef, nameKey: CFStringRef) -> CFStringRef;
+    #[no_mangle]
+    fn CFRelease(cf: CFTypeRef);
+    #[no_mangle]
+    fn CFEqual(cf1: CFTypeRef, cf2: CFTypeRef) -> Boolean;
+    #[no_mangle]
+    fn CTFontGetGlyphsForCharacters(
+        font: CTFontRef,
+        characters: *const UniChar,
+        glyphs: *mut CGGlyph,
+        count: CFIndex,
+    ) -> bool;
+    #[no_mangle]
+    fn CTFontGetGlyphWithName(font: CTFontRef, glyphName: CFStringRef) -> CGGlyph;
+    #[no_mangle]
+    fn CTFontGetBoundingRectsForGlyphs(
+        font: CTFontRef,
+        orientation: CTFontOrientation,
+        glyphs: *const CGGlyph,
+        boundingRects: *mut CGRect,
+        count: CFIndex,
+    ) -> CGRect;
+    #[no_mangle]
+    fn CTFontGetAdvancesForGlyphs(
+        font: CTFontRef,
+        orientation: CTFontOrientation,
+        glyphs: *const CGGlyph,
+        advances: *mut CGSize,
+        count: CFIndex,
+    ) -> libc::c_double;
+    #[no_mangle]
+    static kCTFontFeatureTypeIdentifierKey: CFStringRef;
+    #[no_mangle]
+    static kCTFontFeatureTypeNameKey: CFStringRef;
+    #[no_mangle]
+    static kCTFontFeatureTypeSelectorsKey: CFStringRef;
+    #[no_mangle]
+    static kCTFontFeatureSelectorIdentifierKey: CFStringRef;
+    #[no_mangle]
+    static kCTFontFeatureSelectorNameKey: CFStringRef;
+    #[no_mangle]
+    fn CTFontCopyFeatures(font: CTFontRef) -> CFArrayRef;
+    #[no_mangle]
+    fn CTFontCopyGraphicsFont(font: CTFontRef, attributes: *mut CTFontDescriptorRef) -> CGFontRef;
+}
+pub type __darwin_size_t = libc::c_ulong;
+pub type size_t = __darwin_size_t;
+pub type int32_t = libc::c_int;
+pub type uint16_t = libc::c_ushort;
+pub type uint32_t = libc::c_uint;
+pub type CFStringRef = *const __CFString;
+pub type CFAllocatorRef = *const __CFAllocator;
+pub type UniChar = UInt16;
+pub type UInt16 = libc::c_ushort;
+pub type CFURLRef = *const __CFURL;
+pub type CFDictionaryRef = *const __CFDictionary;
+pub type CGFloat = libc::c_double;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct CGRect {
+    pub origin: CGPoint,
+    pub size: CGSize,
+}
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct CGSize {
+    pub width: CGFloat,
+    pub height: CGFloat,
+}
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct CGPoint {
+    pub x: CGFloat,
+    pub y: CGFloat,
+}
+pub type CFNumberRef = *const __CFNumber;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct CGAffineTransform {
+    pub a: CGFloat,
+    pub b: CGFloat,
+    pub c: CGFloat,
+    pub d: CGFloat,
+    pub tx: CGFloat,
+    pub ty: CGFloat,
+}
+pub type Boolean = libc::c_uchar;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct FT_MemoryRec_ {
+    pub user: *mut libc::c_void,
+    pub alloc: FT_Alloc_Func,
+    pub free: FT_Free_Func,
+    pub realloc: FT_Realloc_Func,
+}
+pub type FT_Realloc_Func = Option<
+    unsafe extern "C" fn(
+        _: FT_Memory,
+        _: libc::c_long,
+        _: libc::c_long,
+        _: *mut libc::c_void,
+    ) -> *mut libc::c_void,
+>;
+pub type FT_Memory = *mut FT_MemoryRec_;
+pub type FT_Free_Func = Option<unsafe extern "C" fn(_: FT_Memory, _: *mut libc::c_void) -> ()>;
+pub type FT_Alloc_Func =
+    Option<unsafe extern "C" fn(_: FT_Memory, _: libc::c_long) -> *mut libc::c_void>;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct FT_StreamRec_ {
+    pub base: *mut libc::c_uchar,
+    pub size: libc::c_ulong,
+    pub pos: libc::c_ulong,
+    pub descriptor: FT_StreamDesc,
+    pub pathname: FT_StreamDesc,
+    pub read: FT_Stream_IoFunc,
+    pub close: FT_Stream_CloseFunc,
+    pub memory: FT_Memory,
+    pub cursor: *mut libc::c_uchar,
+    pub limit: *mut libc::c_uchar,
+}
+pub type FT_Stream_CloseFunc = Option<unsafe extern "C" fn(_: FT_Stream) -> ()>;
+pub type FT_Stream = *mut FT_StreamRec_;
+pub type FT_Stream_IoFunc = Option<
+    unsafe extern "C" fn(
+        _: FT_Stream,
+        _: libc::c_ulong,
+        _: *mut libc::c_uchar,
+        _: libc::c_ulong,
+    ) -> libc::c_ulong,
+>;
+pub type FT_StreamDesc = FT_StreamDesc_;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub union FT_StreamDesc_ {
+    pub value: libc::c_long,
+    pub pointer: *mut libc::c_void,
+}
+pub type FT_Pos = libc::c_long;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct FT_Vector_ {
+    pub x: FT_Pos,
+    pub y: FT_Pos,
+}
+pub type FT_Vector = FT_Vector_;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct FT_BBox_ {
+    pub xMin: FT_Pos,
+    pub yMin: FT_Pos,
+    pub xMax: FT_Pos,
+    pub yMax: FT_Pos,
+}
+pub type FT_BBox = FT_BBox_;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct FT_Bitmap_ {
+    pub rows: libc::c_uint,
+    pub width: libc::c_uint,
+    pub pitch: libc::c_int,
+    pub buffer: *mut libc::c_uchar,
+    pub num_grays: libc::c_ushort,
+    pub pixel_mode: libc::c_uchar,
+    pub palette_mode: libc::c_uchar,
+    pub palette: *mut libc::c_void,
+}
+pub type FT_Bitmap = FT_Bitmap_;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct FT_Outline_ {
+    pub n_contours: libc::c_short,
+    pub n_points: libc::c_short,
+    pub points: *mut FT_Vector,
+    pub tags: *mut libc::c_char,
+    pub contours: *mut libc::c_short,
+    pub flags: libc::c_int,
+}
+pub type FT_Outline = FT_Outline_;
+pub type FT_Glyph_Format_ = libc::c_uint;
+pub const FT_GLYPH_FORMAT_PLOTTER: FT_Glyph_Format_ = 1886154612;
+pub const FT_GLYPH_FORMAT_OUTLINE: FT_Glyph_Format_ = 1869968492;
+pub const FT_GLYPH_FORMAT_BITMAP: FT_Glyph_Format_ = 1651078259;
+pub const FT_GLYPH_FORMAT_COMPOSITE: FT_Glyph_Format_ = 1668246896;
+pub const FT_GLYPH_FORMAT_NONE: FT_Glyph_Format_ = 0;
+pub type FT_Glyph_Format = FT_Glyph_Format_;
+pub type FT_String = libc::c_char;
+pub type FT_Short = libc::c_short;
+pub type FT_UShort = libc::c_ushort;
+pub type FT_Int = libc::c_int;
+pub type FT_UInt = libc::c_uint;
+pub type FT_Long = libc::c_long;
+pub type FT_Fixed = libc::c_long;
+pub type FT_Error = libc::c_int;
+pub type FT_Generic_Finalizer = Option<unsafe extern "C" fn(_: *mut libc::c_void) -> ()>;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct FT_Generic_ {
+    pub data: *mut libc::c_void,
+    pub finalizer: FT_Generic_Finalizer,
+}
+pub type FT_Generic = FT_Generic_;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct FT_ListNodeRec_ {
+    pub prev: FT_ListNode,
+    pub next: FT_ListNode,
+    pub data: *mut libc::c_void,
+}
+pub type FT_ListNode = *mut FT_ListNodeRec_;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct FT_ListRec_ {
+    pub head: FT_ListNode,
+    pub tail: FT_ListNode,
+}
+/* ***************************************************************************
+ *
+ * fttypes.h
+ *
+ *   FreeType simple types definitions (specification only).
+ *
+ * Copyright (C) 1996-2019 by
+ * David Turner, Robert Wilhelm, and Werner Lemberg.
+ *
+ * This file is part of the FreeType project, and may only be used,
+ * modified, and distributed under the terms of the FreeType project
+ * license, LICENSE.TXT.  By continuing to use, modify, or distribute
+ * this file you indicate that you have read the license and
+ * understand and accept it fully.
+ *
+ */
+/* *************************************************************************
+ *
+ * @section:
+ *   basic_types
+ *
+ * @title:
+ *   Basic Data Types
+ *
+ * @abstract:
+ *   The basic data types defined by the library.
+ *
+ * @description:
+ *   This section contains the basic data types defined by FreeType~2,
+ *   ranging from simple scalar types to bitmap descriptors.  More
+ *   font-specific structures are defined in a different section.
+ *
+ * @order:
+ *   FT_Byte
+ *   FT_Bytes
+ *   FT_Char
+ *   FT_Int
+ *   FT_UInt
+ *   FT_Int16
+ *   FT_UInt16
+ *   FT_Int32
+ *   FT_UInt32
+ *   FT_Int64
+ *   FT_UInt64
+ *   FT_Short
+ *   FT_UShort
+ *   FT_Long
+ *   FT_ULong
+ *   FT_Bool
+ *   FT_Offset
+ *   FT_PtrDist
+ *   FT_String
+ *   FT_Tag
+ *   FT_Error
+ *   FT_Fixed
+ *   FT_Pointer
+ *   FT_Pos
+ *   FT_Vector
+ *   FT_BBox
+ *   FT_Matrix
+ *   FT_FWord
+ *   FT_UFWord
+ *   FT_F2Dot14
+ *   FT_UnitVector
+ *   FT_F26Dot6
+ *   FT_Data
+ *
+ *   FT_MAKE_TAG
+ *
+ *   FT_Generic
+ *   FT_Generic_Finalizer
+ *
+ *   FT_Bitmap
+ *   FT_Pixel_Mode
+ *   FT_Palette_Mode
+ *   FT_Glyph_Format
+ *   FT_IMAGE_TAG
+ *
+ */
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_Bool
+ *
+ * @description:
+ *   A typedef of unsigned char, used for simple booleans.  As usual,
+ *   values 1 and~0 represent true and false, respectively.
+ */
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_FWord
+ *
+ * @description:
+ *   A signed 16-bit integer used to store a distance in original font
+ *   units.
+ */
+/* distance in FUnits */
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_UFWord
+ *
+ * @description:
+ *   An unsigned 16-bit integer used to store a distance in original font
+ *   units.
+ */
+/* unsigned distance */
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_Char
+ *
+ * @description:
+ *   A simple typedef for the _signed_ char type.
+ */
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_Byte
+ *
+ * @description:
+ *   A simple typedef for the _unsigned_ char type.
+ */
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_Bytes
+ *
+ * @description:
+ *   A typedef for constant memory areas.
+ */
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_Tag
+ *
+ * @description:
+ *   A typedef for 32-bit tags (as used in the SFNT format).
+ */
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_String
+ *
+ * @description:
+ *   A simple typedef for the char type, usually used for strings.
+ */
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_Short
+ *
+ * @description:
+ *   A typedef for signed short.
+ */
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_UShort
+ *
+ * @description:
+ *   A typedef for unsigned short.
+ */
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_Int
+ *
+ * @description:
+ *   A typedef for the int type.
+ */
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_UInt
+ *
+ * @description:
+ *   A typedef for the unsigned int type.
+ */
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_Long
+ *
+ * @description:
+ *   A typedef for signed long.
+ */
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_ULong
+ *
+ * @description:
+ *   A typedef for unsigned long.
+ */
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_F2Dot14
+ *
+ * @description:
+ *   A signed 2.14 fixed-point type used for unit vectors.
+ */
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_F26Dot6
+ *
+ * @description:
+ *   A signed 26.6 fixed-point type used for vectorial pixel coordinates.
+ */
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_Fixed
+ *
+ * @description:
+ *   This type is used to store 16.16 fixed-point values, like scaling
+ *   values or matrix coefficients.
+ */
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_Error
+ *
+ * @description:
+ *   The FreeType error code type.  A value of~0 is always interpreted as a
+ *   successful operation.
+ */
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_Pointer
+ *
+ * @description:
+ *   A simple typedef for a typeless pointer.
+ */
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_Offset
+ *
+ * @description:
+ *   This is equivalent to the ANSI~C `size_t` type, i.e., the largest
+ *   _unsigned_ integer type used to express a file size or position, or a
+ *   memory block size.
+ */
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_PtrDist
+ *
+ * @description:
+ *   This is equivalent to the ANSI~C `ptrdiff_t` type, i.e., the largest
+ *   _signed_ integer type used to express the distance between two
+ *   pointers.
+ */
+/* *************************************************************************
+ *
+ * @struct:
+ *   FT_UnitVector
+ *
+ * @description:
+ *   A simple structure used to store a 2D vector unit vector.  Uses
+ *   FT_F2Dot14 types.
+ *
+ * @fields:
+ *   x ::
+ *     Horizontal coordinate.
+ *
+ *   y ::
+ *     Vertical coordinate.
+ */
+/* *************************************************************************
+ *
+ * @struct:
+ *   FT_Matrix
+ *
+ * @description:
+ *   A simple structure used to store a 2x2 matrix.  Coefficients are in
+ *   16.16 fixed-point format.  The computation performed is:
+ *
+ *   ```
+ *     x' = x*xx + y*xy
+ *     y' = x*yx + y*yy
+ *   ```
+ *
+ * @fields:
+ *   xx ::
+ *     Matrix coefficient.
+ *
+ *   xy ::
+ *     Matrix coefficient.
+ *
+ *   yx ::
+ *     Matrix coefficient.
+ *
+ *   yy ::
+ *     Matrix coefficient.
+ */
+/* *************************************************************************
+ *
+ * @struct:
+ *   FT_Data
+ *
+ * @description:
+ *   Read-only binary data represented as a pointer and a length.
+ *
+ * @fields:
+ *   pointer ::
+ *     The data.
+ *
+ *   length ::
+ *     The length of the data in bytes.
+ */
+/* *************************************************************************
+ *
+ * @functype:
+ *   FT_Generic_Finalizer
+ *
+ * @description:
+ *   Describe a function used to destroy the 'client' data of any FreeType
+ *   object.  See the description of the @FT_Generic type for details of
+ *   usage.
+ *
+ * @input:
+ *   The address of the FreeType object that is under finalization.  Its
+ *   client data is accessed through its `generic` field.
+ */
+/* *************************************************************************
+ *
+ * @struct:
+ *   FT_Generic
+ *
+ * @description:
+ *   Client applications often need to associate their own data to a
+ *   variety of FreeType core objects.  For example, a text layout API
+ *   might want to associate a glyph cache to a given size object.
+ *
+ *   Some FreeType object contains a `generic` field, of type `FT_Generic`,
+ *   which usage is left to client applications and font servers.
+ *
+ *   It can be used to store a pointer to client-specific data, as well as
+ *   the address of a 'finalizer' function, which will be called by
+ *   FreeType when the object is destroyed (for example, the previous
+ *   client example would put the address of the glyph cache destructor in
+ *   the `finalizer` field).
+ *
+ * @fields:
+ *   data ::
+ *     A typeless pointer to any client-specified data. This field is
+ *     completely ignored by the FreeType library.
+ *
+ *   finalizer ::
+ *     A pointer to a 'generic finalizer' function, which will be called
+ *     when the object is destroyed.  If this field is set to `NULL`, no
+ *     code will be called.
+ */
+/* *************************************************************************
+ *
+ * @macro:
+ *   FT_MAKE_TAG
+ *
+ * @description:
+ *   This macro converts four-letter tags that are used to label TrueType
+ *   tables into an unsigned long, to be used within FreeType.
+ *
+ * @note:
+ *   The produced values **must** be 32-bit integers.  Don't redefine this
+ *   macro.
+ */
+/* ************************************************************************/
+/* ************************************************************************/
+/*                                                                       */
+/*                    L I S T   M A N A G E M E N T                      */
+/*                                                                       */
+/* ************************************************************************/
+/* ************************************************************************/
+/* *************************************************************************
+ *
+ * @section:
+ *   list_processing
+ *
+ */
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_ListNode
+ *
+ * @description:
+ *    Many elements and objects in FreeType are listed through an @FT_List
+ *    record (see @FT_ListRec).  As its name suggests, an FT_ListNode is a
+ *    handle to a single list element.
+ */
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_List
+ *
+ * @description:
+ *   A handle to a list record (see @FT_ListRec).
+ */
+/* *************************************************************************
+ *
+ * @struct:
+ *   FT_ListNodeRec
+ *
+ * @description:
+ *   A structure used to hold a single list element.
+ *
+ * @fields:
+ *   prev ::
+ *     The previous element in the list.  `NULL` if first.
+ *
+ *   next ::
+ *     The next element in the list.  `NULL` if last.
+ *
+ *   data ::
+ *     A typeless pointer to the listed object.
+ */
+/* *************************************************************************
+ *
+ * @struct:
+ *   FT_ListRec
+ *
+ * @description:
+ *   A structure used to hold a simple doubly-linked list.  These are used
+ *   in many parts of FreeType.
+ *
+ * @fields:
+ *   head ::
+ *     The head (first element) of doubly-linked list.
+ *
+ *   tail ::
+ *     The tail (last element) of doubly-linked list.
+ */
+pub type FT_ListRec = FT_ListRec_;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct FT_Glyph_Metrics_ {
+    pub width: FT_Pos,
+    pub height: FT_Pos,
+    pub horiBearingX: FT_Pos,
+    pub horiBearingY: FT_Pos,
+    pub horiAdvance: FT_Pos,
+    pub vertBearingX: FT_Pos,
+    pub vertBearingY: FT_Pos,
+    pub vertAdvance: FT_Pos,
+}
+pub type FT_Glyph_Metrics = FT_Glyph_Metrics_;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct FT_Bitmap_Size_ {
+    pub height: FT_Short,
+    pub width: FT_Short,
+    pub size: FT_Pos,
+    pub x_ppem: FT_Pos,
+    pub y_ppem: FT_Pos,
+}
+pub type FT_Bitmap_Size = FT_Bitmap_Size_;
+pub type FT_Library = *mut FT_LibraryRec_;
+pub type FT_Driver = *mut FT_DriverRec_;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct FT_FaceRec_ {
+    pub num_faces: FT_Long,
+    pub face_index: FT_Long,
+    pub face_flags: FT_Long,
+    pub style_flags: FT_Long,
+    pub num_glyphs: FT_Long,
+    pub family_name: *mut FT_String,
+    pub style_name: *mut FT_String,
+    pub num_fixed_sizes: FT_Int,
+    pub available_sizes: *mut FT_Bitmap_Size,
+    pub num_charmaps: FT_Int,
+    pub charmaps: *mut FT_CharMap,
+    pub generic: FT_Generic,
+    pub bbox: FT_BBox,
+    pub units_per_EM: FT_UShort,
+    pub ascender: FT_Short,
+    pub descender: FT_Short,
+    pub height: FT_Short,
+    pub max_advance_width: FT_Short,
+    pub max_advance_height: FT_Short,
+    pub underline_position: FT_Short,
+    pub underline_thickness: FT_Short,
+    pub glyph: FT_GlyphSlot,
+    pub size: FT_Size,
+    pub charmap: FT_CharMap,
+    pub driver: FT_Driver,
+    pub memory: FT_Memory,
+    pub stream: FT_Stream,
+    pub sizes_list: FT_ListRec,
+    pub autohint: FT_Generic,
+    pub extensions: *mut libc::c_void,
+    pub internal: FT_Face_Internal,
+}
+pub type FT_Face_Internal = *mut FT_Face_InternalRec_;
+pub type FT_CharMap = *mut FT_CharMapRec_;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct FT_CharMapRec_ {
+    pub face: FT_Face,
+    pub encoding: FT_Encoding,
+    pub platform_id: FT_UShort,
+    pub encoding_id: FT_UShort,
+}
+pub type FT_Encoding = FT_Encoding_;
+pub type FT_Encoding_ = libc::c_uint;
+pub const FT_ENCODING_APPLE_ROMAN: FT_Encoding_ = 1634889070;
+pub const FT_ENCODING_OLD_LATIN_2: FT_Encoding_ = 1818326066;
+pub const FT_ENCODING_ADOBE_LATIN_1: FT_Encoding_ = 1818326065;
+pub const FT_ENCODING_ADOBE_CUSTOM: FT_Encoding_ = 1094992451;
+pub const FT_ENCODING_ADOBE_EXPERT: FT_Encoding_ = 1094992453;
+pub const FT_ENCODING_ADOBE_STANDARD: FT_Encoding_ = 1094995778;
+pub const FT_ENCODING_MS_JOHAB: FT_Encoding_ = 1785686113;
+pub const FT_ENCODING_MS_WANSUNG: FT_Encoding_ = 2002873971;
+pub const FT_ENCODING_MS_BIG5: FT_Encoding_ = 1651074869;
+pub const FT_ENCODING_MS_GB2312: FT_Encoding_ = 1734484000;
+pub const FT_ENCODING_MS_SJIS: FT_Encoding_ = 1936353651;
+pub const FT_ENCODING_GB2312: FT_Encoding_ = 1734484000;
+pub const FT_ENCODING_JOHAB: FT_Encoding_ = 1785686113;
+pub const FT_ENCODING_WANSUNG: FT_Encoding_ = 2002873971;
+pub const FT_ENCODING_BIG5: FT_Encoding_ = 1651074869;
+pub const FT_ENCODING_PRC: FT_Encoding_ = 1734484000;
+pub const FT_ENCODING_SJIS: FT_Encoding_ = 1936353651;
+pub const FT_ENCODING_UNICODE: FT_Encoding_ = 1970170211;
+pub const FT_ENCODING_MS_SYMBOL: FT_Encoding_ = 1937337698;
+pub const FT_ENCODING_NONE: FT_Encoding_ = 0;
+pub type FT_Face = *mut FT_FaceRec_;
+pub type FT_Size = *mut FT_SizeRec_;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct FT_SizeRec_ {
+    pub face: FT_Face,
+    pub generic: FT_Generic,
+    pub metrics: FT_Size_Metrics,
+    pub internal: FT_Size_Internal,
+}
+pub type FT_Size_Internal = *mut FT_Size_InternalRec_;
+pub type FT_Size_Metrics = FT_Size_Metrics_;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct FT_Size_Metrics_ {
+    pub x_ppem: FT_UShort,
+    pub y_ppem: FT_UShort,
+    pub x_scale: FT_Fixed,
+    pub y_scale: FT_Fixed,
+    pub ascender: FT_Pos,
+    pub descender: FT_Pos,
+    pub height: FT_Pos,
+    pub max_advance: FT_Pos,
+}
+pub type FT_GlyphSlot = *mut FT_GlyphSlotRec_;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct FT_GlyphSlotRec_ {
+    pub library: FT_Library,
+    pub face: FT_Face,
+    pub next: FT_GlyphSlot,
+    pub glyph_index: FT_UInt,
+    pub generic: FT_Generic,
+    pub metrics: FT_Glyph_Metrics,
+    pub linearHoriAdvance: FT_Fixed,
+    pub linearVertAdvance: FT_Fixed,
+    pub advance: FT_Vector,
+    pub format: FT_Glyph_Format,
+    pub bitmap: FT_Bitmap,
+    pub bitmap_left: FT_Int,
+    pub bitmap_top: FT_Int,
+    pub outline: FT_Outline,
+    pub num_subglyphs: FT_UInt,
+    pub subglyphs: FT_SubGlyph,
+    pub control_data: *mut libc::c_void,
+    pub control_len: libc::c_long,
+    pub lsb_delta: FT_Pos,
+    pub rsb_delta: FT_Pos,
+    pub other: *mut libc::c_void,
+    pub internal: FT_Slot_Internal,
+}
+/* ***************************************************************************
+ *
+ * freetype.h
+ *
+ *   FreeType high-level API and common types (specification only).
+ *
+ * Copyright (C) 1996-2019 by
+ * David Turner, Robert Wilhelm, and Werner Lemberg.
+ *
+ * This file is part of the FreeType project, and may only be used,
+ * modified, and distributed under the terms of the FreeType project
+ * license, LICENSE.TXT.  By continuing to use, modify, or distribute
+ * this file you indicate that you have read the license and
+ * understand and accept it fully.
+ *
+ */
+/* *************************************************************************
+ *
+ * @section:
+ *   header_inclusion
+ *
+ * @title:
+ *   FreeType's header inclusion scheme
+ *
+ * @abstract:
+ *   How client applications should include FreeType header files.
+ *
+ * @description:
+ *   To be as flexible as possible (and for historical reasons), FreeType
+ *   uses a very special inclusion scheme to load header files, for example
+ *
+ *   ```
+ *     #include <ft2build.h>
+ *
+ *     #include FT_FREETYPE_H
+ *     #include FT_OUTLINE_H
+ *   ```
+ *
+ *   A compiler and its preprocessor only needs an include path to find the
+ *   file `ft2build.h`; the exact locations and names of the other FreeType
+ *   header files are hidden by @header_file_macros, loaded by
+ *   `ft2build.h`.  The API documentation always gives the header macro
+ *   name needed for a particular function.
+ *
+ */
+/* *************************************************************************
+ *
+ * @section:
+ *   user_allocation
+ *
+ * @title:
+ *   User allocation
+ *
+ * @abstract:
+ *   How client applications should allocate FreeType data structures.
+ *
+ * @description:
+ *   FreeType assumes that structures allocated by the user and passed as
+ *   arguments are zeroed out except for the actual data.  In other words,
+ *   it is recommended to use `calloc` (or variants of it) instead of
+ *   `malloc` for allocation.
+ *
+ */
+/* ************************************************************************/
+/* ************************************************************************/
+/*                                                                       */
+/*                        B A S I C   T Y P E S                          */
+/*                                                                       */
+/* ************************************************************************/
+/* ************************************************************************/
+/* *************************************************************************
+ *
+ * @section:
+ *   base_interface
+ *
+ * @title:
+ *   Base Interface
+ *
+ * @abstract:
+ *   The FreeType~2 base font interface.
+ *
+ * @description:
+ *   This section describes the most important public high-level API
+ *   functions of FreeType~2.
+ *
+ * @order:
+ *   FT_Library
+ *   FT_Face
+ *   FT_Size
+ *   FT_GlyphSlot
+ *   FT_CharMap
+ *   FT_Encoding
+ *   FT_ENC_TAG
+ *
+ *   FT_FaceRec
+ *
+ *   FT_FACE_FLAG_SCALABLE
+ *   FT_FACE_FLAG_FIXED_SIZES
+ *   FT_FACE_FLAG_FIXED_WIDTH
+ *   FT_FACE_FLAG_HORIZONTAL
+ *   FT_FACE_FLAG_VERTICAL
+ *   FT_FACE_FLAG_COLOR
+ *   FT_FACE_FLAG_SFNT
+ *   FT_FACE_FLAG_CID_KEYED
+ *   FT_FACE_FLAG_TRICKY
+ *   FT_FACE_FLAG_KERNING
+ *   FT_FACE_FLAG_MULTIPLE_MASTERS
+ *   FT_FACE_FLAG_VARIATION
+ *   FT_FACE_FLAG_GLYPH_NAMES
+ *   FT_FACE_FLAG_EXTERNAL_STREAM
+ *   FT_FACE_FLAG_HINTER
+ *
+ *   FT_HAS_HORIZONTAL
+ *   FT_HAS_VERTICAL
+ *   FT_HAS_KERNING
+ *   FT_HAS_FIXED_SIZES
+ *   FT_HAS_GLYPH_NAMES
+ *   FT_HAS_COLOR
+ *   FT_HAS_MULTIPLE_MASTERS
+ *
+ *   FT_IS_SFNT
+ *   FT_IS_SCALABLE
+ *   FT_IS_FIXED_WIDTH
+ *   FT_IS_CID_KEYED
+ *   FT_IS_TRICKY
+ *   FT_IS_NAMED_INSTANCE
+ *   FT_IS_VARIATION
+ *
+ *   FT_STYLE_FLAG_BOLD
+ *   FT_STYLE_FLAG_ITALIC
+ *
+ *   FT_SizeRec
+ *   FT_Size_Metrics
+ *
+ *   FT_GlyphSlotRec
+ *   FT_Glyph_Metrics
+ *   FT_SubGlyph
+ *
+ *   FT_Bitmap_Size
+ *
+ *   FT_Init_FreeType
+ *   FT_Done_FreeType
+ *
+ *   FT_New_Face
+ *   FT_Done_Face
+ *   FT_Reference_Face
+ *   FT_New_Memory_Face
+ *   FT_Face_Properties
+ *   FT_Open_Face
+ *   FT_Open_Args
+ *   FT_Parameter
+ *   FT_Attach_File
+ *   FT_Attach_Stream
+ *
+ *   FT_Set_Char_Size
+ *   FT_Set_Pixel_Sizes
+ *   FT_Request_Size
+ *   FT_Select_Size
+ *   FT_Size_Request_Type
+ *   FT_Size_RequestRec
+ *   FT_Size_Request
+ *   FT_Set_Transform
+ *   FT_Load_Glyph
+ *   FT_Get_Char_Index
+ *   FT_Get_First_Char
+ *   FT_Get_Next_Char
+ *   FT_Get_Name_Index
+ *   FT_Load_Char
+ *
+ *   FT_OPEN_MEMORY
+ *   FT_OPEN_STREAM
+ *   FT_OPEN_PATHNAME
+ *   FT_OPEN_DRIVER
+ *   FT_OPEN_PARAMS
+ *
+ *   FT_LOAD_DEFAULT
+ *   FT_LOAD_RENDER
+ *   FT_LOAD_MONOCHROME
+ *   FT_LOAD_LINEAR_DESIGN
+ *   FT_LOAD_NO_SCALE
+ *   FT_LOAD_NO_HINTING
+ *   FT_LOAD_NO_BITMAP
+ *   FT_LOAD_NO_AUTOHINT
+ *   FT_LOAD_COLOR
+ *
+ *   FT_LOAD_VERTICAL_LAYOUT
+ *   FT_LOAD_IGNORE_TRANSFORM
+ *   FT_LOAD_FORCE_AUTOHINT
+ *   FT_LOAD_NO_RECURSE
+ *   FT_LOAD_PEDANTIC
+ *
+ *   FT_LOAD_TARGET_NORMAL
+ *   FT_LOAD_TARGET_LIGHT
+ *   FT_LOAD_TARGET_MONO
+ *   FT_LOAD_TARGET_LCD
+ *   FT_LOAD_TARGET_LCD_V
+ *
+ *   FT_LOAD_TARGET_MODE
+ *
+ *   FT_Render_Glyph
+ *   FT_Render_Mode
+ *   FT_Get_Kerning
+ *   FT_Kerning_Mode
+ *   FT_Get_Track_Kerning
+ *   FT_Get_Glyph_Name
+ *   FT_Get_Postscript_Name
+ *
+ *   FT_CharMapRec
+ *   FT_Select_Charmap
+ *   FT_Set_Charmap
+ *   FT_Get_Charmap_Index
+ *
+ *   FT_Get_FSType_Flags
+ *   FT_Get_SubGlyph_Info
+ *
+ *   FT_Face_Internal
+ *   FT_Size_Internal
+ *   FT_Slot_Internal
+ *
+ *   FT_FACE_FLAG_XXX
+ *   FT_STYLE_FLAG_XXX
+ *   FT_OPEN_XXX
+ *   FT_LOAD_XXX
+ *   FT_LOAD_TARGET_XXX
+ *   FT_SUBGLYPH_FLAG_XXX
+ *   FT_FSTYPE_XXX
+ *
+ *   FT_HAS_FAST_GLYPHS
+ *
+ */
+/* *************************************************************************
+ *
+ * @struct:
+ *   FT_Glyph_Metrics
+ *
+ * @description:
+ *   A structure to model the metrics of a single glyph.  The values are
+ *   expressed in 26.6 fractional pixel format; if the flag
+ *   @FT_LOAD_NO_SCALE has been used while loading the glyph, values are
+ *   expressed in font units instead.
+ *
+ * @fields:
+ *   width ::
+ *     The glyph's width.
+ *
+ *   height ::
+ *     The glyph's height.
+ *
+ *   horiBearingX ::
+ *     Left side bearing for horizontal layout.
+ *
+ *   horiBearingY ::
+ *     Top side bearing for horizontal layout.
+ *
+ *   horiAdvance ::
+ *     Advance width for horizontal layout.
+ *
+ *   vertBearingX ::
+ *     Left side bearing for vertical layout.
+ *
+ *   vertBearingY ::
+ *     Top side bearing for vertical layout.  Larger positive values mean
+ *     further below the vertical glyph origin.
+ *
+ *   vertAdvance ::
+ *     Advance height for vertical layout.  Positive values mean the glyph
+ *     has a positive advance downward.
+ *
+ * @note:
+ *   If not disabled with @FT_LOAD_NO_HINTING, the values represent
+ *   dimensions of the hinted glyph (in case hinting is applicable).
+ *
+ *   Stroking a glyph with an outside border does not increase
+ *   `horiAdvance` or `vertAdvance`; you have to manually adjust these
+ *   values to account for the added width and height.
+ *
+ *   FreeType doesn't use the 'VORG' table data for CFF fonts because it
+ *   doesn't have an interface to quickly retrieve the glyph height.  The
+ *   y~coordinate of the vertical origin can be simply computed as
+ *   `vertBearingY + height` after loading a glyph.
+ */
+/* *************************************************************************
+ *
+ * @struct:
+ *   FT_Bitmap_Size
+ *
+ * @description:
+ *   This structure models the metrics of a bitmap strike (i.e., a set of
+ *   glyphs for a given point size and resolution) in a bitmap font.  It is
+ *   used for the `available_sizes` field of @FT_Face.
+ *
+ * @fields:
+ *   height ::
+ *     The vertical distance, in pixels, between two consecutive baselines.
+ *     It is always positive.
+ *
+ *   width ::
+ *     The average width, in pixels, of all glyphs in the strike.
+ *
+ *   size ::
+ *     The nominal size of the strike in 26.6 fractional points.  This
+ *     field is not very useful.
+ *
+ *   x_ppem ::
+ *     The horizontal ppem (nominal width) in 26.6 fractional pixels.
+ *
+ *   y_ppem ::
+ *     The vertical ppem (nominal height) in 26.6 fractional pixels.
+ *
+ * @note:
+ *   Windows FNT:
+ *     The nominal size given in a FNT font is not reliable.  If the driver
+ *     finds it incorrect, it sets `size` to some calculated values, and
+ *     `x_ppem` and `y_ppem` to the pixel width and height given in the
+ *     font, respectively.
+ *
+ *   TrueType embedded bitmaps:
+ *     `size`, `width`, and `height` values are not contained in the bitmap
+ *     strike itself.  They are computed from the global font parameters.
+ */
+/* ************************************************************************/
+/* ************************************************************************/
+/*                                                                       */
+/*                     O B J E C T   C L A S S E S                       */
+/*                                                                       */
+/* ************************************************************************/
+/* ************************************************************************/
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_Library
+ *
+ * @description:
+ *   A handle to a FreeType library instance.  Each 'library' is completely
+ *   independent from the others; it is the 'root' of a set of objects like
+ *   fonts, faces, sizes, etc.
+ *
+ *   It also embeds a memory manager (see @FT_Memory), as well as a
+ *   scan-line converter object (see @FT_Raster).
+ *
+ *   [Since 2.5.6] In multi-threaded applications it is easiest to use one
+ *   `FT_Library` object per thread.  In case this is too cumbersome, a
+ *   single `FT_Library` object across threads is possible also, as long as
+ *   a mutex lock is used around @FT_New_Face and @FT_Done_Face.
+ *
+ * @note:
+ *   Library objects are normally created by @FT_Init_FreeType, and
+ *   destroyed with @FT_Done_FreeType.  If you need reference-counting
+ *   (cf. @FT_Reference_Library), use @FT_New_Library and @FT_Done_Library.
+ */
+/* *************************************************************************
+ *
+ * @section:
+ *   module_management
+ *
+ */
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_Module
+ *
+ * @description:
+ *   A handle to a given FreeType module object.  A module can be a font
+ *   driver, a renderer, or anything else that provides services to the
+ *   former.
+ */
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_Driver
+ *
+ * @description:
+ *   A handle to a given FreeType font driver object.  A font driver is a
+ *   module capable of creating faces from font files.
+ */
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_Renderer
+ *
+ * @description:
+ *   A handle to a given FreeType renderer.  A renderer is a module in
+ *   charge of converting a glyph's outline image to a bitmap.  It supports
+ *   a single glyph image format, and one or more target surface depths.
+ */
+/* *************************************************************************
+ *
+ * @section:
+ *   base_interface
+ *
+ */
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_Face
+ *
+ * @description:
+ *   A handle to a typographic face object.  A face object models a given
+ *   typeface, in a given style.
+ *
+ * @note:
+ *   A face object also owns a single @FT_GlyphSlot object, as well as one
+ *   or more @FT_Size objects.
+ *
+ *   Use @FT_New_Face or @FT_Open_Face to create a new face object from a
+ *   given filepath or a custom input stream.
+ *
+ *   Use @FT_Done_Face to destroy it (along with its slot and sizes).
+ *
+ *   An `FT_Face` object can only be safely used from one thread at a time.
+ *   Similarly, creation and destruction of `FT_Face` with the same
+ *   @FT_Library object can only be done from one thread at a time.  On the
+ *   other hand, functions like @FT_Load_Glyph and its siblings are
+ *   thread-safe and do not need the lock to be held as long as the same
+ *   `FT_Face` object is not used from multiple threads at the same time.
+ *
+ * @also:
+ *   See @FT_FaceRec for the publicly accessible fields of a given face
+ *   object.
+ */
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_Size
+ *
+ * @description:
+ *   A handle to an object that models a face scaled to a given character
+ *   size.
+ *
+ * @note:
+ *   An @FT_Face has one _active_ @FT_Size object that is used by functions
+ *   like @FT_Load_Glyph to determine the scaling transformation that in
+ *   turn is used to load and hint glyphs and metrics.
+ *
+ *   You can use @FT_Set_Char_Size, @FT_Set_Pixel_Sizes, @FT_Request_Size
+ *   or even @FT_Select_Size to change the content (i.e., the scaling
+ *   values) of the active @FT_Size.
+ *
+ *   You can use @FT_New_Size to create additional size objects for a given
+ *   @FT_Face, but they won't be used by other functions until you activate
+ *   it through @FT_Activate_Size.  Only one size can be activated at any
+ *   given time per face.
+ *
+ * @also:
+ *   See @FT_SizeRec for the publicly accessible fields of a given size
+ *   object.
+ */
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_GlyphSlot
+ *
+ * @description:
+ *   A handle to a given 'glyph slot'.  A slot is a container that can hold
+ *   any of the glyphs contained in its parent face.
+ *
+ *   In other words, each time you call @FT_Load_Glyph or @FT_Load_Char,
+ *   the slot's content is erased by the new glyph data, i.e., the glyph's
+ *   metrics, its image (bitmap or outline), and other control information.
+ *
+ * @also:
+ *   See @FT_GlyphSlotRec for the publicly accessible glyph fields.
+ */
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_CharMap
+ *
+ * @description:
+ *   A handle to a character map (usually abbreviated to 'charmap').  A
+ *   charmap is used to translate character codes in a given encoding into
+ *   glyph indexes for its parent's face.  Some font formats may provide
+ *   several charmaps per font.
+ *
+ *   Each face object owns zero or more charmaps, but only one of them can
+ *   be 'active', providing the data used by @FT_Get_Char_Index or
+ *   @FT_Load_Char.
+ *
+ *   The list of available charmaps in a face is available through the
+ *   `face->num_charmaps` and `face->charmaps` fields of @FT_FaceRec.
+ *
+ *   The currently active charmap is available as `face->charmap`.  You
+ *   should call @FT_Set_Charmap to change it.
+ *
+ * @note:
+ *   When a new face is created (either through @FT_New_Face or
+ *   @FT_Open_Face), the library looks for a Unicode charmap within the
+ *   list and automatically activates it.  If there is no Unicode charmap,
+ *   FreeType doesn't set an 'active' charmap.
+ *
+ * @also:
+ *   See @FT_CharMapRec for the publicly accessible fields of a given
+ *   character map.
+ */
+/* *************************************************************************
+ *
+ * @macro:
+ *   FT_ENC_TAG
+ *
+ * @description:
+ *   This macro converts four-letter tags into an unsigned long.  It is
+ *   used to define 'encoding' identifiers (see @FT_Encoding).
+ *
+ * @note:
+ *   Since many 16-bit compilers don't like 32-bit enumerations, you should
+ *   redefine this macro in case of problems to something like this:
+ *
+ *   ```
+ *     #define FT_ENC_TAG( value, a, b, c, d )  value
+ *   ```
+ *
+ *   to get a simple enumeration without assigning special numbers.
+ */
+/* FT_ENC_TAG */
+/* *************************************************************************
+ *
+ * @enum:
+ *   FT_Encoding
+ *
+ * @description:
+ *   An enumeration to specify character sets supported by charmaps.  Used
+ *   in the @FT_Select_Charmap API function.
+ *
+ * @note:
+ *   Despite the name, this enumeration lists specific character
+ *   repertories (i.e., charsets), and not text encoding methods (e.g.,
+ *   UTF-8, UTF-16, etc.).
+ *
+ *   Other encodings might be defined in the future.
+ *
+ * @values:
+ *   FT_ENCODING_NONE ::
+ *     The encoding value~0 is reserved for all formats except BDF, PCF,
+ *     and Windows FNT; see below for more information.
+ *
+ *   FT_ENCODING_UNICODE ::
+ *     The Unicode character set.  This value covers all versions of the
+ *     Unicode repertoire, including ASCII and Latin-1.  Most fonts include
+ *     a Unicode charmap, but not all of them.
+ *
+ *     For example, if you want to access Unicode value U+1F028 (and the
+ *     font contains it), use value 0x1F028 as the input value for
+ *     @FT_Get_Char_Index.
+ *
+ *   FT_ENCODING_MS_SYMBOL ::
+ *     Microsoft Symbol encoding, used to encode mathematical symbols and
+ *     wingdings.  For more information, see
+ *     'https://www.microsoft.com/typography/otspec/recom.htm#non-standard-symbol-fonts',
+ *     'http://www.kostis.net/charsets/symbol.htm', and
+ *     'http://www.kostis.net/charsets/wingding.htm'.
+ *
+ *     This encoding uses character codes from the PUA (Private Unicode
+ *     Area) in the range U+F020-U+F0FF.
+ *
+ *   FT_ENCODING_SJIS ::
+ *     Shift JIS encoding for Japanese.  More info at
+ *     'https://en.wikipedia.org/wiki/Shift_JIS'.  See note on multi-byte
+ *     encodings below.
+ *
+ *   FT_ENCODING_PRC ::
+ *     Corresponds to encoding systems mainly for Simplified Chinese as
+ *     used in People's Republic of China (PRC).  The encoding layout is
+ *     based on GB~2312 and its supersets GBK and GB~18030.
+ *
+ *   FT_ENCODING_BIG5 ::
+ *     Corresponds to an encoding system for Traditional Chinese as used in
+ *     Taiwan and Hong Kong.
+ *
+ *   FT_ENCODING_WANSUNG ::
+ *     Corresponds to the Korean encoding system known as Extended Wansung
+ *     (MS Windows code page 949).  For more information see
+ *     'https://www.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/WindowsBestFit/bestfit949.txt'.
+ *
+ *   FT_ENCODING_JOHAB ::
+ *     The Korean standard character set (KS~C 5601-1992), which
+ *     corresponds to MS Windows code page 1361.  This character set
+ *     includes all possible Hangul character combinations.
+ *
+ *   FT_ENCODING_ADOBE_LATIN_1 ::
+ *     Corresponds to a Latin-1 encoding as defined in a Type~1 PostScript
+ *     font.  It is limited to 256 character codes.
+ *
+ *   FT_ENCODING_ADOBE_STANDARD ::
+ *     Adobe Standard encoding, as found in Type~1, CFF, and OpenType/CFF
+ *     fonts.  It is limited to 256 character codes.
+ *
+ *   FT_ENCODING_ADOBE_EXPERT ::
+ *     Adobe Expert encoding, as found in Type~1, CFF, and OpenType/CFF
+ *     fonts.  It is limited to 256 character codes.
+ *
+ *   FT_ENCODING_ADOBE_CUSTOM ::
+ *     Corresponds to a custom encoding, as found in Type~1, CFF, and
+ *     OpenType/CFF fonts.  It is limited to 256 character codes.
+ *
+ *   FT_ENCODING_APPLE_ROMAN ::
+ *     Apple roman encoding.  Many TrueType and OpenType fonts contain a
+ *     charmap for this 8-bit encoding, since older versions of Mac OS are
+ *     able to use it.
+ *
+ *   FT_ENCODING_OLD_LATIN_2 ::
+ *     This value is deprecated and was neither used nor reported by
+ *     FreeType.  Don't use or test for it.
+ *
+ *   FT_ENCODING_MS_SJIS ::
+ *     Same as FT_ENCODING_SJIS.  Deprecated.
+ *
+ *   FT_ENCODING_MS_GB2312 ::
+ *     Same as FT_ENCODING_PRC.  Deprecated.
+ *
+ *   FT_ENCODING_MS_BIG5 ::
+ *     Same as FT_ENCODING_BIG5.  Deprecated.
+ *
+ *   FT_ENCODING_MS_WANSUNG ::
+ *     Same as FT_ENCODING_WANSUNG.  Deprecated.
+ *
+ *   FT_ENCODING_MS_JOHAB ::
+ *     Same as FT_ENCODING_JOHAB.  Deprecated.
+ *
+ * @note:
+ *   By default, FreeType enables a Unicode charmap and tags it with
+ *   `FT_ENCODING_UNICODE` when it is either provided or can be generated
+ *   from PostScript glyph name dictionaries in the font file.  All other
+ *   encodings are considered legacy and tagged only if explicitly defined
+ *   in the font file.  Otherwise, `FT_ENCODING_NONE` is used.
+ *
+ *   `FT_ENCODING_NONE` is set by the BDF and PCF drivers if the charmap is
+ *   neither Unicode nor ISO-8859-1 (otherwise it is set to
+ *   `FT_ENCODING_UNICODE`).  Use @FT_Get_BDF_Charset_ID to find out which
+ *   encoding is really present.  If, for example, the `cs_registry` field
+ *   is 'KOI8' and the `cs_encoding` field is 'R', the font is encoded in
+ *   KOI8-R.
+ *
+ *   `FT_ENCODING_NONE` is always set (with a single exception) by the
+ *   winfonts driver.  Use @FT_Get_WinFNT_Header and examine the `charset`
+ *   field of the @FT_WinFNT_HeaderRec structure to find out which encoding
+ *   is really present.  For example, @FT_WinFNT_ID_CP1251 (204) means
+ *   Windows code page 1251 (for Russian).
+ *
+ *   `FT_ENCODING_NONE` is set if `platform_id` is @TT_PLATFORM_MACINTOSH
+ *   and `encoding_id` is not `TT_MAC_ID_ROMAN` (otherwise it is set to
+ *   `FT_ENCODING_APPLE_ROMAN`).
+ *
+ *   If `platform_id` is @TT_PLATFORM_MACINTOSH, use the function
+ *   @FT_Get_CMap_Language_ID to query the Mac language ID that may be
+ *   needed to be able to distinguish Apple encoding variants.  See
+ *
+ *     https://www.unicode.org/Public/MAPPINGS/VENDORS/APPLE/Readme.txt
+ *
+ *   to get an idea how to do that.  Basically, if the language ID is~0,
+ *   don't use it, otherwise subtract 1 from the language ID.  Then examine
+ *   `encoding_id`.  If, for example, `encoding_id` is `TT_MAC_ID_ROMAN`
+ *   and the language ID (minus~1) is `TT_MAC_LANGID_GREEK`, it is the
+ *   Greek encoding, not Roman.  `TT_MAC_ID_ARABIC` with
+ *   `TT_MAC_LANGID_FARSI` means the Farsi variant the Arabic encoding.
+ */
+/* for backward compatibility */
+/* these constants are deprecated; use the corresponding `FT_Encoding` */
+/* values instead                                                      */
+/* *************************************************************************
+ *
+ * @struct:
+ *   FT_CharMapRec
+ *
+ * @description:
+ *   The base charmap structure.
+ *
+ * @fields:
+ *   face ::
+ *     A handle to the parent face object.
+ *
+ *   encoding ::
+ *     An @FT_Encoding tag identifying the charmap.  Use this with
+ *     @FT_Select_Charmap.
+ *
+ *   platform_id ::
+ *     An ID number describing the platform for the following encoding ID.
+ *     This comes directly from the TrueType specification and gets
+ *     emulated for other formats.
+ *
+ *   encoding_id ::
+ *     A platform-specific encoding number.  This also comes from the
+ *     TrueType specification and gets emulated similarly.
+ */
+/* ************************************************************************/
+/* ************************************************************************/
+/*                                                                       */
+/*                 B A S E   O B J E C T   C L A S S E S                 */
+/*                                                                       */
+/* ************************************************************************/
+/* ************************************************************************/
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_Face_Internal
+ *
+ * @description:
+ *   An opaque handle to an `FT_Face_InternalRec` structure that models the
+ *   private data of a given @FT_Face object.
+ *
+ *   This structure might change between releases of FreeType~2 and is not
+ *   generally available to client applications.
+ */
+/* *************************************************************************
+ *
+ * @struct:
+ *   FT_FaceRec
+ *
+ * @description:
+ *   FreeType root face class structure.  A face object models a typeface
+ *   in a font file.
+ *
+ * @fields:
+ *   num_faces ::
+ *     The number of faces in the font file.  Some font formats can have
+ *     multiple faces in a single font file.
+ *
+ *   face_index ::
+ *     This field holds two different values.  Bits 0-15 are the index of
+ *     the face in the font file (starting with value~0).  They are set
+ *     to~0 if there is only one face in the font file.
+ *
+ *     [Since 2.6.1] Bits 16-30 are relevant to GX and OpenType variation
+ *     fonts only, holding the named instance index for the current face
+ *     index (starting with value~1; value~0 indicates font access without
+ *     a named instance).  For non-variation fonts, bits 16-30 are ignored.
+ *     If we have the third named instance of face~4, say, `face_index` is
+ *     set to 0x00030004.
+ *
+ *     Bit 31 is always zero (this is, `face_index` is always a positive
+ *     value).
+ *
+ *     [Since 2.9] Changing the design coordinates with
+ *     @FT_Set_Var_Design_Coordinates or @FT_Set_Var_Blend_Coordinates does
+ *     not influence the named instance index value (only
+ *     @FT_Set_Named_Instance does that).
+ *
+ *   face_flags ::
+ *     A set of bit flags that give important information about the face;
+ *     see @FT_FACE_FLAG_XXX for the details.
+ *
+ *   style_flags ::
+ *     The lower 16~bits contain a set of bit flags indicating the style of
+ *     the face; see @FT_STYLE_FLAG_XXX for the details.
+ *
+ *     [Since 2.6.1] Bits 16-30 hold the number of named instances
+ *     available for the current face if we have a GX or OpenType variation
+ *     (sub)font.  Bit 31 is always zero (this is, `style_flags` is always
+ *     a positive value).  Note that a variation font has always at least
+ *     one named instance, namely the default instance.
+ *
+ *   num_glyphs ::
+ *     The number of glyphs in the face.  If the face is scalable and has
+ *     sbits (see `num_fixed_sizes`), it is set to the number of outline
+ *     glyphs.
+ *
+ *     For CID-keyed fonts (not in an SFNT wrapper) this value gives the
+ *     highest CID used in the font.
+ *
+ *   family_name ::
+ *     The face's family name.  This is an ASCII string, usually in
+ *     English, that describes the typeface's family (like 'Times New
+ *     Roman', 'Bodoni', 'Garamond', etc).  This is a least common
+ *     denominator used to list fonts.  Some formats (TrueType & OpenType)
+ *     provide localized and Unicode versions of this string.  Applications
+ *     should use the format-specific interface to access them.  Can be
+ *     `NULL` (e.g., in fonts embedded in a PDF file).
+ *
+ *     In case the font doesn't provide a specific family name entry,
+ *     FreeType tries to synthesize one, deriving it from other name
+ *     entries.
+ *
+ *   style_name ::
+ *     The face's style name.  This is an ASCII string, usually in English,
+ *     that describes the typeface's style (like 'Italic', 'Bold',
+ *     'Condensed', etc).  Not all font formats provide a style name, so
+ *     this field is optional, and can be set to `NULL`.  As for
+ *     `family_name`, some formats provide localized and Unicode versions
+ *     of this string.  Applications should use the format-specific
+ *     interface to access them.
+ *
+ *   num_fixed_sizes ::
+ *     The number of bitmap strikes in the face.  Even if the face is
+ *     scalable, there might still be bitmap strikes, which are called
+ *     'sbits' in that case.
+ *
+ *   available_sizes ::
+ *     An array of @FT_Bitmap_Size for all bitmap strikes in the face.  It
+ *     is set to `NULL` if there is no bitmap strike.
+ *
+ *     Note that FreeType tries to sanitize the strike data since they are
+ *     sometimes sloppy or incorrect, but this can easily fail.
+ *
+ *   num_charmaps ::
+ *     The number of charmaps in the face.
+ *
+ *   charmaps ::
+ *     An array of the charmaps of the face.
+ *
+ *   generic ::
+ *     A field reserved for client uses.  See the @FT_Generic type
+ *     description.
+ *
+ *   bbox ::
+ *     The font bounding box.  Coordinates are expressed in font units (see
+ *     `units_per_EM`).  The box is large enough to contain any glyph from
+ *     the font.  Thus, `bbox.yMax` can be seen as the 'maximum ascender',
+ *     and `bbox.yMin` as the 'minimum descender'.  Only relevant for
+ *     scalable formats.
+ *
+ *     Note that the bounding box might be off by (at least) one pixel for
+ *     hinted fonts.  See @FT_Size_Metrics for further discussion.
+ *
+ *   units_per_EM ::
+ *     The number of font units per EM square for this face.  This is
+ *     typically 2048 for TrueType fonts, and 1000 for Type~1 fonts.  Only
+ *     relevant for scalable formats.
+ *
+ *   ascender ::
+ *     The typographic ascender of the face, expressed in font units.  For
+ *     font formats not having this information, it is set to `bbox.yMax`.
+ *     Only relevant for scalable formats.
+ *
+ *   descender ::
+ *     The typographic descender of the face, expressed in font units.  For
+ *     font formats not having this information, it is set to `bbox.yMin`.
+ *     Note that this field is negative for values below the baseline.
+ *     Only relevant for scalable formats.
+ *
+ *   height ::
+ *     This value is the vertical distance between two consecutive
+ *     baselines, expressed in font units.  It is always positive.  Only
+ *     relevant for scalable formats.
+ *
+ *     If you want the global glyph height, use `ascender - descender`.
+ *
+ *   max_advance_width ::
+ *     The maximum advance width, in font units, for all glyphs in this
+ *     face.  This can be used to make word wrapping computations faster.
+ *     Only relevant for scalable formats.
+ *
+ *   max_advance_height ::
+ *     The maximum advance height, in font units, for all glyphs in this
+ *     face.  This is only relevant for vertical layouts, and is set to
+ *     `height` for fonts that do not provide vertical metrics.  Only
+ *     relevant for scalable formats.
+ *
+ *   underline_position ::
+ *     The position, in font units, of the underline line for this face.
+ *     It is the center of the underlining stem.  Only relevant for
+ *     scalable formats.
+ *
+ *   underline_thickness ::
+ *     The thickness, in font units, of the underline for this face.  Only
+ *     relevant for scalable formats.
+ *
+ *   glyph ::
+ *     The face's associated glyph slot(s).
+ *
+ *   size ::
+ *     The current active size for this face.
+ *
+ *   charmap ::
+ *     The current active charmap for this face.
+ *
+ * @note:
+ *   Fields may be changed after a call to @FT_Attach_File or
+ *   @FT_Attach_Stream.
+ *
+ *   For an OpenType variation font, the values of the following fields can
+ *   change after a call to @FT_Set_Var_Design_Coordinates (and friends) if
+ *   the font contains an 'MVAR' table: `ascender`, `descender`, `height`,
+ *   `underline_position`, and `underline_thickness`.
+ *
+ *   Especially for TrueType fonts see also the documentation for
+ *   @FT_Size_Metrics.
+ */
+/*# The following member variables (down to `underline_thickness`) */
+/*# are only relevant to scalable outlines; cf. @FT_Bitmap_Size    */
+/*# for bitmap fonts.                                              */
+/*@private begin */
+/* face-specific auto-hinter data */
+/* unused                         */
+/*@private end */
+/* *************************************************************************
+ *
+ * @enum:
+ *   FT_FACE_FLAG_XXX
+ *
+ * @description:
+ *   A list of bit flags used in the `face_flags` field of the @FT_FaceRec
+ *   structure.  They inform client applications of properties of the
+ *   corresponding face.
+ *
+ * @values:
+ *   FT_FACE_FLAG_SCALABLE ::
+ *     The face contains outline glyphs.  Note that a face can contain
+ *     bitmap strikes also, i.e., a face can have both this flag and
+ *     @FT_FACE_FLAG_FIXED_SIZES set.
+ *
+ *   FT_FACE_FLAG_FIXED_SIZES ::
+ *     The face contains bitmap strikes.  See also the `num_fixed_sizes`
+ *     and `available_sizes` fields of @FT_FaceRec.
+ *
+ *   FT_FACE_FLAG_FIXED_WIDTH ::
+ *     The face contains fixed-width characters (like Courier, Lucida,
+ *     MonoType, etc.).
+ *
+ *   FT_FACE_FLAG_SFNT ::
+ *     The face uses the SFNT storage scheme.  For now, this means TrueType
+ *     and OpenType.
+ *
+ *   FT_FACE_FLAG_HORIZONTAL ::
+ *     The face contains horizontal glyph metrics.  This should be set for
+ *     all common formats.
+ *
+ *   FT_FACE_FLAG_VERTICAL ::
+ *     The face contains vertical glyph metrics.  This is only available in
+ *     some formats, not all of them.
+ *
+ *   FT_FACE_FLAG_KERNING ::
+ *     The face contains kerning information.  If set, the kerning distance
+ *     can be retrieved using the function @FT_Get_Kerning.  Otherwise the
+ *     function always return the vector (0,0).  Note that FreeType doesn't
+ *     handle kerning data from the SFNT 'GPOS' table (as present in many
+ *     OpenType fonts).
+ *
+ *   FT_FACE_FLAG_FAST_GLYPHS ::
+ *     THIS FLAG IS DEPRECATED.  DO NOT USE OR TEST IT.
+ *
+ *   FT_FACE_FLAG_MULTIPLE_MASTERS ::
+ *     The face contains multiple masters and is capable of interpolating
+ *     between them.  Supported formats are Adobe MM, TrueType GX, and
+ *     OpenType variation fonts.
+ *
+ *     See section @multiple_masters for API details.
+ *
+ *   FT_FACE_FLAG_GLYPH_NAMES ::
+ *     The face contains glyph names, which can be retrieved using
+ *     @FT_Get_Glyph_Name.  Note that some TrueType fonts contain broken
+ *     glyph name tables.  Use the function @FT_Has_PS_Glyph_Names when
+ *     needed.
+ *
+ *   FT_FACE_FLAG_EXTERNAL_STREAM ::
+ *     Used internally by FreeType to indicate that a face's stream was
+ *     provided by the client application and should not be destroyed when
+ *     @FT_Done_Face is called.  Don't read or test this flag.
+ *
+ *   FT_FACE_FLAG_HINTER ::
+ *     The font driver has a hinting machine of its own.  For example, with
+ *     TrueType fonts, it makes sense to use data from the SFNT 'gasp'
+ *     table only if the native TrueType hinting engine (with the bytecode
+ *     interpreter) is available and active.
+ *
+ *   FT_FACE_FLAG_CID_KEYED ::
+ *     The face is CID-keyed.  In that case, the face is not accessed by
+ *     glyph indices but by CID values.  For subsetted CID-keyed fonts this
+ *     has the consequence that not all index values are a valid argument
+ *     to @FT_Load_Glyph.  Only the CID values for which corresponding
+ *     glyphs in the subsetted font exist make `FT_Load_Glyph` return
+ *     successfully; in all other cases you get an
+ *     `FT_Err_Invalid_Argument` error.
+ *
+ *     Note that CID-keyed fonts that are in an SFNT wrapper (this is, all
+ *     OpenType/CFF fonts) don't have this flag set since the glyphs are
+ *     accessed in the normal way (using contiguous indices); the
+ *     'CID-ness' isn't visible to the application.
+ *
+ *   FT_FACE_FLAG_TRICKY ::
+ *     The face is 'tricky', this is, it always needs the font format's
+ *     native hinting engine to get a reasonable result.  A typical example
+ *     is the old Chinese font `mingli.ttf` (but not `mingliu.ttc`) that
+ *     uses TrueType bytecode instructions to move and scale all of its
+ *     subglyphs.
+ *
+ *     It is not possible to auto-hint such fonts using
+ *     @FT_LOAD_FORCE_AUTOHINT; it will also ignore @FT_LOAD_NO_HINTING.
+ *     You have to set both @FT_LOAD_NO_HINTING and @FT_LOAD_NO_AUTOHINT to
+ *     really disable hinting; however, you probably never want this except
+ *     for demonstration purposes.
+ *
+ *     Currently, there are about a dozen TrueType fonts in the list of
+ *     tricky fonts; they are hard-coded in file `ttobjs.c`.
+ *
+ *   FT_FACE_FLAG_COLOR ::
+ *     [Since 2.5.1] The face has color glyph tables.  See @FT_LOAD_COLOR
+ *     for more information.
+ *
+ *   FT_FACE_FLAG_VARIATION ::
+ *     [Since 2.9] Set if the current face (or named instance) has been
+ *     altered with @FT_Set_MM_Design_Coordinates,
+ *     @FT_Set_Var_Design_Coordinates, or @FT_Set_Var_Blend_Coordinates.
+ *     This flag is unset by a call to @FT_Set_Named_Instance.
+ */
+/* *************************************************************************
+ *
+ * @macro:
+ *   FT_HAS_HORIZONTAL
+ *
+ * @description:
+ *   A macro that returns true whenever a face object contains horizontal
+ *   metrics (this is true for all font formats though).
+ *
+ * @also:
+ *   @FT_HAS_VERTICAL can be used to check for vertical metrics.
+ *
+ */
+/* *************************************************************************
+ *
+ * @macro:
+ *   FT_HAS_VERTICAL
+ *
+ * @description:
+ *   A macro that returns true whenever a face object contains real
+ *   vertical metrics (and not only synthesized ones).
+ *
+ */
+/* *************************************************************************
+ *
+ * @macro:
+ *   FT_HAS_KERNING
+ *
+ * @description:
+ *   A macro that returns true whenever a face object contains kerning data
+ *   that can be accessed with @FT_Get_Kerning.
+ *
+ */
+/* *************************************************************************
+ *
+ * @macro:
+ *   FT_IS_SCALABLE
+ *
+ * @description:
+ *   A macro that returns true whenever a face object contains a scalable
+ *   font face (true for TrueType, Type~1, Type~42, CID, OpenType/CFF, and
+ *   PFR font formats).
+ *
+ */
+/* *************************************************************************
+ *
+ * @macro:
+ *   FT_IS_SFNT
+ *
+ * @description:
+ *   A macro that returns true whenever a face object contains a font whose
+ *   format is based on the SFNT storage scheme.  This usually means:
+ *   TrueType fonts, OpenType fonts, as well as SFNT-based embedded bitmap
+ *   fonts.
+ *
+ *   If this macro is true, all functions defined in @FT_SFNT_NAMES_H and
+ *   @FT_TRUETYPE_TABLES_H are available.
+ *
+ */
+/* *************************************************************************
+ *
+ * @macro:
+ *   FT_IS_FIXED_WIDTH
+ *
+ * @description:
+ *   A macro that returns true whenever a face object contains a font face
+ *   that contains fixed-width (or 'monospace', 'fixed-pitch', etc.)
+ *   glyphs.
+ *
+ */
+/* *************************************************************************
+ *
+ * @macro:
+ *   FT_HAS_FIXED_SIZES
+ *
+ * @description:
+ *   A macro that returns true whenever a face object contains some
+ *   embedded bitmaps.  See the `available_sizes` field of the @FT_FaceRec
+ *   structure.
+ *
+ */
+/* *************************************************************************
+ *
+ * @macro:
+ *   FT_HAS_FAST_GLYPHS
+ *
+ * @description:
+ *   Deprecated.
+ *
+ */
+/* *************************************************************************
+ *
+ * @macro:
+ *   FT_HAS_GLYPH_NAMES
+ *
+ * @description:
+ *   A macro that returns true whenever a face object contains some glyph
+ *   names that can be accessed through @FT_Get_Glyph_Name.
+ *
+ */
+/* *************************************************************************
+ *
+ * @macro:
+ *   FT_HAS_MULTIPLE_MASTERS
+ *
+ * @description:
+ *   A macro that returns true whenever a face object contains some
+ *   multiple masters.  The functions provided by @FT_MULTIPLE_MASTERS_H
+ *   are then available to choose the exact design you want.
+ *
+ */
+/* *************************************************************************
+ *
+ * @macro:
+ *   FT_IS_NAMED_INSTANCE
+ *
+ * @description:
+ *   A macro that returns true whenever a face object is a named instance
+ *   of a GX or OpenType variation font.
+ *
+ *   [Since 2.9] Changing the design coordinates with
+ *   @FT_Set_Var_Design_Coordinates or @FT_Set_Var_Blend_Coordinates does
+ *   not influence the return value of this macro (only
+ *   @FT_Set_Named_Instance does that).
+ *
+ * @since:
+ *   2.7
+ *
+ */
+/* *************************************************************************
+ *
+ * @macro:
+ *   FT_IS_VARIATION
+ *
+ * @description:
+ *   A macro that returns true whenever a face object has been altered by
+ *   @FT_Set_MM_Design_Coordinates, @FT_Set_Var_Design_Coordinates, or
+ *   @FT_Set_Var_Blend_Coordinates.
+ *
+ * @since:
+ *   2.9
+ *
+ */
+/* *************************************************************************
+ *
+ * @macro:
+ *   FT_IS_CID_KEYED
+ *
+ * @description:
+ *   A macro that returns true whenever a face object contains a CID-keyed
+ *   font.  See the discussion of @FT_FACE_FLAG_CID_KEYED for more details.
+ *
+ *   If this macro is true, all functions defined in @FT_CID_H are
+ *   available.
+ *
+ */
+/* *************************************************************************
+ *
+ * @macro:
+ *   FT_IS_TRICKY
+ *
+ * @description:
+ *   A macro that returns true whenever a face represents a 'tricky' font.
+ *   See the discussion of @FT_FACE_FLAG_TRICKY for more details.
+ *
+ */
+/* *************************************************************************
+ *
+ * @macro:
+ *   FT_HAS_COLOR
+ *
+ * @description:
+ *   A macro that returns true whenever a face object contains tables for
+ *   color glyphs.
+ *
+ * @since:
+ *   2.5.1
+ *
+ */
+/* *************************************************************************
+ *
+ * @enum:
+ *   FT_STYLE_FLAG_XXX
+ *
+ * @description:
+ *   A list of bit flags to indicate the style of a given face.  These are
+ *   used in the `style_flags` field of @FT_FaceRec.
+ *
+ * @values:
+ *   FT_STYLE_FLAG_ITALIC ::
+ *     The face style is italic or oblique.
+ *
+ *   FT_STYLE_FLAG_BOLD ::
+ *     The face is bold.
+ *
+ * @note:
+ *   The style information as provided by FreeType is very basic.  More
+ *   details are beyond the scope and should be done on a higher level (for
+ *   example, by analyzing various fields of the 'OS/2' table in SFNT based
+ *   fonts).
+ */
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_Size_Internal
+ *
+ * @description:
+ *   An opaque handle to an `FT_Size_InternalRec` structure, used to model
+ *   private data of a given @FT_Size object.
+ */
+/* *************************************************************************
+ *
+ * @struct:
+ *   FT_Size_Metrics
+ *
+ * @description:
+ *   The size metrics structure gives the metrics of a size object.
+ *
+ * @fields:
+ *   x_ppem ::
+ *     The width of the scaled EM square in pixels, hence the term 'ppem'
+ *     (pixels per EM).  It is also referred to as 'nominal width'.
+ *
+ *   y_ppem ::
+ *     The height of the scaled EM square in pixels, hence the term 'ppem'
+ *     (pixels per EM).  It is also referred to as 'nominal height'.
+ *
+ *   x_scale ::
+ *     A 16.16 fractional scaling value to convert horizontal metrics from
+ *     font units to 26.6 fractional pixels.  Only relevant for scalable
+ *     font formats.
+ *
+ *   y_scale ::
+ *     A 16.16 fractional scaling value to convert vertical metrics from
+ *     font units to 26.6 fractional pixels.  Only relevant for scalable
+ *     font formats.
+ *
+ *   ascender ::
+ *     The ascender in 26.6 fractional pixels, rounded up to an integer
+ *     value.  See @FT_FaceRec for the details.
+ *
+ *   descender ::
+ *     The descender in 26.6 fractional pixels, rounded down to an integer
+ *     value.  See @FT_FaceRec for the details.
+ *
+ *   height ::
+ *     The height in 26.6 fractional pixels, rounded to an integer value.
+ *     See @FT_FaceRec for the details.
+ *
+ *   max_advance ::
+ *     The maximum advance width in 26.6 fractional pixels, rounded to an
+ *     integer value.  See @FT_FaceRec for the details.
+ *
+ * @note:
+ *   The scaling values, if relevant, are determined first during a size
+ *   changing operation.  The remaining fields are then set by the driver.
+ *   For scalable formats, they are usually set to scaled values of the
+ *   corresponding fields in @FT_FaceRec.  Some values like ascender or
+ *   descender are rounded for historical reasons; more precise values (for
+ *   outline fonts) can be derived by scaling the corresponding @FT_FaceRec
+ *   values manually, with code similar to the following.
+ *
+ *   ```
+ *     scaled_ascender = FT_MulFix( face->ascender,
+ *                                  size_metrics->y_scale );
+ *   ```
+ *
+ *   Note that due to glyph hinting and the selected rendering mode these
+ *   values are usually not exact; consequently, they must be treated as
+ *   unreliable with an error margin of at least one pixel!
+ *
+ *   Indeed, the only way to get the exact metrics is to render _all_
+ *   glyphs.  As this would be a definite performance hit, it is up to
+ *   client applications to perform such computations.
+ *
+ *   The `FT_Size_Metrics` structure is valid for bitmap fonts also.
+ *
+ *
+ *   **TrueType fonts with native bytecode hinting**
+ *
+ *   All applications that handle TrueType fonts with native hinting must
+ *   be aware that TTFs expect different rounding of vertical font
+ *   dimensions.  The application has to cater for this, especially if it
+ *   wants to rely on a TTF's vertical data (for example, to properly align
+ *   box characters vertically).
+ *
+ *   Only the application knows _in advance_ that it is going to use native
+ *   hinting for TTFs!  FreeType, on the other hand, selects the hinting
+ *   mode not at the time of creating an @FT_Size object but much later,
+ *   namely while calling @FT_Load_Glyph.
+ *
+ *   Here is some pseudo code that illustrates a possible solution.
+ *
+ *   ```
+ *     font_format = FT_Get_Font_Format( face );
+ *
+ *     if ( !strcmp( font_format, "TrueType" ) &&
+ *          do_native_bytecode_hinting         )
+ *     {
+ *       ascender  = ROUND( FT_MulFix( face->ascender,
+ *                                     size_metrics->y_scale ) );
+ *       descender = ROUND( FT_MulFix( face->descender,
+ *                                     size_metrics->y_scale ) );
+ *     }
+ *     else
+ *     {
+ *       ascender  = size_metrics->ascender;
+ *       descender = size_metrics->descender;
+ *     }
+ *
+ *     height      = size_metrics->height;
+ *     max_advance = size_metrics->max_advance;
+ *   ```
+ */
+/* horizontal pixels per EM               */
+/* vertical pixels per EM                 */
+/* scaling values used to convert font    */
+/* units to 26.6 fractional pixels        */
+/* ascender in 26.6 frac. pixels          */
+/* descender in 26.6 frac. pixels         */
+/* text height in 26.6 frac. pixels       */
+/* max horizontal advance, in 26.6 pixels */
+/* *************************************************************************
+ *
+ * @struct:
+ *   FT_SizeRec
+ *
+ * @description:
+ *   FreeType root size class structure.  A size object models a face
+ *   object at a given size.
+ *
+ * @fields:
+ *   face ::
+ *     Handle to the parent face object.
+ *
+ *   generic ::
+ *     A typeless pointer, unused by the FreeType library or any of its
+ *     drivers.  It can be used by client applications to link their own
+ *     data to each size object.
+ *
+ *   metrics ::
+ *     Metrics for this size object.  This field is read-only.
+ */
+/* parent face object              */
+/* generic pointer for client uses */
+/* size metrics                    */
+/* *************************************************************************
+ *
+ * @struct:
+ *   FT_SubGlyph
+ *
+ * @description:
+ *   The subglyph structure is an internal object used to describe
+ *   subglyphs (for example, in the case of composites).
+ *
+ * @note:
+ *   The subglyph implementation is not part of the high-level API, hence
+ *   the forward structure declaration.
+ *
+ *   You can however retrieve subglyph information with
+ *   @FT_Get_SubGlyph_Info.
+ */
+/* *************************************************************************
+ *
+ * @type:
+ *   FT_Slot_Internal
+ *
+ * @description:
+ *   An opaque handle to an `FT_Slot_InternalRec` structure, used to model
+ *   private data of a given @FT_GlyphSlot object.
+ */
+pub type FT_Slot_Internal = *mut FT_Slot_InternalRec_;
+pub type FT_SubGlyph = *mut FT_SubGlyphRec_;
+pub type scaled_t = int32_t;
+pub type UInt8 = libc::c_uchar;
+pub type UInt32 = libc::c_uint;
+pub type SInt32 = libc::c_int;
+pub type Fixed = SInt32;
+pub type Fract = SInt32;
+#[derive(Copy, Clone)]
+#[repr(C, packed(2))]
+pub struct FixedPoint {
+    pub x: Fixed,
+    pub y: Fixed,
+}
+pub type CFOptionFlags = libc::c_ulong;
+pub type CFHashCode = libc::c_ulong;
+pub type CFIndex = libc::c_long;
+pub type CFTypeRef = *const libc::c_void;
+pub type CFComparisonResult = CFIndex;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct CFRange {
+    pub location: CFIndex,
+    pub length: CFIndex,
+}
+pub type CFArrayRetainCallBack =
+    Option<unsafe extern "C" fn(_: CFAllocatorRef, _: *const libc::c_void) -> *const libc::c_void>;
+pub type CFArrayReleaseCallBack =
+    Option<unsafe extern "C" fn(_: CFAllocatorRef, _: *const libc::c_void) -> ()>;
+pub type CFArrayCopyDescriptionCallBack =
+    Option<unsafe extern "C" fn(_: *const libc::c_void) -> CFStringRef>;
+pub type CFArrayEqualCallBack =
+    Option<unsafe extern "C" fn(_: *const libc::c_void, _: *const libc::c_void) -> Boolean>;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct CFArrayCallBacks {
+    pub version: CFIndex,
+    pub retain: CFArrayRetainCallBack,
+    pub release: CFArrayReleaseCallBack,
+    pub copyDescription: CFArrayCopyDescriptionCallBack,
+    pub equal: CFArrayEqualCallBack,
+}
+pub type CFArrayRef = *const __CFArray;
+pub type CFMutableArrayRef = *mut __CFArray;
+pub type CFDictionaryRetainCallBack =
+    Option<unsafe extern "C" fn(_: CFAllocatorRef, _: *const libc::c_void) -> *const libc::c_void>;
+pub type CFDictionaryReleaseCallBack =
+    Option<unsafe extern "C" fn(_: CFAllocatorRef, _: *const libc::c_void) -> ()>;
+pub type CFDictionaryCopyDescriptionCallBack =
+    Option<unsafe extern "C" fn(_: *const libc::c_void) -> CFStringRef>;
+pub type CFDictionaryEqualCallBack =
+    Option<unsafe extern "C" fn(_: *const libc::c_void, _: *const libc::c_void) -> Boolean>;
+pub type CFDictionaryHashCallBack =
+    Option<unsafe extern "C" fn(_: *const libc::c_void) -> CFHashCode>;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct CFDictionaryKeyCallBacks {
+    pub version: CFIndex,
+    pub retain: CFDictionaryRetainCallBack,
+    pub release: CFDictionaryReleaseCallBack,
+    pub copyDescription: CFDictionaryCopyDescriptionCallBack,
+    pub equal: CFDictionaryEqualCallBack,
+    pub hash: CFDictionaryHashCallBack,
+}
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct CFDictionaryValueCallBacks {
+    pub version: CFIndex,
+    pub retain: CFDictionaryRetainCallBack,
+    pub release: CFDictionaryReleaseCallBack,
+    pub copyDescription: CFDictionaryCopyDescriptionCallBack,
+    pub equal: CFDictionaryEqualCallBack,
+}
+pub type CFMutableDictionaryRef = *mut __CFDictionary;
+pub type CFStringEncoding = UInt32;
+pub type C2RustUnnamed = libc::c_uint;
+pub const kCFStringEncodingUTF32LE: C2RustUnnamed = 469762304;
+pub const kCFStringEncodingUTF32BE: C2RustUnnamed = 402653440;
+pub const kCFStringEncodingUTF32: C2RustUnnamed = 201326848;
+pub const kCFStringEncodingUTF16LE: C2RustUnnamed = 335544576;
+pub const kCFStringEncodingUTF16BE: C2RustUnnamed = 268435712;
+pub const kCFStringEncodingUTF16: C2RustUnnamed = 256;
+pub const kCFStringEncodingNonLossyASCII: C2RustUnnamed = 3071;
+pub const kCFStringEncodingUTF8: C2RustUnnamed = 134217984;
+pub const kCFStringEncodingUnicode: C2RustUnnamed = 256;
+pub const kCFStringEncodingASCII: C2RustUnnamed = 1536;
+pub const kCFStringEncodingNextStepLatin: C2RustUnnamed = 2817;
+pub const kCFStringEncodingISOLatin1: C2RustUnnamed = 513;
+pub const kCFStringEncodingWindowsLatin1: C2RustUnnamed = 1280;
+pub const kCFStringEncodingMacRoman: C2RustUnnamed = 0;
+pub type CFStringCompareFlags = CFOptionFlags;
+pub type C2RustUnnamed_0 = libc::c_uint;
+pub const kCFCompareForcedOrdering: C2RustUnnamed_0 = 512;
+pub const kCFCompareWidthInsensitive: C2RustUnnamed_0 = 256;
+pub const kCFCompareDiacriticInsensitive: C2RustUnnamed_0 = 128;
+pub const kCFCompareNumerically: C2RustUnnamed_0 = 64;
+pub const kCFCompareLocalized: C2RustUnnamed_0 = 32;
+pub const kCFCompareNonliteral: C2RustUnnamed_0 = 16;
+pub const kCFCompareAnchored: C2RustUnnamed_0 = 8;
+pub const kCFCompareBackwards: C2RustUnnamed_0 = 4;
+pub const kCFCompareCaseInsensitive: C2RustUnnamed_0 = 1;
+pub type CFBooleanRef = *const __CFBoolean;
+pub type CFNumberType = CFIndex;
+pub type C2RustUnnamed_1 = libc::c_uint;
+pub const kCFNumberMaxType: C2RustUnnamed_1 = 16;
+pub const kCFNumberCGFloatType: C2RustUnnamed_1 = 16;
+pub const kCFNumberNSIntegerType: C2RustUnnamed_1 = 15;
+pub const kCFNumberCFIndexType: C2RustUnnamed_1 = 14;
+pub const kCFNumberDoubleType: C2RustUnnamed_1 = 13;
+pub const kCFNumberFloatType: C2RustUnnamed_1 = 12;
+pub const kCFNumberLongLongType: C2RustUnnamed_1 = 11;
+pub const kCFNumberLongType: C2RustUnnamed_1 = 10;
+pub const kCFNumberIntType: C2RustUnnamed_1 = 9;
+pub const kCFNumberShortType: C2RustUnnamed_1 = 8;
+pub const kCFNumberCharType: C2RustUnnamed_1 = 7;
+pub const kCFNumberFloat64Type: C2RustUnnamed_1 = 6;
+pub const kCFNumberFloat32Type: C2RustUnnamed_1 = 5;
+pub const kCFNumberSInt64Type: C2RustUnnamed_1 = 4;
+pub const kCFNumberSInt32Type: C2RustUnnamed_1 = 3;
+pub const kCFNumberSInt16Type: C2RustUnnamed_1 = 2;
+pub const kCFNumberSInt8Type: C2RustUnnamed_1 = 1;
+pub type CFAttributedStringRef = *const __CFAttributedString;
+pub type CGColorRef = *mut CGColor;
+pub type CGFontRef = *mut CGFont;
+pub type CGFontIndex = libc::c_ushort;
+pub type CGGlyph = CGFontIndex;
+pub type CTFontDescriptorRef = *const __CTFontDescriptor;
+pub type CTFontOrientation = uint32_t;
+pub type C2RustUnnamed_2 = libc::c_uint;
+pub const kCTFontVerticalOrientation: C2RustUnnamed_2 = 2;
+pub const kCTFontHorizontalOrientation: C2RustUnnamed_2 = 1;
+pub const kCTFontDefaultOrientation: C2RustUnnamed_2 = 0;
+pub const kCTFontOrientationVertical: C2RustUnnamed_2 = 2;
+pub const kCTFontOrientationHorizontal: C2RustUnnamed_2 = 1;
+pub const kCTFontOrientationDefault: C2RustUnnamed_2 = 0;
+pub type CTFontRef = *const __CTFont;
+pub type CTLineRef = *const __CTLine;
+pub type CTTypesetterRef = *const __CTTypesetter;
+pub type CTRunRef = *const __CTRun;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct GlyphBBox {
+    pub xMin: libc::c_float,
+    pub yMin: libc::c_float,
+    pub xMax: libc::c_float,
+    pub yMax: libc::c_float,
+}
+/* The annoying `memory_word` type. We have to make sure the byte-swapping
+ * that the (un)dumping routines do suffices to put things in the right place
+ * in memory.
+ *
+ * This set of data used to be a huge mess (see comment after the
+ * definitions). It is now (IMO) a lot more reasonable, but there will no
+ * doubt be carryover weird terminology around the code.
+ *
+ * ## ENDIANNESS (cheat sheet because I'm lame)
+ *
+ * Intel is little-endian. Say that we have a 32-bit integer stored in memory
+ * with `p` being a `uint8` pointer to its location. In little-endian land,
+ * `p[0]` is least significant byte and `p[3]` is its most significant byte.
+ *
+ * Conversely, in big-endian land, `p[0]` is its most significant byte and
+ * `p[3]` is its least significant byte.
+ *
+ * ## MEMORY_WORD LAYOUT
+ *
+ * Little endian:
+ *
+ *   bytes: --0-- --1-- --2-- --3-- --4-- --5-- --6-- --7--
+ *   b32:   [lsb......s0.......msb] [lsb......s1.......msb]
+ *   b16:   [l..s0...m] [l..s1...m] [l..s2...m] [l..s3...m]
+ *
+ * Big endian:
+ *
+ *   bytes: --0-- --1-- --2-- --3-- --4-- --5-- --6-- --7--
+ *   b32:   [msb......s1.......lsb] [msb......s0.......lsb]
+ *   b16:   [m..s3...l] [m..s2...l] [m..s1...l] [m...s0..l]
+ *
+ */
+pub type b32x2 = b32x2_le_t;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct b32x2_le_t {
+    pub s0: int32_t,
+    pub s1: int32_t,
+}
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub union memory_word {
+    pub b32: b32x2,
+    pub b16: b16x4,
+    pub gr: libc::c_double,
+    pub ptr: *mut libc::c_void,
+}
+pub type b16x4 = b16x4_le_t;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct b16x4_le_t {
+    pub s0: uint16_t,
+    pub s1: uint16_t,
+    pub s2: uint16_t,
+    pub s3: uint16_t,
+}
+pub type str_number = int32_t;
+/* tectonic/core-strutils.h: miscellaneous C string utilities
+   Copyright 2016-2018 the Tectonic Project
+   Licensed under the MIT License.
+*/
+/* Note that we explicitly do *not* change this on Windows. For maximum
+ * portability, we should probably accept *either* forward or backward slashes
+ * as directory separators. */
+#[inline]
+unsafe extern "C" fn strstartswith(
+    mut s: *const libc::c_char,
+    mut prefix: *const libc::c_char,
+) -> *const libc::c_char {
+    let mut length: size_t = 0;
+    length = strlen(prefix);
+    if strncmp(s, prefix, length) == 0i32 {
+        return s.offset(length as isize);
+    }
+    return 0 as *const libc::c_char;
+}
+#[inline]
+unsafe extern "C" fn streq_ptr(mut s1: *const libc::c_char, mut s2: *const libc::c_char) -> bool {
+    if !s1.is_null() && !s2.is_null() {
+        return strcmp(s1, s2) == 0i32;
+    }
+    return 0i32 != 0;
+}
+/* ***************************************************************************\
+ Part of the XeTeX typesetting system
+ Copyright (c) 1994-2008 by SIL International
+ Copyright (c) 2009 by Jonathan Kew
+ Copyright (c) 2012, 2013 by Jiang Jiang
+ Copyright (c) 2012-2015 by Khaled Hosny
+
+ SIL Author(s): Jonathan Kew
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE
+FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Except as contained in this notice, the name of the copyright holders
+shall not be used in advertising or otherwise to promote the sale,
+use or other dealings in this Software without prior written
+authorization from the copyright holders.
+\****************************************************************************/
+/* XeTeX_mac.c
+ * additional plain C extensions for XeTeX - MacOS-specific routines
+ */
+#[inline]
+unsafe extern "C" fn TeXtoPSPoints(mut pts: libc::c_double) -> libc::c_double {
+    return pts * 72.0f64 / 72.27f64;
+}
+#[inline]
+unsafe extern "C" fn PStoTeXPoints(mut pts: libc::c_double) -> libc::c_double {
+    return pts * 72.27f64 / 72.0f64;
+}
+#[inline]
+unsafe extern "C" fn FixedPStoTeXPoints(mut pts: libc::c_double) -> Fixed {
+    return D2Fix(PStoTeXPoints(pts));
+}
+#[no_mangle]
+pub unsafe extern "C" fn fontFromAttributes(mut attributes: CFDictionaryRef) -> CTFontRef {
+    return CFDictionaryGetValue(attributes, kCTFontAttributeName as *const libc::c_void)
+        as CTFontRef;
+}
+#[no_mangle]
+pub unsafe extern "C" fn fontFromInteger(mut font: int32_t) -> CTFontRef {
+    let mut attributes: CFDictionaryRef =
+        *font_layout_engine.offset(font as isize) as CFDictionaryRef;
+    return fontFromAttributes(attributes);
+}
+#[no_mangle]
+pub unsafe extern "C" fn DoAATLayout(mut p: *mut libc::c_void, mut justify: libc::c_int) {
+    let mut glyphRuns: CFArrayRef = 0 as *const __CFArray;
+    let mut i: CFIndex = 0;
+    let mut j: CFIndex = 0;
+    let mut runCount: CFIndex = 0;
+    let mut totalGlyphCount: CFIndex = 0i32 as CFIndex;
+    let mut glyphIDs: *mut UInt16 = 0 as *mut UInt16;
+    let mut glyphAdvances: *mut Fixed = 0 as *mut Fixed;
+    let mut glyph_info: *mut libc::c_void = 0 as *mut libc::c_void;
+    let mut locations: *mut FixedPoint = 0 as *mut FixedPoint;
+    let mut width: CGFloat = 0.;
+    let mut txtLen: libc::c_long = 0;
+    let mut txtPtr: *const UniChar = 0 as *const UniChar;
+    let mut attributes: CFDictionaryRef = 0 as *const __CFDictionary;
+    let mut string: CFStringRef = 0 as *const __CFString;
+    let mut attrString: CFAttributedStringRef = 0 as *const __CFAttributedString;
+    let mut typesetter: CTTypesetterRef = 0 as *const __CTTypesetter;
+    let mut line: CTLineRef = 0 as *const __CTLine;
+    let mut node: *mut memory_word = p as *mut memory_word;
+    let mut f: libc::c_uint = (*node.offset(4)).b16.s2 as libc::c_uint;
+    if *font_area.offset(f as isize) as libc::c_uint != 0xffffu32 {
+        _tt_abort(b"DoAATLayout called for non-AAT font\x00" as *const u8 as *const libc::c_char);
+    }
+    txtLen = (*node.offset(4)).b16.s1 as libc::c_long;
+    txtPtr = node.offset(6) as *mut UniChar;
+    attributes = *font_layout_engine.offset((*node.offset(4)).b16.s2 as isize) as CFDictionaryRef;
+    string =
+        CFStringCreateWithCharactersNoCopy(0 as CFAllocatorRef, txtPtr, txtLen, kCFAllocatorNull);
+    attrString = CFAttributedStringCreate(0 as CFAllocatorRef, string, attributes);
+    CFRelease(string as CFTypeRef);
+    typesetter = CTTypesetterCreateWithAttributedString(attrString);
+    CFRelease(attrString as CFTypeRef);
+    line = CTTypesetterCreateLine(typesetter, CFRangeMake(0i32 as CFIndex, txtLen));
+    if justify != 0 {
+        let mut lineWidth: CGFloat = TeXtoPSPoints(Fix2D((*node.offset(1)).b32.s1));
+        let mut justifiedLine: CTLineRef = CTLineCreateJustifiedLine(
+            line,
+            TeXtoPSPoints(Fix2D(0x40000000i64 as Fract)),
+            lineWidth,
+        );
+        // TODO(jjgod): how to handle the case when justification failed? for
+        // now we just fallback to use the original line.
+        if !justifiedLine.is_null() {
+            CFRelease(line as CFTypeRef);
+            line = justifiedLine
+        }
+    }
+    glyphRuns = CTLineGetGlyphRuns(line);
+    runCount = CFArrayGetCount(glyphRuns);
+    totalGlyphCount = CTLineGetGlyphCount(line);
+    if totalGlyphCount > 0i32 as libc::c_long {
+        glyph_info = xmalloc((totalGlyphCount * 10i32 as libc::c_long) as size_t);
+        locations = glyph_info as *mut FixedPoint;
+        glyphIDs = locations.offset(totalGlyphCount as isize) as *mut UInt16;
+        glyphAdvances = xmalloc(
+            (totalGlyphCount as libc::c_ulong)
+                .wrapping_mul(::std::mem::size_of::<Fixed>() as libc::c_ulong),
+        ) as *mut Fixed;
+        totalGlyphCount = 0i32 as CFIndex;
+        width = 0i32 as CGFloat;
+        i = 0i32 as CFIndex;
+        while i < runCount {
+            let mut run: CTRunRef = CFArrayGetValueAtIndex(glyphRuns, i) as CTRunRef;
+            let mut count: CFIndex = CTRunGetGlyphCount(run);
+            let mut runAttributes: CFDictionaryRef = CTRunGetAttributes(run);
+            let mut vertical: CFBooleanRef = CFDictionaryGetValue(
+                runAttributes,
+                kCTVerticalFormsAttributeName as *const libc::c_void,
+            ) as CFBooleanRef;
+            // TODO(jjgod): Avoid unnecessary allocation with CTRunGetFoosPtr().
+            let mut glyphs: *mut CGGlyph = xmalloc(
+                (count as libc::c_ulong)
+                    .wrapping_mul(::std::mem::size_of::<CGGlyph>() as libc::c_ulong),
+            ) as *mut CGGlyph;
+            let mut positions: *mut CGPoint = xmalloc(
+                (count as libc::c_ulong)
+                    .wrapping_mul(::std::mem::size_of::<CGPoint>() as libc::c_ulong),
+            ) as *mut CGPoint;
+            let mut advances: *mut CGSize = xmalloc(
+                (count as libc::c_ulong)
+                    .wrapping_mul(::std::mem::size_of::<CGSize>() as libc::c_ulong),
+            ) as *mut CGSize;
+            let mut runWidth: CGFloat = CTRunGetTypographicBounds(
+                run,
+                CFRangeMake(0i32 as CFIndex, 0i32 as CFIndex),
+                0 as *mut CGFloat,
+                0 as *mut CGFloat,
+                0 as *mut CGFloat,
+            );
+            CTRunGetGlyphs(run, CFRangeMake(0i32 as CFIndex, 0i32 as CFIndex), glyphs);
+            CTRunGetPositions(
+                run,
+                CFRangeMake(0i32 as CFIndex, 0i32 as CFIndex),
+                positions,
+            );
+            CTRunGetAdvances(run, CFRangeMake(0i32 as CFIndex, 0i32 as CFIndex), advances);
+            j = 0i32 as CFIndex;
+            while j < count {
+                // XXX Core Text has that font cascading thing that will do
+                // font substitution for missing glyphs, which we do not want
+                // but I can not find a way to disable it yet, so if the font
+                // of the resulting run is not the same font we asked for, use
+                // the glyph at index 0 (usually .notdef) instead or we will be
+                // showing garbage or even invalid glyphs
+                if CFEqual(
+                    fontFromAttributes(attributes) as CFTypeRef,
+                    fontFromAttributes(runAttributes) as CFTypeRef,
+                ) == 0
+                {
+                    *glyphIDs.offset(totalGlyphCount as isize) = 0i32 as UInt16
+                } else {
+                    *glyphIDs.offset(totalGlyphCount as isize) = *glyphs.offset(j as isize)
+                }
+                // Swap X and Y when doing vertical layout
+                if vertical == kCFBooleanTrue {
+                    (*locations.offset(totalGlyphCount as isize)).x =
+                        -FixedPStoTeXPoints((*positions.offset(j as isize)).y);
+                    (*locations.offset(totalGlyphCount as isize)).y =
+                        FixedPStoTeXPoints((*positions.offset(j as isize)).x)
+                } else {
+                    (*locations.offset(totalGlyphCount as isize)).x =
+                        FixedPStoTeXPoints((*positions.offset(j as isize)).x);
+                    (*locations.offset(totalGlyphCount as isize)).y =
+                        -FixedPStoTeXPoints((*positions.offset(j as isize)).y)
+                }
+                *glyphAdvances.offset(totalGlyphCount as isize) =
+                    (*advances.offset(j as isize)).width as Fixed;
+                totalGlyphCount += 1;
+                j += 1
+            }
+            width += FixedPStoTeXPoints(runWidth) as libc::c_double;
+            free(glyphs as *mut libc::c_void);
+            free(positions as *mut libc::c_void);
+            free(advances as *mut libc::c_void);
+            i += 1
+        }
+    }
+    (*node.offset(4)).b16.s0 = totalGlyphCount as uint16_t;
+    let ref mut fresh0 = (*node.offset(5)).ptr;
+    *fresh0 = glyph_info;
+    if justify == 0 {
+        (*node.offset(1)).b32.s1 = width as int32_t;
+        if totalGlyphCount > 0i32 as libc::c_long {
+            /* this is essentially a copy from similar code in XeTeX_ext.c, easier
+             * to be done here */
+            if *font_letter_space.offset(f as isize) != 0i32 {
+                let mut lsDelta: Fixed = 0i32;
+                let mut lsUnit: Fixed = *font_letter_space.offset(f as isize);
+                let mut i_0: libc::c_int = 0;
+                i_0 = 0i32;
+                while (i_0 as libc::c_long) < totalGlyphCount {
+                    if *glyphAdvances.offset(i_0 as isize) == 0i32 && lsDelta != 0i32 {
+                        lsDelta -= lsUnit
+                    }
+                    let ref mut fresh1 = (*locations.offset(i_0 as isize)).x;
+                    *fresh1 += lsDelta;
+                    lsDelta += lsUnit;
+                    i_0 += 1
+                }
+                if lsDelta != 0i32 {
+                    lsDelta -= lsUnit;
+                    let ref mut fresh2 = (*node.offset(1)).b32.s1;
+                    *fresh2 += lsDelta
+                }
+            }
+        }
+    }
+    free(glyphAdvances as *mut libc::c_void);
+    CFRelease(line as CFTypeRef);
+    CFRelease(typesetter as CFTypeRef);
+}
+#[inline]
+unsafe extern "C" fn __CGAffineTransformMake(
+    mut a: CGFloat,
+    mut b: CGFloat,
+    mut c: CGFloat,
+    mut d: CGFloat,
+    mut tx: CGFloat,
+    mut ty: CGFloat,
+) -> CGAffineTransform {
+    let mut t: CGAffineTransform = CGAffineTransform {
+        a: 0.,
+        b: 0.,
+        c: 0.,
+        d: 0.,
+        tx: 0.,
+        ty: 0.,
+    };
+    t.a = a;
+    t.b = b;
+    t.c = c;
+    t.d = d;
+    t.tx = tx;
+    t.ty = ty;
+    return t;
+}
+unsafe extern "C" fn getGlyphBBoxFromCTFont(
+    mut font: CTFontRef,
+    mut gid: UInt16,
+    mut bbox: *mut GlyphBBox,
+) {
+    let mut rect: CGRect = CGRect {
+        origin: CGPoint { x: 0., y: 0. },
+        size: CGSize {
+            width: 0.,
+            height: 0.,
+        },
+    };
+    (*bbox).xMin = 65536.0f64 as libc::c_float;
+    (*bbox).yMin = 65536.0f64 as libc::c_float;
+    (*bbox).xMax = -65536.0f64 as libc::c_float;
+    (*bbox).yMax = -65536.0f64 as libc::c_float;
+    rect = CTFontGetBoundingRectsForGlyphs(
+        font,
+        0i32 as CTFontOrientation,
+        &mut gid as *mut UInt16 as *const CGGlyph,
+        0 as *mut CGRect,
+        1i32 as CFIndex,
+    );
+    if CGRectIsNull(rect) {
+        (*bbox).yMax = 0i32 as libc::c_float;
+        (*bbox).xMax = (*bbox).yMax;
+        (*bbox).yMin = (*bbox).xMax;
+        (*bbox).xMin = (*bbox).yMin
+    } else {
+        (*bbox).yMin = PStoTeXPoints(rect.origin.y) as libc::c_float;
+        (*bbox).yMax = PStoTeXPoints(rect.origin.y + rect.size.height) as libc::c_float;
+        (*bbox).xMin = PStoTeXPoints(rect.origin.x) as libc::c_float;
+        (*bbox).xMax = PStoTeXPoints(rect.origin.x + rect.size.width) as libc::c_float
+    };
+}
+#[no_mangle]
+pub unsafe extern "C" fn GetGlyphBBox_AAT(
+    mut attributes: CFDictionaryRef,
+    mut gid: UInt16,
+    mut bbox: *mut GlyphBBox,
+)
+/* returns glyph bounding box in TeX points */
+{
+    let mut font: CTFontRef = fontFromAttributes(attributes);
+    return getGlyphBBoxFromCTFont(font, gid, bbox);
+}
+unsafe extern "C" fn getGlyphWidthFromCTFont(
+    mut font: CTFontRef,
+    mut gid: UInt16,
+) -> libc::c_double {
+    return PStoTeXPoints(CTFontGetAdvancesForGlyphs(
+        font,
+        kCTFontOrientationHorizontal as libc::c_int as CTFontOrientation,
+        &mut gid as *mut UInt16 as *const CGGlyph,
+        0 as *mut CGSize,
+        1i32 as CFIndex,
+    ));
+}
+#[no_mangle]
+pub unsafe extern "C" fn GetGlyphWidth_AAT(
+    mut attributes: CFDictionaryRef,
+    mut gid: UInt16,
+) -> libc::c_double
+/* returns TeX points */ {
+    let mut font: CTFontRef = fontFromAttributes(attributes);
+    return getGlyphWidthFromCTFont(font, gid);
+}
+#[no_mangle]
+pub unsafe extern "C" fn GetGlyphHeightDepth_AAT(
+    mut attributes: CFDictionaryRef,
+    mut gid: UInt16,
+    mut ht: *mut libc::c_float,
+    mut dp: *mut libc::c_float,
+)
+/* returns TeX points */
+{
+    let mut bbox: GlyphBBox = GlyphBBox {
+        xMin: 0.,
+        yMin: 0.,
+        xMax: 0.,
+        yMax: 0.,
+    };
+    GetGlyphBBox_AAT(attributes, gid, &mut bbox);
+    *ht = bbox.yMax;
+    *dp = -bbox.yMin;
+}
+#[no_mangle]
+pub unsafe extern "C" fn GetGlyphSidebearings_AAT(
+    mut attributes: CFDictionaryRef,
+    mut gid: UInt16,
+    mut lsb: *mut libc::c_float,
+    mut rsb: *mut libc::c_float,
+)
+/* returns TeX points */
+{
+    let mut font: CTFontRef = fontFromAttributes(attributes);
+    let mut advances: [CGSize; 1] = [CGSizeMake(0i32 as CGFloat, 0i32 as CGFloat)];
+    let mut advance: libc::c_double = CTFontGetAdvancesForGlyphs(
+        font,
+        0i32 as CTFontOrientation,
+        &mut gid as *mut UInt16 as *const CGGlyph,
+        advances.as_mut_ptr(),
+        1i32 as CFIndex,
+    );
+    let mut bbox: GlyphBBox = GlyphBBox {
+        xMin: 0.,
+        yMin: 0.,
+        xMax: 0.,
+        yMax: 0.,
+    };
+    getGlyphBBoxFromCTFont(font, gid, &mut bbox);
+    *lsb = bbox.xMin;
+    *rsb = (PStoTeXPoints(advance) - bbox.xMax as libc::c_double) as libc::c_float;
+}
+#[inline]
+unsafe extern "C" fn CGSizeMake(mut width: CGFloat, mut height: CGFloat) -> CGSize {
+    let mut size: CGSize = CGSize {
+        width: 0.,
+        height: 0.,
+    };
+    size.width = width;
+    size.height = height;
+    return size;
+}
+#[no_mangle]
+pub unsafe extern "C" fn GetGlyphItalCorr_AAT(
+    mut attributes: CFDictionaryRef,
+    mut gid: UInt16,
+) -> libc::c_double {
+    let mut font: CTFontRef = fontFromAttributes(attributes);
+    let mut advances: [CGSize; 1] = [CGSizeMake(0i32 as CGFloat, 0i32 as CGFloat)];
+    let mut advance: libc::c_double = CTFontGetAdvancesForGlyphs(
+        font,
+        0i32 as CTFontOrientation,
+        &mut gid as *mut UInt16 as *const CGGlyph,
+        advances.as_mut_ptr(),
+        1i32 as CFIndex,
+    );
+    let mut bbox: GlyphBBox = GlyphBBox {
+        xMin: 0.,
+        yMin: 0.,
+        xMax: 0.,
+        yMax: 0.,
+    };
+    getGlyphBBoxFromCTFont(font, gid, &mut bbox);
+    if bbox.xMax as libc::c_double > PStoTeXPoints(advance) {
+        return bbox.xMax as libc::c_double - PStoTeXPoints(advance);
+    }
+    return 0i32 as libc::c_double;
+}
+unsafe extern "C" fn mapCharToGlyphFromCTFont(mut font: CTFontRef, mut ch: UInt32) -> libc::c_int {
+    let mut glyphs: [CGGlyph; 2] = [0i32 as CGGlyph, 0];
+    let mut txt: [UniChar; 2] = [0; 2];
+    let mut len: libc::c_int = 1i32;
+    if ch > 0xffffi32 as libc::c_uint {
+        ch = (ch as libc::c_uint).wrapping_sub(0x10000i32 as libc::c_uint) as UInt32 as UInt32;
+        txt[0] = (0xd800i32 as libc::c_uint).wrapping_add(ch.wrapping_div(1024i32 as libc::c_uint))
+            as UniChar;
+        txt[1] = (0xdc00i32 as libc::c_uint).wrapping_add(ch.wrapping_rem(1024i32 as libc::c_uint))
+            as UniChar;
+        len = 2i32
+    } else {
+        txt[0] = ch as UniChar
+    }
+    if CTFontGetGlyphsForCharacters(
+        font,
+        txt.as_mut_ptr() as *const UniChar,
+        glyphs.as_mut_ptr(),
+        len as CFIndex,
+    ) {
+        return glyphs[0] as libc::c_int;
+    }
+    return 0i32;
+}
+#[no_mangle]
+pub unsafe extern "C" fn MapCharToGlyph_AAT(
+    mut attributes: CFDictionaryRef,
+    mut ch: UInt32,
+) -> libc::c_int {
+    let mut font: CTFontRef = fontFromAttributes(attributes);
+    return mapCharToGlyphFromCTFont(font, ch);
+}
+unsafe extern "C" fn GetGlyphIDFromCTFont(
+    mut ctFontRef: CTFontRef,
+    mut glyphName: *const libc::c_char,
+) -> libc::c_int {
+    let mut glyphname: CFStringRef = CFStringCreateWithCStringNoCopy(
+        kCFAllocatorDefault,
+        glyphName,
+        kCFStringEncodingUTF8 as libc::c_int as CFStringEncoding,
+        kCFAllocatorNull,
+    );
+    let mut rval: libc::c_int = CTFontGetGlyphWithName(ctFontRef, glyphname) as libc::c_int;
+    CFRelease(glyphname as CFTypeRef);
+    return rval;
+}
+/* single-purpose metrics accessors */
+/* the metrics params here are really TeX 'scaled' (or MacOS 'Fixed') values, but that typedef isn't available every place this is included */
+/* functions in XeTeX_mac.c */
+#[no_mangle]
+pub unsafe extern "C" fn MapGlyphToIndex_AAT(
+    mut attributes: CFDictionaryRef,
+    mut glyphName: *const libc::c_char,
+) -> libc::c_int {
+    let mut font: CTFontRef = fontFromAttributes(attributes);
+    return GetGlyphIDFromCTFont(font, glyphName);
+}
+#[no_mangle]
+pub unsafe extern "C" fn GetGlyphNameFromCTFont(
+    mut ctFontRef: CTFontRef,
+    mut gid: UInt16,
+    mut len: *mut libc::c_int,
+) -> *mut libc::c_char {
+    let mut cgfont: CGFontRef = 0 as *mut CGFont;
+    static mut buffer: [libc::c_char; 256] = [0; 256];
+    buffer[0] = 0i32 as libc::c_char;
+    *len = 0i32;
+    cgfont = CTFontCopyGraphicsFont(ctFontRef, 0 as *mut CTFontDescriptorRef);
+    if !cgfont.is_null() && (gid as libc::c_ulong) < CGFontGetNumberOfGlyphs(cgfont) {
+        let mut glyphname: CFStringRef = CGFontCopyGlyphNameForGlyph(cgfont, gid);
+        if !glyphname.is_null() {
+            if CFStringGetCString(
+                glyphname,
+                buffer.as_mut_ptr(),
+                256i32 as CFIndex,
+                kCFStringEncodingUTF8 as libc::c_int as CFStringEncoding,
+            ) != 0
+            {
+                *len = strlen(buffer.as_mut_ptr()) as libc::c_int
+            }
+            CFRelease(glyphname as CFTypeRef);
+        }
+        CGFontRelease(cgfont);
+    }
+    return &mut *buffer.as_mut_ptr().offset(0) as *mut libc::c_char;
+}
+#[no_mangle]
+pub unsafe extern "C" fn GetFontCharRange_AAT(
+    mut attributes: CFDictionaryRef,
+    mut reqFirst: libc::c_int,
+) -> libc::c_int {
+    if reqFirst != 0 {
+        let mut ch: libc::c_int = 0i32;
+        while MapCharToGlyph_AAT(attributes, ch as UInt32) == 0i32 && ch < 0x10ffffi32 {
+            ch += 1
+        }
+        return ch;
+    } else {
+        let mut ch_0: libc::c_int = 0x10ffffi32;
+        while MapCharToGlyph_AAT(attributes, ch_0 as UInt32) == 0i32 && ch_0 > 0i32 {
+            ch_0 -= 1
+        }
+        return ch_0;
+    };
+}
+#[no_mangle]
+pub unsafe extern "C" fn getNameFromCTFont(
+    mut ctFontRef: CTFontRef,
+    mut nameKey: CFStringRef,
+) -> *mut libc::c_char {
+    let mut buf: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut name: CFStringRef = CTFontCopyName(ctFontRef, nameKey);
+    let mut len: CFIndex = CFStringGetLength(name);
+    len = len * 6i32 as libc::c_long + 1i32 as libc::c_long;
+    buf = xmalloc(len as size_t) as *mut libc::c_char;
+    if CFStringGetCString(
+        name,
+        buf,
+        len,
+        kCFStringEncodingUTF8 as libc::c_int as CFStringEncoding,
+    ) != 0
+    {
+        return buf;
+    }
+    free(buf as *mut libc::c_void);
+    return 0 as *mut libc::c_char;
+}
+#[no_mangle]
+pub unsafe extern "C" fn getFileNameFromCTFont(
+    mut ctFontRef: CTFontRef,
+    mut index: *mut uint32_t,
+) -> *mut libc::c_char {
+    let mut ret: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut url: CFURLRef = 0 as CFURLRef;
+    url = CTFontCopyAttribute(ctFontRef, kCTFontURLAttribute) as CFURLRef;
+    if !url.is_null() {
+        let mut pathname: [UInt8; 1024] = [0; 1024];
+        if CFURLGetFileSystemRepresentation(
+            url,
+            1i32 as Boolean,
+            pathname.as_mut_ptr(),
+            1024i32 as CFIndex,
+        ) != 0
+        {
+            let mut error: FT_Error = 0;
+            let mut face: FT_Face = 0 as *mut FT_FaceRec_;
+            *index = 0i32 as uint32_t;
+            if gFreeTypeLibrary.is_null() {
+                error = FT_Init_FreeType(&mut gFreeTypeLibrary);
+                if error != 0 {
+                    _tt_abort(
+                        b"FreeType initialization failed; error %d\x00" as *const u8
+                            as *const libc::c_char,
+                        error,
+                    );
+                }
+            }
+            error = FT_New_Face(
+                gFreeTypeLibrary,
+                pathname.as_mut_ptr() as *mut libc::c_char,
+                0i32 as FT_Long,
+                &mut face,
+            );
+            if error == 0 {
+                if (*face).num_faces > 1i32 as libc::c_long {
+                    let mut num_faces: libc::c_int = (*face).num_faces as libc::c_int;
+                    let mut ps_name1: *mut libc::c_char =
+                        getNameFromCTFont(ctFontRef, kCTFontPostScriptNameKey);
+                    let mut i: libc::c_int = 0;
+                    *index = -1i32 as uint32_t;
+                    FT_Done_Face(face);
+                    i = 0i32;
+                    while i < num_faces {
+                        error = FT_New_Face(
+                            gFreeTypeLibrary,
+                            pathname.as_mut_ptr() as *mut libc::c_char,
+                            i as FT_Long,
+                            &mut face,
+                        );
+                        if error == 0 {
+                            let mut ps_name2: *const libc::c_char = FT_Get_Postscript_Name(face);
+                            if streq_ptr(ps_name1, ps_name2) {
+                                *index = i as uint32_t;
+                                break;
+                            } else {
+                                FT_Done_Face(face);
+                            }
+                        }
+                        i += 1
+                    }
+                    free(ps_name1 as *mut libc::c_void);
+                }
+            }
+            if *index != -1i32 as libc::c_uint {
+                ret = strdup(pathname.as_mut_ptr() as *mut libc::c_char)
+            }
+        }
+        CFRelease(url as CFTypeRef);
+    }
+    return ret;
+}
+#[no_mangle]
+pub unsafe extern "C" fn findDictionaryInArrayWithIdentifier(
+    mut array: CFArrayRef,
+    mut identifierKey: *const libc::c_void,
+    mut identifier: libc::c_int,
+) -> CFDictionaryRef {
+    let mut dict: CFDictionaryRef = 0 as CFDictionaryRef;
+    if !array.is_null() {
+        let mut value: libc::c_int = -1i32;
+        let mut i: CFIndex = 0;
+        i = 0i32 as CFIndex;
+        while i < CFArrayGetCount(array) {
+            let mut item: CFDictionaryRef = CFArrayGetValueAtIndex(array, i) as CFDictionaryRef;
+            let mut itemId: CFNumberRef = CFDictionaryGetValue(item, identifierKey) as CFNumberRef;
+            if !itemId.is_null() {
+                CFNumberGetValue(
+                    itemId,
+                    kCFNumberIntType as libc::c_int as CFNumberType,
+                    &mut value as *mut libc::c_int as *mut libc::c_void,
+                );
+                if value == identifier {
+                    dict = item;
+                    break;
+                }
+            }
+            i += 1
+        }
+    }
+    return dict;
+}
+#[inline(always)]
+unsafe extern "C" fn CFRangeMake(mut loc: CFIndex, mut len: CFIndex) -> CFRange {
+    let mut range: CFRange = CFRange {
+        location: 0,
+        length: 0,
+    };
+    range.location = loc;
+    range.length = len;
+    return range;
+}
+#[no_mangle]
+pub unsafe extern "C" fn findDictionaryInArray(
+    mut array: CFArrayRef,
+    mut nameKey: *const libc::c_void,
+    mut name: *const libc::c_char,
+    mut nameLength: libc::c_int,
+) -> CFDictionaryRef {
+    let mut dict: CFDictionaryRef = 0 as CFDictionaryRef;
+    if !array.is_null() {
+        let mut itemName: CFStringRef = 0 as *const __CFString;
+        let mut i: CFIndex = 0;
+        itemName = CFStringCreateWithBytes(
+            0 as CFAllocatorRef,
+            name as *mut UInt8,
+            nameLength as CFIndex,
+            kCFStringEncodingUTF8 as libc::c_int as CFStringEncoding,
+            0i32 as Boolean,
+        );
+        i = 0i32 as CFIndex;
+        while i < CFArrayGetCount(array) {
+            let mut item: CFDictionaryRef = CFArrayGetValueAtIndex(array, i) as CFDictionaryRef;
+            let mut iName: CFStringRef = CFDictionaryGetValue(item, nameKey) as CFStringRef;
+            if !iName.is_null()
+                && CFStringCompare(
+                    itemName,
+                    iName,
+                    kCFCompareCaseInsensitive as libc::c_int as CFStringCompareFlags,
+                ) == 0
+            {
+                dict = item;
+                break;
+            } else {
+                i += 1
+            }
+        }
+        CFRelease(itemName as CFTypeRef);
+    }
+    return dict;
+}
+#[no_mangle]
+pub unsafe extern "C" fn findSelectorByName(
+    mut feature: CFDictionaryRef,
+    mut name: *const libc::c_char,
+    mut nameLength: libc::c_int,
+) -> CFNumberRef {
+    let mut selector: CFNumberRef = 0 as CFNumberRef;
+    let mut selectors: CFArrayRef = CFDictionaryGetValue(
+        feature,
+        kCTFontFeatureTypeSelectorsKey as *const libc::c_void,
+    ) as CFArrayRef;
+    if !selectors.is_null() {
+        let mut s: CFDictionaryRef = findDictionaryInArray(
+            selectors,
+            kCTFontFeatureSelectorNameKey as *const libc::c_void,
+            name,
+            nameLength,
+        );
+        if !s.is_null() {
+            selector = CFDictionaryGetValue(
+                s,
+                kCTFontFeatureSelectorIdentifierKey as *const libc::c_void,
+            ) as CFNumberRef
+        }
+    }
+    return selector;
+}
+unsafe extern "C" fn createFeatureSettingDictionary(
+    mut featureTypeIdentifier: CFNumberRef,
+    mut featureSelectorIdentifier: CFNumberRef,
+) -> CFDictionaryRef {
+    let mut settingKeys: [*const libc::c_void; 2] = [
+        kCTFontFeatureTypeIdentifierKey as *const libc::c_void,
+        kCTFontFeatureSelectorIdentifierKey as *const libc::c_void,
+    ];
+    let mut settingValues: [*const libc::c_void; 2] = [
+        featureTypeIdentifier as *const libc::c_void,
+        featureSelectorIdentifier as *const libc::c_void,
+    ];
+    return CFDictionaryCreate(
+        kCFAllocatorDefault,
+        settingKeys.as_mut_ptr(),
+        settingValues.as_mut_ptr(),
+        2i32 as CFIndex,
+        &kCFTypeDictionaryKeyCallBacks,
+        &kCFTypeDictionaryValueCallBacks,
+    );
+}
+// CFSTR causes undefined builtin errors with c2rust
+static mut kXeTeXEmboldenAttributeName: CFStringRef = 0 as CFStringRef;
+static mut kLastResort: CFStringRef = 0 as CFStringRef;
+#[no_mangle]
+pub unsafe extern "C" fn getkXeTeXEmboldenAttributeName() -> CFStringRef {
+    if kXeTeXEmboldenAttributeName.is_null() {
+        kXeTeXEmboldenAttributeName = CFStringCreateWithCString(
+            0 as CFAllocatorRef,
+            b"XeTeXEmbolden\x00" as *const u8 as *const libc::c_char,
+            kCFStringEncodingUTF8 as libc::c_int as CFStringEncoding,
+        )
+    }
+    return kXeTeXEmboldenAttributeName;
+}
+#[no_mangle]
+pub unsafe extern "C" fn getLastResort() -> CFStringRef {
+    if kLastResort.is_null() {
+        kLastResort = CFStringCreateWithCString(
+            0 as CFAllocatorRef,
+            b"LastResort\x00" as *const u8 as *const libc::c_char,
+            kCFStringEncodingUTF8 as libc::c_int as CFStringEncoding,
+        )
+    }
+    return kLastResort;
+}
+#[no_mangle]
+pub unsafe extern "C" fn loadAATfont(
+    mut descriptor: CTFontDescriptorRef,
+    mut scaled_size: int32_t,
+    mut cp1: *const libc::c_char,
+) -> *mut libc::c_void {
+    let mut current_block: u64;
+    let mut font: CTFontRef = 0 as *const __CTFont;
+    let mut actualFont: CTFontRef = 0 as *const __CTFont;
+    let mut ctSize: CGFloat = 0.;
+    let mut stringAttributes: CFMutableDictionaryRef = 0 as *mut __CFDictionary;
+    let mut attributes: CFMutableDictionaryRef = 0 as *mut __CFDictionary;
+    let mut matrix: CGAffineTransform = CGAffineTransform {
+        a: 0.,
+        b: 0.,
+        c: 0.,
+        d: 0.,
+        tx: 0.,
+        ty: 0.,
+    };
+    let mut cascadeList: CFMutableArrayRef = 0 as *mut __CFArray;
+    let mut lastResort: CTFontDescriptorRef = 0 as *const __CTFontDescriptor;
+    let mut tracking: libc::c_double = 0.0f64;
+    let mut extend: libc::c_float = 1.0f64 as libc::c_float;
+    let mut slant: libc::c_float = 0.0f64 as libc::c_float;
+    let mut embolden: libc::c_float = 0.0f64 as libc::c_float;
+    let mut letterspace: libc::c_float = 0.0f64 as libc::c_float;
+    let mut rgbValue: uint32_t = 0;
+    // create a base font instance for applying further attributes
+    ctSize = TeXtoPSPoints(Fix2D(scaled_size));
+    font = CTFontCreateWithFontDescriptor(descriptor, ctSize, 0 as *const CGAffineTransform);
+    if font.is_null() {
+        return 0 as *mut libc::c_void;
+    }
+    stringAttributes = CFDictionaryCreateMutable(
+        0 as CFAllocatorRef,
+        0i32 as CFIndex,
+        &kCFTypeDictionaryKeyCallBacks,
+        &kCFTypeDictionaryValueCallBacks,
+    );
+    attributes = CFDictionaryCreateMutable(
+        0 as CFAllocatorRef,
+        0i32 as CFIndex,
+        &kCFTypeDictionaryKeyCallBacks,
+        &kCFTypeDictionaryValueCallBacks,
+    );
+    if !cp1.is_null() {
+        let mut features: CFArrayRef = CTFontCopyFeatures(font);
+        let mut featureSettings: CFMutableArrayRef =
+            CFArrayCreateMutable(0 as CFAllocatorRef, 0i32 as CFIndex, &kCFTypeArrayCallBacks);
+        // interpret features following ":"
+        while *cp1 != 0 {
+            let mut feature: CFDictionaryRef = 0 as *const __CFDictionary;
+            let mut ret: libc::c_int = 0;
+            let mut cp2: *const libc::c_char = 0 as *const libc::c_char;
+            let mut cp3: *const libc::c_char = 0 as *const libc::c_char;
+            // locate beginning of name=value pair
+            if *cp1 as libc::c_int == ':' as i32 || *cp1 as libc::c_int == ';' as i32 {
+                // skip over separator
+                cp1 = cp1.offset(1)
+            }
+            while *cp1 as libc::c_int == ' ' as i32 || *cp1 as libc::c_int == '\t' as i32 {
+                // skip leading whitespace
+                cp1 = cp1.offset(1)
+            }
+            if *cp1 as libc::c_int == 0i32 {
+                break;
+            }
+            // scan to end of pair
+            cp2 = cp1;
+            while *cp2 as libc::c_int != 0
+                && *cp2 as libc::c_int != ';' as i32
+                && *cp2 as libc::c_int != ':' as i32
+            {
+                cp2 = cp2.offset(1)
+            }
+            // look for the '=' separator
+            cp3 = cp1;
+            while cp3 < cp2 && *cp3 as libc::c_int != '=' as i32 {
+                cp3 = cp3.offset(1)
+            }
+            if cp3 == cp2 {
+                current_block = 4154772336439402900;
+            } else {
+                // now cp1 points to option name, cp3 to '=', cp2 to ';' or null
+                // first try for a feature by this name
+                feature = findDictionaryInArray(
+                    features,
+                    kCTFontFeatureTypeNameKey as *const libc::c_void,
+                    cp1,
+                    cp3.wrapping_offset_from(cp1) as libc::c_long as libc::c_int,
+                );
+                if !feature.is_null() {
+                    // look past the '=' separator for setting names
+                    let mut featLen: libc::c_int =
+                        cp3.wrapping_offset_from(cp1) as libc::c_long as libc::c_int;
+                    let mut zeroInteger: libc::c_int = 0i32;
+                    let mut zero: CFNumberRef = CFNumberCreate(
+                        0 as CFAllocatorRef,
+                        kCFNumberIntType as libc::c_int as CFNumberType,
+                        &mut zeroInteger as *mut libc::c_int as *const libc::c_void,
+                    );
+                    cp3 = cp3.offset(1);
+                    while cp3 < cp2 {
+                        let mut selector: CFNumberRef = 0 as *const __CFNumber;
+                        let mut disable: libc::c_int = 0i32;
+                        let mut cp4: *const libc::c_char = 0 as *const libc::c_char;
+                        // skip leading whitespace
+                        while *cp3 as libc::c_int == ' ' as i32
+                            || *cp3 as libc::c_int == '\t' as i32
+                        {
+                            cp3 = cp3.offset(1)
+                        }
+                        // possibly multiple settings...
+                        if *cp3 as libc::c_int == '!' as i32 {
+                            // check for negation
+                            disable = 1i32;
+                            cp3 = cp3.offset(1)
+                        }
+                        // scan for end of setting name
+                        cp4 = cp3;
+                        while cp4 < cp2 && *cp4 as libc::c_int != ',' as i32 {
+                            cp4 = cp4.offset(1)
+                        }
+                        // now cp3 points to name, cp4 to ',' or ';' or null
+                        selector = findSelectorByName(
+                            feature,
+                            cp3,
+                            cp4.wrapping_offset_from(cp3) as libc::c_long as libc::c_int,
+                        );
+                        if !selector.is_null()
+                            && CFNumberCompare(selector, zero, 0 as *mut libc::c_void)
+                                >= 0i32 as libc::c_long
+                        {
+                            let mut featureType: CFNumberRef = CFDictionaryGetValue(
+                                feature,
+                                kCTFontFeatureTypeIdentifierKey as *const libc::c_void,
+                            )
+                                as CFNumberRef;
+                            let mut featureSetting: CFDictionaryRef =
+                                createFeatureSettingDictionary(featureType, selector);
+                            CFArrayAppendValue(
+                                featureSettings,
+                                featureSetting as *const libc::c_void,
+                            );
+                            CFRelease(featureSetting as CFTypeRef);
+                        } else {
+                            font_feature_warning(
+                                cp1 as *const libc::c_void,
+                                featLen,
+                                cp3 as *const libc::c_void,
+                                cp4.wrapping_offset_from(cp3) as libc::c_long as int32_t,
+                            );
+                        }
+                        // point beyond setting name terminator
+                        cp3 = cp4.offset(1)
+                    }
+                    CFRelease(zero as CFTypeRef);
+                    current_block = 15938117740974259152;
+                } else {
+                    // didn't find feature, try other options...
+                    ret = readCommonFeatures(
+                        cp1,
+                        cp2,
+                        &mut extend,
+                        &mut slant,
+                        &mut embolden,
+                        &mut letterspace,
+                        &mut rgbValue,
+                    );
+                    if ret == 1i32 {
+                        current_block = 15938117740974259152;
+                    } else if ret == -1i32 {
+                        current_block = 4154772336439402900;
+                    } else {
+                        cp3 =
+                            strstartswith(cp1, b"tracking\x00" as *const u8 as *const libc::c_char);
+                        if !cp3.is_null() {
+                            let mut trackingNumber: CFNumberRef = 0 as *const __CFNumber;
+                            if *cp3 as libc::c_int != '=' as i32 {
+                                current_block = 4154772336439402900;
+                            } else {
+                                cp3 = cp3.offset(1);
+                                tracking = read_double(&mut cp3);
+                                trackingNumber = CFNumberCreate(
+                                    0 as CFAllocatorRef,
+                                    kCFNumberDoubleType as libc::c_int as CFNumberType,
+                                    &mut tracking as *mut libc::c_double as *const libc::c_void,
+                                );
+                                CFDictionaryAddValue(
+                                    stringAttributes,
+                                    kCTKernAttributeName as *const libc::c_void,
+                                    trackingNumber as *const libc::c_void,
+                                );
+                                CFRelease(trackingNumber as CFTypeRef);
+                                current_block = 15938117740974259152;
+                            }
+                        } else {
+                            current_block = 4154772336439402900;
+                        }
+                    }
+                }
+            }
+            match current_block {
+                4154772336439402900 =>
+                // not a name=value pair, or not recognized....
+                // check for plain "vertical" before complaining
+                {
+                    if !strstartswith(cp1, b"vertical\x00" as *const u8 as *const libc::c_char)
+                        .is_null()
+                    {
+                        cp3 = cp2;
+                        if *cp3 as libc::c_int == ';' as i32 || *cp3 as libc::c_int == ':' as i32 {
+                            cp3 = cp3.offset(-1)
+                        }
+                        while *cp3 as libc::c_int == '\u{0}' as i32
+                            || *cp3 as libc::c_int == ' ' as i32
+                            || *cp3 as libc::c_int == '\t' as i32
+                        {
+                            cp3 = cp3.offset(-1)
+                        }
+                        if *cp3 != 0 {
+                            cp3 = cp3.offset(1)
+                        }
+                        if cp3 == cp1.offset(8) {
+                            let mut orientation: libc::c_int =
+                                kCTFontOrientationVertical as libc::c_int;
+                            let mut orientationNumber: CFNumberRef = CFNumberCreate(
+                                0 as CFAllocatorRef,
+                                kCFNumberIntType as libc::c_int as CFNumberType,
+                                &mut orientation as *mut libc::c_int as *const libc::c_void,
+                            );
+                            CFDictionaryAddValue(
+                                attributes,
+                                kCTFontOrientationAttribute as *const libc::c_void,
+                                orientationNumber as *const libc::c_void,
+                            );
+                            CFRelease(orientationNumber as CFTypeRef);
+                            CFDictionaryAddValue(
+                                stringAttributes,
+                                kCTVerticalFormsAttributeName as *const libc::c_void,
+                                kCFBooleanTrue as *const libc::c_void,
+                            );
+                            current_block = 15938117740974259152;
+                        } else {
+                            current_block = 8464383504555462953;
+                        }
+                    } else {
+                        current_block = 8464383504555462953;
+                    }
+                    match current_block {
+                        15938117740974259152 => {}
+                        _ => {
+                            font_feature_warning(
+                                cp1 as *const libc::c_void,
+                                cp2.wrapping_offset_from(cp1) as libc::c_long as int32_t,
+                                0 as *const libc::c_void,
+                                0i32,
+                            );
+                        }
+                    }
+                }
+                _ => {}
+            }
+            // go to next name=value pair
+            cp1 = cp2
+        }
+        // break if end of string
+        if !features.is_null() {
+            CFRelease(features as CFTypeRef);
+        }
+        if CFArrayGetCount(featureSettings as CFArrayRef) != 0 {
+            CFDictionaryAddValue(
+                attributes,
+                kCTFontFeatureSettingsAttribute as *const libc::c_void,
+                featureSettings as *const libc::c_void,
+            );
+        }
+        CFRelease(featureSettings as CFTypeRef);
+    }
+    if loaded_font_flags as libc::c_int & 0x1i32 != 0i32 {
+        let mut red: CGFloat = ((rgbValue & 0xff000000u32) >> 24i32) as libc::c_double / 255.0f64;
+        let mut green: CGFloat =
+            ((rgbValue & 0xff0000i32 as libc::c_uint) >> 16i32) as libc::c_double / 255.0f64;
+        let mut blue: CGFloat =
+            ((rgbValue & 0xff00i32 as libc::c_uint) >> 8i32) as libc::c_double / 255.0f64;
+        let mut alpha: CGFloat = (rgbValue & 0xffi32 as libc::c_uint) as libc::c_double / 255.0f64;
+        let mut color: CGColorRef = CGColorCreateGenericRGB(red, green, blue, alpha);
+        CFDictionaryAddValue(
+            stringAttributes,
+            kCTForegroundColorAttributeName as *const libc::c_void,
+            color as *const libc::c_void,
+        );
+        CGColorRelease(color);
+    }
+    matrix = CGAffineTransformIdentity;
+    if extend as libc::c_double != 1.0f64 || slant as libc::c_double != 0.0f64 {
+        matrix = __CGAffineTransformMake(
+            extend as CGFloat,
+            0i32 as CGFloat,
+            slant as CGFloat,
+            1.0f64,
+            0i32 as CGFloat,
+            0i32 as CGFloat,
+        )
+    }
+    if embolden as libc::c_double != 0.0f64 {
+        let mut emboldenNumber: CFNumberRef = 0 as *const __CFNumber;
+        embolden = (embolden as libc::c_double * Fix2D(scaled_size) / 100.0f64) as libc::c_float;
+        emboldenNumber = CFNumberCreate(
+            0 as CFAllocatorRef,
+            kCFNumberFloatType as libc::c_int as CFNumberType,
+            &mut embolden as *mut libc::c_float as *const libc::c_void,
+        );
+        CFDictionaryAddValue(
+            stringAttributes,
+            getkXeTeXEmboldenAttributeName() as *const libc::c_void,
+            emboldenNumber as *const libc::c_void,
+        );
+        CFRelease(emboldenNumber as CFTypeRef);
+    }
+    if letterspace as libc::c_double != 0.0f64 {
+        loaded_font_letter_space =
+            (letterspace as libc::c_double / 100.0f64 * scaled_size as libc::c_double) as scaled_t
+    }
+    // Disable Core Text font fallback (cascading) with only the last resort font
+    // in the cascade list.
+    cascadeList =
+        CFArrayCreateMutable(0 as CFAllocatorRef, 1i32 as CFIndex, &kCFTypeArrayCallBacks);
+    lastResort = CTFontDescriptorCreateWithNameAndSize(getLastResort(), 0i32 as CGFloat);
+    CFArrayAppendValue(cascadeList, lastResort as *const libc::c_void);
+    CFRelease(lastResort as CFTypeRef);
+    CFDictionaryAddValue(
+        attributes,
+        kCTFontCascadeListAttribute as *const libc::c_void,
+        cascadeList as *const libc::c_void,
+    );
+    CFRelease(cascadeList as CFTypeRef);
+    descriptor = CTFontDescriptorCreateWithAttributes(attributes as CFDictionaryRef);
+    CFRelease(attributes as CFTypeRef);
+    actualFont = CTFontCreateCopyWithAttributes(
+        font,
+        ctSize,
+        &mut matrix as *mut CGAffineTransform as *const CGAffineTransform,
+        descriptor,
+    );
+    CFRelease(font as CFTypeRef);
+    CFDictionaryAddValue(
+        stringAttributes,
+        kCTFontAttributeName as *const libc::c_void,
+        actualFont as *const libc::c_void,
+    );
+    CFRelease(actualFont as CFTypeRef);
+    native_font_type_flag = 0xffffu32 as int32_t;
+    return stringAttributes as *mut libc::c_void;
+}

--- a/engine/tectonic/xetex-ext.c
+++ b/engine/tectonic/xetex-ext.c
@@ -1,0 +1,2139 @@
+/****************************************************************************\
+ Part of the XeTeX typesetting system
+ Copyright (c) 1994-2008 by SIL International
+ Copyright (c) 2009, 2011 by Jonathan Kew
+ Copyright (c) 2012-2015 by Khaled Hosny
+ Copyright (c) 2012, 2013 by Jiang Jiang
+
+ SIL Author(s): Jonathan Kew
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE
+FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Except as contained in this notice, the name of the copyright holders
+shall not be used in advertising or otherwise to promote the sale,
+use or other dealings in this Software without prior written
+authorization from the copyright holders.
+\****************************************************************************/
+
+/* XeTeX_ext.c
+ * additional plain C extensions for XeTeX - mostly platform-neutral
+ */
+
+#include "xetex-core.h"
+#include "xetex-ext.h"
+#include "teckit-c-Engine.h"
+#include "xetex-XeTeXLayoutInterface.h"
+#include "xetex-swap.h"
+
+#include <assert.h>
+#include <locale.h>
+#include <math.h> /* for fabs() */
+#include <signal.h>
+#include <time.h>
+
+#ifndef _MSC_VER
+#include <sys/time.h>
+#endif
+
+#include <unicode/ubidi.h>
+#include <unicode/ubrk.h>
+#include <unicode/ucnv.h>
+
+#include <graphite2/Font.h>
+
+#include "xetex-xetexd.h"
+
+
+/* OT-related constants we need */
+#define kGSUB HB_TAG('G','S','U','B')
+#define kGPOS HB_TAG('G','P','O','S')
+
+
+static UBreakIterator* brkIter = NULL;
+static int brkLocaleStrNum = 0;
+
+void
+linebreak_start(int f, int32_t localeStrNum, uint16_t* text, int32_t textLength)
+{
+    UErrorCode status = U_ZERO_ERROR;
+    char* locale = (char*)gettexstring(localeStrNum);
+
+    if (font_area[f] == OTGR_FONT_FLAG && streq_ptr(locale, "G")) {
+        XeTeXLayoutEngine engine = (XeTeXLayoutEngine) font_layout_engine[f];
+        if (initGraphiteBreaking(engine, text, textLength))
+            /* user asked for Graphite line breaking and the font supports it */
+            return;
+    }
+
+    if ((localeStrNum != brkLocaleStrNum) && (brkIter != NULL)) {
+        ubrk_close(brkIter);
+        brkIter = NULL;
+    }
+
+    if (brkIter == NULL) {
+        brkIter = ubrk_open(UBRK_LINE, locale, NULL, 0, &status);
+        if (U_FAILURE(status)) {
+            begin_diagnostic();
+            print_nl('E');
+            print_c_string("rror ");
+            print_int(status);
+            print_c_string(" creating linebreak iterator for locale `");
+            print_c_string(locale);
+            print_c_string("'; trying default locale `en_us'.");
+            end_diagnostic(1);
+            if (brkIter != NULL)
+                ubrk_close(brkIter);
+            status = U_ZERO_ERROR;
+            brkIter = ubrk_open(UBRK_LINE, "en_us", NULL, 0, &status);
+        }
+        free(locale);
+        brkLocaleStrNum = localeStrNum;
+    }
+
+    if (brkIter == NULL)
+        _tt_abort ("failed to create linebreak iterator, status=%d", (int) status);
+
+    ubrk_setText(brkIter, (UChar*) text, textLength, &status);
+}
+
+int
+linebreak_next(void)
+{
+    if (brkIter != NULL)
+        return ubrk_next((UBreakIterator*)brkIter);
+    else
+        return findNextGraphiteBreak();
+}
+
+int
+get_encoding_mode_and_info(int32_t* info)
+{
+    /* \XeTeXinputencoding "enc-name"
+     *   -> name is packed in |nameoffile| as a C string, starting at [1]
+     * Check if it's a built-in name; if not, try to open an ICU converter by that name
+     */
+    UErrorCode err = U_ZERO_ERROR;
+    UConverter* cnv;
+    *info = 0;
+    if (strcasecmp(name_of_file, "auto") == 0) {
+        return AUTO;
+    }
+    if (strcasecmp(name_of_file, "utf8") == 0) {
+        return UTF8;
+    }
+    if (strcasecmp(name_of_file, "utf16") == 0) {   /* depends on host platform */
+        return US_NATIVE_UTF16;
+    }
+    if (strcasecmp(name_of_file, "utf16be") == 0) {
+        return UTF16BE;
+    }
+    if (strcasecmp(name_of_file, "utf16le") == 0) {
+        return UTF16LE;
+    }
+    if (strcasecmp(name_of_file, "bytes") == 0) {
+        return RAW;
+    }
+
+    /* try for an ICU converter */
+    cnv = ucnv_open(name_of_file, &err);
+    if (cnv == NULL) {
+        begin_diagnostic();
+        print_nl('U'); /* ensure message starts on a new line */
+        print_c_string("nknown encoding `");
+        print_c_string(name_of_file);
+        print_c_string("'; reading as raw bytes");
+        end_diagnostic(1);
+        return RAW;
+    } else {
+        ucnv_close(cnv);
+        *info = maketexstring(name_of_file);
+        return ICUMAPPING;
+    }
+}
+
+void
+print_utf8_str(const unsigned char* str, int len)
+{
+    while (len-- > 0)
+        print_raw_char(*(str++), true); /* bypass utf-8 encoding done in print_char() */
+}
+
+void
+print_chars(const unsigned short* str, int len)
+{
+    while (len-- > 0)
+        print_char(*(str++));
+}
+
+static void*
+load_mapping_file(const char* s, const char* e, char byteMapping)
+{
+    TECkit_Converter cnv = 0;
+    char* buffer = xmalloc(e - s + 5);
+    rust_input_handle_t map;
+
+    strncpy(buffer, s, e - s);
+    buffer[e - s] = 0;
+    strcat(buffer, ".tec");
+
+    map = ttstub_input_open (buffer, TTIF_MISCFONTS, 0);
+    if (map) {
+        size_t mappingSize = ttstub_input_get_size (map);
+        Byte *mapping = xmalloc(mappingSize);
+        ssize_t r = ttstub_input_read(map, (char *) mapping, mappingSize);
+
+        if (r < 0 || (size_t) r != mappingSize)
+            _tt_abort("could not read mapping file \"%s\"", buffer);
+
+        ttstub_input_close(map);
+
+        if (byteMapping != 0)
+            TECkit_CreateConverter(mapping, mappingSize,
+                                   false,
+                                   UTF16_NATIVE, kForm_Bytes,
+                                   &cnv);
+        else
+            TECkit_CreateConverter(mapping, mappingSize,
+                                   true,
+                                   UTF16_NATIVE, UTF16_NATIVE,
+                                   &cnv);
+
+        if (cnv == NULL)
+            font_mapping_warning(buffer, strlen(buffer), 2); /* not loadable */
+        else if (get_tracing_fonts_state() > 1)
+            font_mapping_warning(buffer, strlen(buffer), 0); /* tracing */
+    } else {
+        font_mapping_warning(buffer, strlen(buffer), 1); /* not found */
+    }
+
+    free(buffer);
+
+    return cnv;
+}
+
+static char *saved_mapping_name = NULL;
+void
+check_for_tfm_font_mapping(void)
+{
+    char* cp = strstr(name_of_file, ":mapping=");
+    saved_mapping_name = mfree(saved_mapping_name);
+    if (cp != NULL) {
+        *cp = 0;
+        cp += 9;
+        while (*cp && *cp <= ' ')
+            ++cp;
+        if (*cp)
+            saved_mapping_name = xstrdup(cp);
+    }
+}
+
+void*
+load_tfm_font_mapping(void)
+{
+    void* rval = NULL;
+    if (saved_mapping_name != NULL) {
+        rval = load_mapping_file(saved_mapping_name,
+                saved_mapping_name + strlen(saved_mapping_name), 1);
+        saved_mapping_name = mfree(saved_mapping_name);
+    }
+    return rval;
+}
+
+int
+apply_tfm_font_mapping(void* cnv, int c)
+{
+    UniChar in = c;
+    Byte out[2];
+    UInt32 inUsed, outUsed;
+    /* TECkit_Status status; */
+    /* status = */ TECkit_ConvertBuffer((TECkit_Converter)cnv,
+            (const Byte*)&in, sizeof(in), &inUsed, out, sizeof(out), &outUsed, 1);
+    if (outUsed < 1)
+        return 0;
+    else
+        return out[0];
+}
+
+double
+read_double(const char** s)
+{
+    int neg = 0;
+    double val = 0.0;
+    const char* cp = *s;
+
+    while (*cp == ' '|| *cp == '\t')
+        ++cp;
+    if (*cp == '-') {
+        neg = 1;
+        ++cp;
+    } else if (*cp == '+') {
+        ++cp;
+    }
+
+    while (*cp >= '0' && *cp <= '9') {
+        val = val * 10.0 + *cp - '0';
+        ++cp;
+    }
+    if (*cp == '.') {
+        double dec = 10.0;
+        ++cp;
+        while (*cp >= '0' && *cp <= '9') {
+            val = val + (*cp - '0') / dec;
+            ++cp;
+            dec = dec * 10.0;
+        }
+    }
+    *s = cp;
+
+    return neg ? -val : val;
+}
+
+static hb_tag_t
+read_tag_with_param(const char* cp, int* param)
+{
+    const char* cp2;
+    hb_tag_t tag;
+
+    cp2 = cp;
+    while (*cp2 && (*cp2 != ':') && (*cp2 != ';') && (*cp2 != ',') && (*cp2 != '='))
+        ++cp2;
+
+    tag = hb_tag_from_string(cp, cp2 - cp);
+
+    cp = cp2;
+    if (*cp == '=') {
+        int neg = 0;
+        ++cp;
+        if (*cp == '-') {
+            ++neg;
+            ++cp;
+        }
+        while (*cp >= '0' && *cp <= '9') {
+            *param = *param * 10 + *cp - '0';
+            ++cp;
+        }
+        if (neg)
+            *param = -(*param);
+    }
+
+    return tag;
+}
+
+unsigned int
+read_rgb_a(const char** cp)
+{
+    uint32_t rgbValue = 0;
+    uint32_t alpha = 0;
+    int i;
+    for (i = 0; i < 6; ++i) {
+        if ((**cp >= '0') && (**cp <= '9'))
+            rgbValue = (rgbValue << 4) + **cp - '0';
+        else if ((**cp >= 'A') && (**cp <= 'F'))
+            rgbValue = (rgbValue << 4) + **cp - 'A' + 10;
+        else if ((**cp >= 'a') && (**cp <= 'f'))
+            rgbValue = (rgbValue << 4) + **cp - 'a' + 10;
+        else
+            return 0x000000FF;
+        (*cp)++;
+    }
+    rgbValue <<= 8;
+    for (i = 0; i < 2; ++i) {
+        if ((**cp >= '0') && (**cp <= '9'))
+            alpha = (alpha << 4) + **cp - '0';
+        else if ((**cp >= 'A') && (**cp <= 'F'))
+            alpha = (alpha << 4) + **cp - 'A' + 10;
+        else if ((**cp >= 'a') && (**cp <= 'f'))
+            alpha = (alpha << 4) + **cp - 'a' + 10;
+        else
+            break;
+        (*cp)++;
+    }
+    if (i == 2)
+        rgbValue += alpha;
+    else
+        rgbValue += 0xFF;
+    return rgbValue;
+}
+
+int
+readCommonFeatures(const char* feat, const char* end, float* extend, float* slant, float* embolden, float* letterspace, uint32_t* rgbValue)
+    // returns 1 to go to next_option, -1 for bad_option, 0 to continue
+{
+    const char* sep;
+    sep = strstartswith(feat, "mapping");
+    if (sep) {
+        if (*sep != '=')
+            return -1;
+        loaded_font_mapping = load_mapping_file(sep + 1, end, 0);
+        return 1;
+    }
+
+    sep = strstartswith(feat, "extend");
+    if (sep) {
+        if (*sep != '=')
+            return -1;
+        ++sep;
+        *extend = read_double(&sep);
+        return 1;
+    }
+
+    sep = strstartswith(feat, "slant");
+    if (sep) {
+        if (*sep != '=')
+            return -1;
+        ++sep;
+        *slant = read_double(&sep);
+        return 1;
+    }
+
+    sep = strstartswith(feat, "embolden");
+    if (sep) {
+        if (*sep != '=')
+            return -1;
+        ++sep;
+        *embolden = read_double(&sep);
+        return 1;
+    }
+
+    sep = strstartswith(feat, "letterspace");
+    if (sep) {
+        if (*sep != '=')
+            return -1;
+        ++sep;
+        *letterspace = read_double(&sep);
+        return 1;
+    }
+
+    sep = strstartswith(feat, "color");
+    if (sep) {
+        const char* s;
+        if (*sep != '=')
+            return -1;
+        ++sep;
+        s = sep;
+        *rgbValue = read_rgb_a(&sep);
+        if ((sep == s+6) || (sep == s+8))
+            loaded_font_flags |= FONT_FLAGS_COLORED;
+        else
+            return -1;
+        return 1;
+    }
+
+    return 0;
+}
+
+static bool
+readFeatureNumber(const char* s, const char* e, hb_tag_t* f, int* v)
+    /* s...e is a "id=setting" string; */
+{
+    *f = 0;
+    *v = 0;
+    if (*s < '0' || *s > '9')
+        return false;
+    while (*s >= '0' && *s <= '9')
+        *f = *f * 10 + *s++ - '0';
+    while ((*s == ' ') || (*s == '\t'))
+        ++s;
+    if (*s++ != '=')
+        /* no setting was specified */
+        return false;
+
+    if (*s < '0' || *s > '9')
+        return false;
+    while (*s >= '0' && *s <= '9')
+        *v = *v * 10 + *s++ - '0';
+    while ((*s == ' ') || (*s == '\t'))
+        ++s;
+    if (s != e)
+        return false;
+    return true;
+}
+
+static void*
+loadOTfont(PlatformFontRef fontRef, XeTeXFont font, Fixed scaled_size, char* cp1)
+{
+    XeTeXLayoutEngine engine = NULL;
+    hb_tag_t script = HB_TAG_NONE;
+    char * language = NULL;
+    hb_feature_t* features = NULL;
+    char** shapers = NULL; /* NULL-terminated array */
+    int nFeatures = 0;
+    int nShapers = 0;
+
+    char* cp2;
+    const char* cp3;
+
+    hb_tag_t tag;
+
+    uint32_t rgbValue = 0x000000FF;
+
+    float extend = 1.0;
+    float slant = 0.0;
+    float embolden = 0.0;
+    float letterspace = 0.0;
+
+    int i;
+
+    char reqEngine = getReqEngine();
+
+    if (reqEngine == 'O' || reqEngine == 'G') {
+        shapers = (char**) xrealloc(shapers, (nShapers + 1) * sizeof(char *));
+        if (reqEngine == 'O') {
+            static char ot_const[] = "ot";
+            shapers[nShapers] = ot_const;
+        } else if (reqEngine == 'G') {
+            static char graphite2_const[] = "graphite2";
+            shapers[nShapers] = graphite2_const;
+        }
+        nShapers++;
+    }
+
+    if (reqEngine == 'G') {
+        char* tmpShapers[] = {shapers[0]};
+        /* create a default engine so we can query the font for Graphite features;
+         * because of font caching, it's cheap to discard this and create the real one later */
+        engine = createLayoutEngine(fontRef, font, script, language,
+                features, nFeatures, tmpShapers, rgbValue, extend, slant, embolden);
+
+        if (engine == NULL)
+            return NULL;
+    }
+
+    /* scan the feature string (if any) */
+    if (cp1 != NULL) {
+        while (*cp1) {
+            if ((*cp1 == ':') || (*cp1 == ';') || (*cp1 == ','))
+                ++cp1;
+            while ((*cp1 == ' ') || (*cp1 == '\t')) /* skip leading whitespace */
+                ++cp1;
+            if (*cp1 == 0) /* break if end of string */
+                break;
+
+            cp2 = cp1;
+            while (*cp2 && (*cp2 != ':') && (*cp2 != ';') && (*cp2 != ','))
+                ++cp2;
+
+            cp3 = strstartswith(cp1, "script");
+            if (cp3) {
+                if (*cp3 != '=')
+                    goto bad_option;
+                ++cp3;
+                script = hb_tag_from_string(cp3, cp2 - cp3);
+                goto next_option;
+            }
+
+            cp3 = strstartswith(cp1, "language");
+            if (cp3) {
+                if (*cp3 != '=')
+                    goto bad_option;
+                ++cp3;
+                language = xmalloc(cp2 - cp3 + 1);
+                language[cp2 - cp3] = '\0';
+                memcpy(language, cp3, cp2 - cp3);
+                goto next_option;
+            }
+
+            cp3 = strstartswith(cp1, "shaper");
+            if (cp3) {
+                if (*cp3 != '=')
+                    goto bad_option;
+                ++cp3;
+                shapers = (char**) xrealloc(shapers, (nShapers + 1) * sizeof(char *));
+                /* some dumb systems have no strndup() */
+                shapers[nShapers] = strdup(cp3);
+                shapers[nShapers][cp2 - cp3] = '\0';
+                nShapers++;
+                goto next_option;
+            }
+
+            i = readCommonFeatures(cp1, cp2, &extend, &slant, &embolden, &letterspace, &rgbValue);
+            if (i == 1)
+                goto next_option;
+            else if (i == -1)
+                goto bad_option;
+
+            if (reqEngine == 'G') {
+                int value = 0;
+                if (readFeatureNumber(cp1, cp2, &tag, &value)
+                 || findGraphiteFeature(engine, cp1, cp2, &tag, &value)) {
+                    features = (hb_feature_t*) xrealloc(features, (nFeatures + 1) * sizeof(hb_feature_t));
+                    features[nFeatures].tag = tag;
+                    features[nFeatures].value = value;
+                    features[nFeatures].start = 0;
+                    features[nFeatures].end = (unsigned int) -1;
+                    nFeatures++;
+                    goto next_option;
+                }
+            }
+
+            if (*cp1 == '+') {
+                int param = 0;
+                tag = read_tag_with_param(cp1 + 1, &param);
+                features = (hb_feature_t*) xrealloc(features, (nFeatures + 1) * sizeof(hb_feature_t));
+                features[nFeatures].tag = tag;
+                features[nFeatures].start = 0;
+                features[nFeatures].end = (unsigned int) -1;
+                // for backward compatibility with pre-0.9999 where feature
+                // indices started from 0
+                if (param >= 0)
+                    param++;
+                features[nFeatures].value = param;
+                nFeatures++;
+                goto next_option;
+            }
+
+            if (*cp1 == '-') {
+                ++cp1;
+                tag = hb_tag_from_string(cp1, cp2 - cp1);
+                features = (hb_feature_t*) xrealloc(features, (nFeatures + 1) * sizeof(hb_feature_t));
+                features[nFeatures].tag = tag;
+                features[nFeatures].start = 0;
+                features[nFeatures].end = (unsigned int) -1;
+                features[nFeatures].value = 0;
+                nFeatures++;
+                goto next_option;
+            }
+
+            if (strstartswith(cp1, "vertical")) {
+                cp3 = cp2;
+                if (*cp3 == ';' || *cp3 == ':' || *cp3 == ',')
+                    --cp3;
+                while (*cp3 == '\0' || *cp3 == ' ' || *cp3 == '\t')
+                    --cp3;
+                if (*cp3)
+                    ++cp3;
+                if (cp3 == cp1 + 8) {
+                    loaded_font_flags |= FONT_FLAGS_VERTICAL;
+                    goto next_option;
+                }
+            }
+
+        bad_option:
+            font_feature_warning((void*) cp1, cp2 - cp1, 0, 0);
+
+        next_option:
+            cp1 = cp2;
+        }
+    }
+
+    if (shapers != NULL) {
+        shapers = (char**) xrealloc(shapers, (nShapers + 1) * sizeof(char *));
+        shapers[nShapers] = NULL;
+    }
+
+    if (embolden != 0.0)
+        embolden = embolden * Fix2D(scaled_size) / 100.0;
+
+    if (letterspace != 0.0)
+        loaded_font_letter_space = (letterspace / 100.0) * scaled_size;
+
+    if ((loaded_font_flags & FONT_FLAGS_COLORED) == 0)
+        rgbValue = 0x000000FF;
+
+    if ((loaded_font_flags & FONT_FLAGS_VERTICAL) != 0)
+        setFontLayoutDir(font, 1);
+
+    engine = createLayoutEngine(fontRef, font, script, language,
+                    features, nFeatures, shapers, rgbValue, extend, slant, embolden);
+
+    if (!engine) {
+        // only free these if creation failed, otherwise the engine now owns them
+        free(features);
+        free(shapers);
+    } else {
+        native_font_type_flag = OTGR_FONT_FLAG;
+    }
+
+    return engine;
+}
+
+static void
+splitFontName(char* name, char** var, char** feat, char** end, int* index)
+{
+    *var = NULL;
+    *feat = NULL;
+    *index = 0;
+    if (*name == '[') {
+        int withinFileName = 1;
+        ++name;
+        while (*name) {
+            if (withinFileName && *name == ']') {
+                withinFileName = 0;
+                if (*var == NULL)
+                    *var = name;
+            } else if (*name == ':') {
+                if (withinFileName && *var == NULL) {
+                    *var = name;
+                    ++name;
+                    while (*name >= '0' && *name <= '9')
+                        *index = *index * 10 + *name++ - '0';
+                    --name;
+                } else if (!withinFileName && *feat == NULL)
+                    *feat = name;
+            }
+            ++name;
+        }
+        *end = name;
+    } else {
+        while (*name) {
+            if (*name == '/' && *var == NULL && *feat == NULL)
+                *var = name;
+            else if (*name == ':' && *feat == NULL)
+                *feat = name;
+            ++name;
+        }
+        *end = name;
+    }
+    if (*feat == NULL)
+        *feat = name;
+    if (*var == NULL)
+        *var = *feat;
+}
+
+void*
+find_native_font(char* uname, int32_t scaled_size)
+    /* scaled_size here is in TeX points, or is a negative integer for 'scaled_t' */
+{
+    void* rval = NULL;
+    char* nameString;
+    char* var;
+    char* feat;
+    char* end;
+    char* name = (char*)uname;
+    char* varString = NULL;
+    char* featString = NULL;
+    PlatformFontRef fontRef;
+    XeTeXFont font = NULL;
+    int index = 0;
+
+    loaded_font_mapping = NULL;
+    loaded_font_flags = 0;
+    loaded_font_letter_space = 0;
+
+    splitFontName(name, &var, &feat, &end, &index);
+    nameString = xmalloc(var - name + 1);
+    strncpy(nameString, name, var - name);
+    nameString[var - name] = 0;
+
+    if (feat > var) {
+        varString = xmalloc(feat - var);
+        strncpy(varString, var + 1, feat - var - 1);
+        varString[feat - var - 1] = 0;
+    }
+
+    if (end > feat) {
+        featString = xmalloc(end - feat);
+        strncpy(featString, feat + 1, end - feat - 1);
+        featString[end - feat - 1] = 0;
+    }
+
+    // check for "[filename]" form, don't search maps in this case
+    if (nameString[0] == '[') {
+        if (scaled_size < 0) {
+            font = createFontFromFile(nameString + 1, index, 655360L);
+            if (font != NULL) {
+                Fixed dsize = D2Fix(getDesignSize(font));
+                if (scaled_size == -1000)
+                    scaled_size = dsize;
+                else
+                    scaled_size = xn_over_d(dsize, -scaled_size, 1000);
+                deleteFont(font);
+            }
+        }
+        font = createFontFromFile(nameString + 1, index, scaled_size);
+        if (font != NULL) {
+            loaded_font_design_size = D2Fix(getDesignSize(font));
+
+            /* This is duplicated in XeTeXFontMgr::findFont! */
+            setReqEngine(0);
+            if (varString) {
+                if (strstartswith(varString, "/AAT"))
+                    setReqEngine('A');
+                else if ((strstartswith(varString, "/OT")) || (strstartswith(varString, "/ICU")))
+                    setReqEngine('O');
+                else if (strstartswith(varString, "/GR"))
+                    setReqEngine('G');
+            }
+
+            rval = loadOTfont(0, font, scaled_size, featString);
+            if (rval == NULL)
+                deleteFont(font);
+            if (rval != NULL && get_tracing_fonts_state() > 0) {
+                begin_diagnostic();
+                print_nl(' ');
+                print_c_string("-> ");
+                print_c_string(nameString + 1);
+                end_diagnostic(0);
+            }
+        }
+    } else {
+        fontRef = findFontByName(nameString, varString, Fix2D(scaled_size));
+
+        if (fontRef) {
+            /* update name_of_file to the full name of the font, for error messages during font loading */
+            const char* fullName = getFullName(fontRef);
+            name_length = strlen(fullName);
+            if (featString != NULL)
+                name_length += strlen(featString) + 1;
+            if (varString != NULL)
+                name_length += strlen(varString) + 1;
+            free(name_of_file);
+            name_of_file = xmalloc(name_length + 1);
+            strcpy(name_of_file, fullName);
+
+            if (scaled_size < 0) {
+                font = createFont(fontRef, scaled_size);
+                if (font != NULL) {
+                    Fixed dsize = D2Fix(getDesignSize(font));
+                    if (scaled_size == -1000)
+                        scaled_size = dsize;
+                    else
+                        scaled_size = xn_over_d(dsize, -scaled_size, 1000);
+                    deleteFont(font);
+                }
+            }
+
+            font = createFont(fontRef, scaled_size);
+            if (font != NULL) {
+#ifdef XETEX_MAC
+                /* decide whether to use AAT or OpenType rendering with this font */
+                if (getReqEngine() == 'A') {
+                    rval = loadAATfont(fontRef, scaled_size, featString);
+                    if (rval == NULL)
+                        deleteFont(font);
+                } else {
+                    if (getReqEngine() == 'O' || getReqEngine() == 'G' ||
+                            getFontTablePtr(font, kGSUB) != NULL || getFontTablePtr(font, kGPOS) != NULL)
+                        rval = loadOTfont(fontRef, font, scaled_size, featString);
+
+                    /* loadOTfont failed or the above check was false */
+                    if (rval == NULL)
+                        rval = loadAATfont(fontRef, scaled_size, featString);
+
+                    if (rval == NULL)
+                        deleteFont(font);
+                }
+#else
+                rval = loadOTfont(fontRef, font, scaled_size, featString);
+                if (rval == NULL)
+                    deleteFont(font);
+#endif
+            }
+
+            /* append the style and feature strings, so that \show\fontID will give a full result */
+            if (varString != NULL && *varString != 0) {
+                strcat(name_of_file, "/");
+                strcat(name_of_file, varString);
+            }
+            if (featString != NULL && *featString != 0) {
+                strcat(name_of_file, ":");
+                strcat(name_of_file, featString);
+            }
+            name_length = strlen(name_of_file);
+        }
+    }
+
+    free(varString);
+
+    free(featString);
+
+    free(nameString);
+
+    return rval;
+}
+
+void
+release_font_engine(void* engine, int type_flag)
+{
+#ifdef XETEX_MAC
+    if (type_flag == AAT_FONT_FLAG) {
+        CFRelease((CFDictionaryRef)engine);
+    } else
+#endif
+    if (type_flag == OTGR_FONT_FLAG) {
+        deleteLayoutEngine((XeTeXLayoutEngine)engine);
+    }
+}
+
+void
+ot_get_font_metrics(void* pEngine, scaled_t* ascent, scaled_t* descent, scaled_t* xheight, scaled_t* capheight, scaled_t* slant)
+{
+    XeTeXLayoutEngine engine = (XeTeXLayoutEngine)pEngine;
+    float a, d;
+
+    getAscentAndDescent(engine, &a, &d);
+    *ascent = D2Fix(a);
+    *descent = D2Fix(d);
+
+    *slant = D2Fix(Fix2D(getSlant(getFont(engine))) * getExtendFactor(engine)
+                    + getSlantFactor(engine));
+
+    /* get cap and x height from OS/2 table */
+    getCapAndXHeight(engine, &a, &d);
+    *capheight = D2Fix(a);
+    *xheight = D2Fix(d);
+
+    /* fallback in case the font does not have OS/2 table */
+    if (*xheight == 0) {
+        int glyphID = mapCharToGlyph(engine, 'x');
+        if (glyphID != 0) {
+            getGlyphHeightDepth(engine, glyphID, &a, &d);
+            *xheight = D2Fix(a);
+        } else {
+            *xheight = *ascent / 2; /* arbitrary figure if there's no 'x' in the font */
+        }
+    }
+
+    if (*capheight == 0) {
+        int glyphID = mapCharToGlyph(engine, 'X');
+        if (glyphID != 0) {
+            getGlyphHeightDepth(engine, glyphID, &a, &d);
+            *capheight = D2Fix(a);
+        } else {
+            *capheight = *ascent; /* arbitrary figure if there's no 'X' in the font */
+        }
+    }
+}
+
+int32_t
+ot_font_get(int32_t what, void* pEngine)
+{
+    XeTeXLayoutEngine engine = (XeTeXLayoutEngine)pEngine;
+    XeTeXFont fontInst = getFont(engine);
+    switch (what) {
+        case XeTeX_count_glyphs:
+            return countGlyphs(fontInst);
+            break;
+
+        case XeTeX_count_features: /* ie Graphite features */
+            return countGraphiteFeatures(engine);
+            break;
+
+        case XeTeX_OT_count_scripts:
+            return countScripts(fontInst);
+            break;
+    }
+    return 0;
+}
+
+
+int32_t
+ot_font_get_1(int32_t what, void* pEngine, int32_t param)
+{
+    XeTeXLayoutEngine engine = (XeTeXLayoutEngine)pEngine;
+    XeTeXFont fontInst = getFont(engine);
+    switch (what) {
+        case XeTeX_OT_count_languages:
+            return countLanguages(fontInst, param);
+            break;
+
+        case XeTeX_OT_script_code:
+            return getIndScript(fontInst, param);
+            break;
+
+        /* for graphite fonts...*/
+        case XeTeX_feature_code:
+            return getGraphiteFeatureCode(engine, param);
+            break;
+        case XeTeX_is_exclusive_feature:
+            return 1;
+            break;
+        case XeTeX_count_selectors:
+            return countGraphiteFeatureSettings(engine, param);
+            break;
+    }
+    return 0;
+}
+
+
+int32_t
+ot_font_get_2(int32_t what, void* pEngine, int32_t param1, int32_t param2)
+{
+    XeTeXLayoutEngine engine = (XeTeXLayoutEngine)pEngine;
+    XeTeXFont fontInst = getFont(engine);
+    switch (what) {
+        case XeTeX_OT_language_code:
+            return getIndLanguage(fontInst, param1, param2);
+            break;
+
+        case XeTeX_OT_count_features:
+            return countFeatures(fontInst, param1, param2);
+            break;
+
+        /* for graphite fonts */
+        case XeTeX_selector_code:
+            return getGraphiteFeatureSettingCode(engine, param1, param2);
+            break;
+        case XeTeX_is_default_selector:
+            return getGraphiteFeatureDefaultSetting(engine, param1) == param2;
+            break;
+    }
+
+    return 0;
+}
+
+
+int32_t
+ot_font_get_3(int32_t what, void* pEngine, int32_t param1, int32_t param2, int32_t param3)
+{
+    XeTeXLayoutEngine engine = (XeTeXLayoutEngine)pEngine;
+    XeTeXFont fontInst = getFont(engine);
+    switch (what) {
+        case XeTeX_OT_feature_code:
+            return getIndFeature(fontInst, param1, param2, param3);
+            break;
+    }
+
+    return 0;
+}
+
+void
+gr_print_font_name(int32_t what, void* pEngine, int32_t param1, int32_t param2)
+{
+    char* name = NULL;
+    XeTeXLayoutEngine engine = (XeTeXLayoutEngine)pEngine;
+    switch (what) {
+        case XeTeX_feature_name:
+            name = getGraphiteFeatureLabel(engine, param1);
+            break;
+        case XeTeX_selector_name:
+            name = getGraphiteFeatureSettingLabel(engine, param1, param2);
+            break;
+    }
+
+    if (name != NULL) {
+        print_c_string(name);
+        gr_label_destroy(name);
+    }
+}
+
+int32_t
+gr_font_get_named(int32_t what, void* pEngine)
+{
+    long rval = -1;
+    XeTeXLayoutEngine engine = (XeTeXLayoutEngine)pEngine;
+    switch (what) {
+        case XeTeX_find_feature_by_name:
+            rval = findGraphiteFeatureNamed(engine, name_of_file, name_length);
+            break;
+    }
+    return rval;
+}
+
+int32_t
+gr_font_get_named_1(int32_t what, void* pEngine, int32_t param)
+{
+    long rval = -1;
+    XeTeXLayoutEngine engine = (XeTeXLayoutEngine)pEngine;
+    switch (what) {
+        case XeTeX_find_selector_by_name:
+            rval = findGraphiteFeatureSettingNamed(engine, param, name_of_file, name_length);
+            break;
+    }
+    return rval;
+}
+
+#define XDV_FLAG_VERTICAL       0x0100
+#define XDV_FLAG_COLORED        0x0200
+#define XDV_FLAG_EXTEND         0x1000
+#define XDV_FLAG_SLANT          0x2000
+#define XDV_FLAG_EMBOLDEN       0x4000
+
+#ifdef XETEX_MAC
+static UInt32
+cgColorToRGBA32(CGColorRef color)
+{
+    const CGFloat *components = CGColorGetComponents(color);
+
+    UInt32 rval = (UInt8)(components[0] * 255.0 + 0.5);
+    rval <<= 8;
+    rval += (UInt8)(components[1] * 255.0 + 0.5);
+    rval <<= 8;
+    rval += (UInt8)(components[2] * 255.0 + 0.5);
+    rval <<= 8;
+    rval += (UInt8)(components[3] * 255.0 + 0.5);
+    return rval;
+}
+#endif
+
+static int xdvBufSize = 0;
+
+int
+makeXDVGlyphArrayData(void* pNode)
+{
+    unsigned char* cp;
+    uint16_t* glyphIDs;
+    memory_word* p = (memory_word*) pNode;
+    void* glyph_info;
+    FixedPoint* locations;
+    Fixed width;
+    uint16_t glyphCount = native_glyph_count(p);
+
+    int i = glyphCount * native_glyph_info_size + 8; /* to guarantee enough space in the buffer */
+    if (i > xdvBufSize) {
+        free(xdv_buffer);
+        xdvBufSize = ((i / 1024) + 1) * 1024;
+        xdv_buffer = xmalloc(xdvBufSize);
+    }
+
+    glyph_info = native_glyph_info_ptr(p);
+    locations = (FixedPoint*)glyph_info;
+    glyphIDs = (uint16_t*)(locations + glyphCount);
+
+    cp = (unsigned char*)xdv_buffer;
+
+    width = node_width(p);
+    *cp++ = (width >> 24) & 0xff;
+    *cp++ = (width >> 16) & 0xff;
+    *cp++ = (width >> 8) & 0xff;
+    *cp++ = width & 0xff;
+
+    *cp++ = (glyphCount >> 8) & 0xff;
+    *cp++ = glyphCount & 0xff;
+
+    for (i = 0; i < glyphCount; ++i) {
+        Fixed x = locations[i].x;
+        Fixed y = locations[i].y;
+        *cp++ = (x >> 24) & 0xff;
+        *cp++ = (x >> 16) & 0xff;
+        *cp++ = (x >> 8) & 0xff;
+        *cp++ = x & 0xff;
+        *cp++ = (y >> 24) & 0xff;
+        *cp++ = (y >> 16) & 0xff;
+        *cp++ = (y >> 8) & 0xff;
+        *cp++ = y & 0xff;
+    }
+
+    for (i = 0; i < glyphCount; ++i) {
+        uint16_t g = glyphIDs[i];
+        *cp++ = (g >> 8) & 0xff;
+        *cp++ = g & 0xff;
+    }
+
+    return ((char*)cp - xdv_buffer);
+}
+
+int
+make_font_def(int32_t f)
+{
+    uint16_t flags = 0;
+    uint32_t rgba;
+    Fixed size;
+    char* filename;
+    uint32_t index;
+    uint8_t filenameLen;
+    int fontDefLength;
+    char* cp;
+    /* PlatformFontRef fontRef = 0; */
+    float extend = 1.0;
+    float slant = 0.0;
+    float embolden = 0.0;
+
+#ifdef XETEX_MAC
+    CFDictionaryRef attributes = NULL;
+
+    if (font_area[f] == AAT_FONT_FLAG) {
+        CTFontRef font;
+        CGColorRef color;
+        CGAffineTransform t;
+        CFNumberRef emboldenNumber;
+        CGFloat fSize;
+
+        attributes = (CFDictionaryRef) font_layout_engine[f];
+        font = CFDictionaryGetValue(attributes, kCTFontAttributeName);
+
+        filename = getFileNameFromCTFont(font, &index);
+        assert(filename);
+
+        if (CFDictionaryGetValue(attributes, kCTVerticalFormsAttributeName))
+            flags |= XDV_FLAG_VERTICAL;
+
+        color = (CGColorRef) CFDictionaryGetValue(attributes, kCTForegroundColorAttributeName);
+        if (color)
+            rgba = cgColorToRGBA32(color);
+
+        t = CTFontGetMatrix(font);
+        extend = t.a;
+        slant = t.c;
+
+        emboldenNumber = CFDictionaryGetValue(attributes, getkXeTeXEmboldenAttributeName());
+        if (emboldenNumber)
+            CFNumberGetValue(emboldenNumber, kCFNumberFloatType, &embolden);
+
+        fSize = CTFontGetSize(font);
+        size = D2Fix(fSize);
+    } else
+#endif
+    if (font_area[f] == OTGR_FONT_FLAG) {
+        XeTeXLayoutEngine engine;
+
+        engine = (XeTeXLayoutEngine)font_layout_engine[f];
+        /* fontRef = */ getFontRef(engine);
+        filename = getFontFilename(engine, &index);
+        assert(filename);
+
+        rgba = getRgbValue(engine);
+        if ((font_flags[f] & FONT_FLAGS_VERTICAL) != 0)
+            flags |= XDV_FLAG_VERTICAL;
+
+        extend = getExtendFactor(engine);
+        slant = getSlantFactor(engine);
+        embolden = getEmboldenFactor(engine);
+
+        size = D2Fix(getPointSize(engine));
+    } else {
+        _tt_abort("bad native font flag in `make_font_def`");
+    }
+
+    filenameLen = strlen(filename);
+
+    /* parameters after internal font ID:
+    //  size[4]
+    //  flags[2]
+    //  l[1] n[l]
+    //  if flags & COLORED:
+    //      c[4]
+    */
+
+    fontDefLength
+        = 4 /* size */
+        + 2 /* flags */
+        + 1 /* name length */
+        + filenameLen
+        + 4 /* face index */;
+
+    if ((font_flags[f] & FONT_FLAGS_COLORED) != 0) {
+        fontDefLength += 4; /* 32-bit RGBA value */
+        flags |= XDV_FLAG_COLORED;
+    }
+
+    if (extend != 1.0) {
+        fontDefLength += 4;
+        flags |= XDV_FLAG_EXTEND;
+    }
+    if (slant != 0.0) {
+        fontDefLength += 4;
+        flags |= XDV_FLAG_SLANT;
+    }
+    if (embolden != 0.0) {
+        fontDefLength += 4;
+        flags |= XDV_FLAG_EMBOLDEN;
+    }
+
+    if (fontDefLength > xdvBufSize) {
+        free(xdv_buffer);
+        xdvBufSize = ((fontDefLength / 1024) + 1) * 1024;
+        xdv_buffer = xmalloc(xdvBufSize);
+    }
+    cp = xdv_buffer;
+
+    *(Fixed*)cp = SWAP32(size);
+    cp += 4;
+
+    *(uint16_t*)cp = SWAP16(flags);
+    cp += 2;
+
+    *(uint8_t*)cp = filenameLen;
+    cp += 1;
+    memcpy(cp, filename, filenameLen);
+    cp += filenameLen;
+
+    *(uint32_t*)cp = SWAP32(index);
+    cp += 4;
+
+    if ((font_flags[f] & FONT_FLAGS_COLORED) != 0) {
+        *(uint32_t*)cp = SWAP32(rgba);
+        cp += 4;
+    }
+
+    if (flags & XDV_FLAG_EXTEND) {
+        Fixed f = D2Fix(extend);
+        *(uint32_t*)(cp) = SWAP32(f);
+        cp += 4;
+    }
+    if (flags & XDV_FLAG_SLANT) {
+        Fixed f = D2Fix(slant);
+        *(uint32_t*)(cp) = SWAP32(f);
+        cp += 4;
+    }
+    if (flags & XDV_FLAG_EMBOLDEN) {
+        Fixed f = D2Fix(embolden);
+        *(uint32_t*)(cp) = SWAP32(f);
+        cp += 4;
+    }
+
+    free((char*) filename);
+
+    return fontDefLength;
+}
+
+int
+apply_mapping(void* pCnv, uint16_t* txtPtr, int txtLen)
+{
+    TECkit_Converter cnv = (TECkit_Converter)pCnv;
+    UInt32 inUsed, outUsed;
+    TECkit_Status status;
+    static UInt32 outLength = 0;
+
+    /* allocate outBuffer if not big enough */
+    if (outLength < txtLen * sizeof(UniChar) + 32) {
+        free(mapped_text);
+        outLength = txtLen * sizeof(UniChar) + 32;
+        mapped_text = xmalloc(outLength);
+    }
+
+    /* try the mapping */
+retry:
+    status = TECkit_ConvertBuffer(cnv,
+            (Byte*)txtPtr, txtLen * sizeof(UniChar), &inUsed,
+            (Byte*)mapped_text, outLength, &outUsed, true);
+
+    switch (status) {
+        case kStatus_NoError:
+            txtPtr = (UniChar*)mapped_text;
+            return outUsed / sizeof(UniChar);
+
+        case kStatus_OutputBufferFull:
+            outLength += (txtLen * sizeof(UniChar)) + 32;
+            free(mapped_text);
+            mapped_text = xmalloc(outLength);
+            goto retry;
+
+        default:
+            return 0;
+    }
+}
+
+static void
+snap_zone(scaled_t* value, scaled_t snap_value, scaled_t fuzz)
+{
+    scaled_t difference = *value - snap_value;
+    if (difference <= fuzz && difference >= -fuzz)
+        *value = snap_value;
+}
+
+void
+get_native_char_height_depth(int32_t font, int32_t ch, scaled_t* height, scaled_t* depth)
+{
+#define QUAD(f)         font_info[6+param_base[f]].b32.s1
+#define X_HEIGHT(f)     font_info[5+param_base[f]].b32.s1
+#define CAP_HEIGHT(f)   font_info[8+param_base[f]].b32.s1
+
+    float ht = 0.0;
+    float dp = 0.0;
+    Fixed fuzz;
+
+#ifdef XETEX_MAC
+    if (font_area[font] == AAT_FONT_FLAG) {
+        CFDictionaryRef attributes = (CFDictionaryRef)(font_layout_engine[font]);
+        int gid = MapCharToGlyph_AAT(attributes, ch);
+        GetGlyphHeightDepth_AAT(attributes, gid, &ht, &dp);
+    } else
+#endif
+    if (font_area[font] == OTGR_FONT_FLAG) {
+        XeTeXLayoutEngine engine = (XeTeXLayoutEngine)font_layout_engine[font];
+        int gid = mapCharToGlyph(engine, ch);
+        getGlyphHeightDepth(engine, gid, &ht, &dp);
+    } else {
+        _tt_abort("bad native font flag in `get_native_char_height_depth`");
+    }
+
+    *height = D2Fix(ht);
+    *depth = D2Fix(dp);
+
+    /* snap to "known" zones for baseline, x-height, cap-height if within 4% of em-size */
+    fuzz = QUAD(font) / 25;
+    snap_zone(depth, 0, fuzz);
+    snap_zone(height, 0, fuzz);
+    snap_zone(height, X_HEIGHT(font), fuzz);
+    snap_zone(height, CAP_HEIGHT(font), fuzz);
+}
+
+scaled_t
+getnativecharht(int32_t f, int32_t c)
+{
+    scaled_t h, d;
+    get_native_char_height_depth(f, c, &h, &d);
+    return h;
+}
+
+scaled_t
+getnativechardp(int32_t f, int32_t c)
+{
+    scaled_t h, d;
+    get_native_char_height_depth(f, c, &h, &d);
+    return d;
+}
+
+void
+get_native_char_sidebearings(int32_t font, int32_t ch, scaled_t* lsb, scaled_t* rsb)
+{
+    float l, r;
+
+#ifdef XETEX_MAC
+    if (font_area[font] == AAT_FONT_FLAG) {
+        CFDictionaryRef attributes = (CFDictionaryRef)(font_layout_engine[font]);
+        int gid = MapCharToGlyph_AAT(attributes, ch);
+        GetGlyphSidebearings_AAT(attributes, gid, &l, &r);
+    } else
+#endif
+    if (font_area[font] == OTGR_FONT_FLAG) {
+        XeTeXLayoutEngine engine = (XeTeXLayoutEngine)font_layout_engine[font];
+        int gid = mapCharToGlyph(engine, ch);
+        getGlyphSidebearings(engine, gid, &l, &r);
+    } else {
+        _tt_abort("bad native font flag in `get_native_char_side_bearings`");
+    }
+
+    *lsb = D2Fix(l);
+    *rsb = D2Fix(r);
+}
+
+scaled_t
+get_glyph_bounds(int32_t font, int32_t edge, int32_t gid)
+{
+/* edge codes 1,2,3,4 => L T R B */
+    float a, b;
+
+#ifdef XETEX_MAC
+    if (font_area[font] == AAT_FONT_FLAG) {
+        CFDictionaryRef attributes = (CFDictionaryRef)(font_layout_engine[font]);
+        if (edge & 1)
+            GetGlyphSidebearings_AAT(attributes, gid, &a, &b);
+        else
+            GetGlyphHeightDepth_AAT(attributes, gid, &a, &b);
+    } else
+#endif
+    if (font_area[font] == OTGR_FONT_FLAG) {
+        XeTeXLayoutEngine engine = (XeTeXLayoutEngine)font_layout_engine[font];
+        if (edge & 1)
+            getGlyphSidebearings(engine, gid, &a, &b);
+        else
+            getGlyphHeightDepth(engine, gid, &a, &b);
+    } else {
+        _tt_abort("bad native font flag in `get_glyph_bounds`");
+    }
+    return D2Fix((edge <= 2) ? a : b);
+}
+
+scaled_t
+getnativecharic(int32_t f, int32_t c)
+{
+    scaled_t lsb, rsb;
+    get_native_char_sidebearings(f, c, &lsb, &rsb);
+    if (rsb < 0)
+        return font_letter_space[f] - rsb;
+    else
+        return font_letter_space[f];
+}
+
+scaled_t
+getnativecharwd(int32_t f, int32_t c)
+{
+    scaled_t wd = 0;
+#ifdef XETEX_MAC
+    if (font_area[f] == AAT_FONT_FLAG) {
+        CFDictionaryRef attributes = (CFDictionaryRef)(font_layout_engine[f]);
+        int gid = MapCharToGlyph_AAT(attributes, c);
+        wd = D2Fix(GetGlyphWidth_AAT(attributes, gid));
+    } else
+#endif
+    if (font_area[f] == OTGR_FONT_FLAG) {
+        XeTeXLayoutEngine engine = (XeTeXLayoutEngine)font_layout_engine[f];
+        int gid = mapCharToGlyph(engine, c);
+        wd = D2Fix(getGlyphWidthFromEngine(engine, gid));
+    } else {
+        _tt_abort("bad native font flag in `get_native_char_wd`");
+    }
+    return wd;
+}
+
+uint16_t
+real_get_native_glyph(void* pNode, unsigned int index)
+{
+    memory_word* node = (memory_word*)pNode;
+    FixedPoint* locations = (FixedPoint*)native_glyph_info_ptr(node);
+    uint16_t* glyphIDs = (uint16_t*)(locations + native_glyph_count(node));
+    if (index >= native_glyph_count(node))
+        return 0;
+    else
+        return glyphIDs[index];
+}
+
+void
+store_justified_native_glyphs(void* pNode)
+{
+    memory_word* node = (memory_word*)pNode;
+    unsigned int f = native_font(node);
+
+#ifdef XETEX_MAC /* separate Mac-only codepath for AAT fonts */
+    if (font_area[f] == AAT_FONT_FLAG) {
+        (void)DoAATLayout(node, 1);
+        return;
+    }
+#endif
+
+    /* save desired width */
+    int savedWidth = node_width(node);
+
+    measure_native_node(node, 0);
+
+    if (node_width(node) != savedWidth) {
+        /* see how much adjustment is needed overall */
+        double justAmount = Fix2D(savedWidth - node_width(node));
+
+        /* apply justification to spaces (or if there are none, distribute it to all glyphs as a last resort) */
+        FixedPoint* locations = (FixedPoint*)native_glyph_info_ptr(node);
+        uint16_t* glyphIDs = (uint16_t*)(locations + native_glyph_count(node));
+        int glyphCount = native_glyph_count(node);
+        int spaceCount = 0, i;
+
+        int spaceGlyph = map_char_to_glyph(f, ' ');
+        for (i = 0; i < glyphCount; ++i)
+            if (glyphIDs[i] == spaceGlyph)
+                spaceCount++;
+
+        if (spaceCount > 0) {
+            double adjustment = 0;
+            int spaceIndex = 0;
+            for (i = 0; i < glyphCount; ++i) {
+                locations[i].x = D2Fix(Fix2D(locations[i].x) + adjustment);
+                if (glyphIDs[i] == spaceGlyph) {
+                    spaceIndex++;
+                    adjustment = justAmount * spaceIndex / spaceCount;
+                }
+            }
+        } else {
+            for (i = 1; i < glyphCount; ++i)
+                locations[i].x = D2Fix(Fix2D(locations[i].x) + justAmount * i / (glyphCount - 1));
+        }
+
+        node_width(node) = savedWidth;
+    }
+}
+
+void
+measure_native_node(void* pNode, int use_glyph_metrics)
+{
+    memory_word* node = (memory_word*)pNode;
+    int txtLen = native_length(node);
+    uint16_t* txtPtr = (uint16_t*)(node + NATIVE_NODE_SIZE);
+
+    unsigned int f = native_font(node);
+
+#ifdef XETEX_MAC
+    if (font_area[f] == AAT_FONT_FLAG) {
+        /* we're using this font in AAT mode, so font_layout_engine[f] is actually a CFDictionaryRef */
+        DoAATLayout(node, 0);
+    } else
+#endif
+    if (font_area[f] == OTGR_FONT_FLAG) {
+        /* using this font in OT Layout mode, so font_layout_engine[f] is actually a XeTeXLayoutEngine */
+
+        XeTeXLayoutEngine engine = (XeTeXLayoutEngine)(font_layout_engine[f]);
+
+        FixedPoint* locations = NULL;
+        uint16_t* glyphIDs;
+        Fixed* glyphAdvances = NULL;
+        int totalGlyphCount = 0;
+
+        /* need to find direction runs within the text, and call layoutChars separately for each */
+
+        UBiDiDirection dir;
+        void* glyph_info = 0;
+        static FloatPoint* positions = 0;
+        static float* advances = 0;
+        static uint32_t* glyphs = 0;
+
+        UBiDi* pBiDi = ubidi_open();
+
+        UErrorCode errorCode = U_ZERO_ERROR;
+        ubidi_setPara(pBiDi, (const UChar*) txtPtr, txtLen, getDefaultDirection(engine), NULL, &errorCode);
+
+        dir = ubidi_getDirection(pBiDi);
+        if (dir == UBIDI_MIXED) {
+            /* we actually do the layout twice here, once to count glyphs and then again to get them;
+               which is inefficient, but i figure that MIXED is a relatively rare occurrence, so i can't be
+               bothered to deal with the memory reallocation headache of doing it differently
+            */
+            int nRuns = ubidi_countRuns(pBiDi, &errorCode);
+            double width = 0;
+            int i, runIndex;
+            int32_t logicalStart, length;
+            for (runIndex = 0; runIndex < nRuns; ++runIndex) {
+                dir = ubidi_getVisualRun(pBiDi, runIndex, &logicalStart, &length);
+                totalGlyphCount += layoutChars(engine, txtPtr, logicalStart, length, txtLen, (dir == UBIDI_RTL));
+            }
+
+            if (totalGlyphCount > 0) {
+                double x, y;
+                glyph_info = xcalloc(totalGlyphCount, native_glyph_info_size);
+                locations = (FixedPoint*)glyph_info;
+                glyphIDs = (uint16_t*)(locations + totalGlyphCount);
+                glyphAdvances = xcalloc(totalGlyphCount, sizeof(Fixed));
+                totalGlyphCount = 0;
+
+                x = y = 0.0;
+                for (runIndex = 0; runIndex < nRuns; ++runIndex) {
+                    int nGlyphs;
+                    dir = ubidi_getVisualRun(pBiDi, runIndex, &logicalStart, &length);
+                    nGlyphs = layoutChars(engine, txtPtr, logicalStart, length, txtLen,
+                                            (dir == UBIDI_RTL));
+
+                    glyphs = xcalloc(nGlyphs, sizeof(uint32_t));
+                    positions = xcalloc(nGlyphs + 1, sizeof(FloatPoint));
+                    advances = xcalloc(nGlyphs, sizeof(float));
+
+                    getGlyphs(engine, glyphs);
+                    getGlyphAdvances(engine, advances);
+                    getGlyphPositions(engine, positions);
+
+                    for (i = 0; i < nGlyphs; ++i) {
+                        glyphIDs[totalGlyphCount] = glyphs[i];
+                        locations[totalGlyphCount].x = D2Fix(positions[i].x + x);
+                        locations[totalGlyphCount].y = D2Fix(positions[i].y + y);
+                        glyphAdvances[totalGlyphCount] = D2Fix(advances[i]);
+                        ++totalGlyphCount;
+                    }
+                    x += positions[nGlyphs].x;
+                    y += positions[nGlyphs].y;
+
+                    free(glyphs);
+                    free(positions);
+                    free(advances);
+                }
+                width = x;
+            }
+
+            node_width(node) = D2Fix(width);
+            native_glyph_count(node) = totalGlyphCount;
+            native_glyph_info_ptr(node) = glyph_info;
+        } else {
+            double width = 0;
+            totalGlyphCount = layoutChars(engine, txtPtr, 0, txtLen, txtLen, (dir == UBIDI_RTL));
+
+            glyphs = xcalloc(totalGlyphCount, sizeof(uint32_t));
+            positions = xcalloc(totalGlyphCount + 1, sizeof(FloatPoint));
+            advances = xcalloc(totalGlyphCount, sizeof(float));
+
+            getGlyphs(engine, glyphs);
+            getGlyphAdvances(engine, advances);
+            getGlyphPositions(engine, positions);
+
+            if (totalGlyphCount > 0) {
+                int i;
+                glyph_info = xcalloc(totalGlyphCount, native_glyph_info_size);
+                locations = (FixedPoint*)glyph_info;
+                glyphIDs = (uint16_t*)(locations + totalGlyphCount);
+                glyphAdvances = xcalloc(totalGlyphCount, sizeof(Fixed));
+                for (i = 0; i < totalGlyphCount; ++i) {
+                    glyphIDs[i] = glyphs[i];
+                    glyphAdvances[i] = D2Fix(advances[i]);
+                    locations[i].x = D2Fix(positions[i].x);
+                    locations[i].y = D2Fix(positions[i].y);
+                }
+                width = positions[totalGlyphCount].x;
+            }
+
+            node_width(node) = D2Fix(width);
+            native_glyph_count(node) = totalGlyphCount;
+            native_glyph_info_ptr(node) = glyph_info;
+
+            free(glyphs);
+            free(positions);
+            free(advances);
+        }
+
+        ubidi_close(pBiDi);
+
+
+        if (font_letter_space[f] != 0) {
+            Fixed lsDelta = 0;
+            Fixed lsUnit = font_letter_space[f];
+            int i;
+            for (i = 0; i < totalGlyphCount; ++i) {
+                if (glyphAdvances[i] == 0 && lsDelta != 0)
+                    lsDelta -= lsUnit;
+                locations[i].x += lsDelta;
+                lsDelta += lsUnit;
+            }
+            if (lsDelta != 0) {
+                lsDelta -= lsUnit;
+                node_width(node) += lsDelta;
+            }
+        }
+        free(glyphAdvances);
+    } else {
+        _tt_abort("bad native font flag in `measure_native_node`");
+    }
+
+    if (use_glyph_metrics == 0 || native_glyph_count(node) == 0) {
+        /* for efficiency, height and depth are the font's ascent/descent,
+            not true values based on the actual content of the word,
+            unless use_glyph_metrics is non-zero */
+        node_height(node) = height_base[f];
+        node_depth(node) = depth_base[f];
+    } else {
+        /* this iterates over the glyph data whether it comes from AAT or OT layout */
+        FixedPoint* locations = (FixedPoint*)native_glyph_info_ptr(node);
+        uint16_t* glyphIDs = (uint16_t*)(locations + native_glyph_count(node));
+        float yMin = 65536.0;
+        float yMax = -65536.0;
+        int i;
+        for (i = 0; i < native_glyph_count(node); ++i) {
+            float ht, dp;
+            float y = Fix2D(-locations[i].y); /* NB negative is upwards in locations[].y! */
+
+            GlyphBBox bbox;
+            if (getCachedGlyphBBox(f, glyphIDs[i], &bbox) == 0) {
+#ifdef XETEX_MAC
+                if (font_area[f] == AAT_FONT_FLAG)
+                    GetGlyphBBox_AAT((CFDictionaryRef)(font_layout_engine[f]), glyphIDs[i], &bbox);
+                else
+#endif
+                if (font_area[f] == OTGR_FONT_FLAG)
+                    getGlyphBounds((XeTeXLayoutEngine)(font_layout_engine[f]), glyphIDs[i], &bbox);
+
+                cacheGlyphBBox(f, glyphIDs[i], &bbox);
+            }
+
+            ht = bbox.yMax;
+            dp = -bbox.yMin;
+
+            if (y + ht > yMax)
+                yMax = y + ht;
+            if (y - dp < yMin)
+                yMin = y - dp;
+        }
+        node_height(node) = D2Fix(yMax);
+        node_depth(node) = -D2Fix(yMin);
+    }
+}
+
+Fixed
+real_get_native_italic_correction(void* pNode)
+{
+    memory_word* node = (memory_word*) pNode;
+    unsigned int f = native_font(node);
+    unsigned int n = native_glyph_count(node);
+    if (n > 0) {
+        FixedPoint* locations = (FixedPoint*)native_glyph_info_ptr(node);
+        uint16_t* glyphIDs = (uint16_t*)(locations + n);
+
+#ifdef XETEX_MAC
+        if (font_area[f] == AAT_FONT_FLAG)
+            return D2Fix(GetGlyphItalCorr_AAT((CFDictionaryRef)(font_layout_engine[f]), glyphIDs[n-1]))
+                    + font_letter_space[f];
+#endif
+        if (font_area[f] == OTGR_FONT_FLAG)
+            return D2Fix(getGlyphItalCorr((XeTeXLayoutEngine)(font_layout_engine[f]), glyphIDs[n-1]))
+                    + font_letter_space[f];
+    }
+
+    return 0;
+}
+
+
+Fixed
+real_get_native_glyph_italic_correction(void* pNode)
+{
+    memory_word* node = (memory_word*) pNode;
+    uint16_t gid = native_glyph(node);
+    unsigned int f = native_font(node);
+
+#ifdef XETEX_MAC
+    if (font_area[f] == AAT_FONT_FLAG)
+        return D2Fix(GetGlyphItalCorr_AAT((CFDictionaryRef)(font_layout_engine[f]), gid));
+#endif
+    if (font_area[f] == OTGR_FONT_FLAG)
+        return D2Fix(getGlyphItalCorr((XeTeXLayoutEngine)(font_layout_engine[f]), gid));
+
+    return 0;   /* can't actually happen */
+}
+
+void
+measure_native_glyph(void* pNode, int use_glyph_metrics)
+{
+    memory_word* node = (memory_word*) pNode;
+    uint16_t gid = native_glyph(node);
+    unsigned int f = native_font(node);
+
+    float ht = 0.0;
+    float dp = 0.0;
+
+#ifdef XETEX_MAC
+    if (font_area[f] == AAT_FONT_FLAG) {
+        CFDictionaryRef attributes = (CFDictionaryRef)(font_layout_engine[f]);
+        node_width(node) = D2Fix(GetGlyphWidth_AAT(attributes, gid));
+        if (use_glyph_metrics)
+            GetGlyphHeightDepth_AAT(attributes, gid, &ht, &dp);
+    } else
+#endif
+    if (font_area[f] == OTGR_FONT_FLAG) {
+        XeTeXLayoutEngine engine = (XeTeXLayoutEngine)font_layout_engine[f];
+        XeTeXFont fontInst = getFont(engine);
+        node_width(node) = D2Fix(getGlyphWidth(fontInst, gid));
+        if (use_glyph_metrics)
+            getGlyphHeightDepth(engine, gid, &ht, &dp);
+    } else {
+        _tt_abort("bad native font flag in `measure_native_glyph`");
+    }
+
+    if (use_glyph_metrics) {
+        node_height(node) = D2Fix(ht);
+        node_depth(node) = D2Fix(dp);
+    } else {
+        node_height(node) = height_base[f];
+        node_depth(node) = depth_base[f];
+    }
+}
+
+int32_t
+map_char_to_glyph(int32_t font, int32_t ch)
+{
+    if (ch > 0x10ffff || ((ch >= 0xd800) && (ch <= 0xdfff)))
+        return 0;
+#ifdef XETEX_MAC
+    if (font_area[font] == AAT_FONT_FLAG)
+        return MapCharToGlyph_AAT((CFDictionaryRef)(font_layout_engine[font]), ch);
+    else
+#endif
+    if (font_area[font] == OTGR_FONT_FLAG)
+        return mapCharToGlyph((XeTeXLayoutEngine)(font_layout_engine[font]), ch);
+    else {
+        _tt_abort("bad native font flag in `map_char_to_glyph`");
+    }
+}
+
+int32_t
+map_glyph_to_index(int32_t font)
+    /* glyph name is at name_of_file */
+{
+#ifdef XETEX_MAC
+    if (font_area[font] == AAT_FONT_FLAG)
+        return MapGlyphToIndex_AAT((CFDictionaryRef)(font_layout_engine[font]), name_of_file);
+    else
+#endif
+    if (font_area[font] == OTGR_FONT_FLAG)
+        return mapGlyphToIndex((XeTeXLayoutEngine)(font_layout_engine[font]), name_of_file);
+    else
+        _tt_abort("bad native font flag in `map_glyph_to_index`");
+}
+
+int32_t
+get_font_char_range(int32_t font, int first)
+{
+#ifdef XETEX_MAC
+    if (font_area[font] == AAT_FONT_FLAG)
+        return GetFontCharRange_AAT((CFDictionaryRef)(font_layout_engine[font]), first);
+    else
+#endif
+    if (font_area[font] == OTGR_FONT_FLAG)
+        return getFontCharRange((XeTeXLayoutEngine)(font_layout_engine[font]), first);
+    else
+        _tt_abort("bad native font flag in `get_font_char_range'`");
+}
+
+Fixed D2Fix(double d)
+{
+    Fixed rval = (int)(d * 65536.0 + 0.5);
+    return rval;
+}
+
+double Fix2D(Fixed f)
+{
+    double rval = f / 65536.0;
+    return rval;
+}
+
+/* these are here, not XeTeX_mac.c, because we need stubs on other platforms */
+void
+aat_get_font_metrics(CFDictionaryRef attributes, int32_t* ascent, int32_t* descent, int32_t* xheight, int32_t* capheight, int32_t* slant)
+{
+#ifdef XETEX_MAC
+    CTFontRef font = fontFromAttributes(attributes);
+
+    *ascent = D2Fix(CTFontGetAscent(font));
+    *descent = D2Fix(CTFontGetDescent(font));
+    *xheight = D2Fix(CTFontGetXHeight(font));
+    *capheight = D2Fix(CTFontGetCapHeight(font));
+    *slant = D2Fix(tan(-CTFontGetSlantAngle(font) * M_PI / 180.0));
+#endif
+}
+
+int
+aat_font_get(int what, CFDictionaryRef attributes)
+{
+    int rval = -1;
+
+#ifdef XETEX_MAC
+    CTFontRef font = fontFromAttributes(attributes);
+    CFArrayRef list;
+
+    switch (what) {
+        case XeTeX_count_glyphs:
+            rval = CTFontGetGlyphCount(font);
+            break;
+
+        case XeTeX_count_features:
+            list = CTFontCopyFeatures(font);
+            if (list) {
+                rval = CFArrayGetCount(list);
+                CFRelease(list);
+            }
+            break;
+    }
+#endif
+    return rval;
+}
+
+int
+aat_font_get_1(int what, CFDictionaryRef attributes, int param)
+{
+    int rval = -1;
+
+#ifdef XETEX_MAC
+    CTFontRef font = fontFromAttributes(attributes);
+
+    switch (what) {
+        case XeTeX_feature_code:
+        {
+            CFArrayRef features = CTFontCopyFeatures(font);
+            if (features) {
+                if (CFArrayGetCount(features) > param) {
+                    CFDictionaryRef feature = CFArrayGetValueAtIndex(features, param);
+                    CFNumberRef identifier = CFDictionaryGetValue(feature, kCTFontFeatureTypeIdentifierKey);
+                    if (identifier)
+                        CFNumberGetValue(identifier, kCFNumberIntType, &rval);
+                }
+                CFRelease(features);
+            }
+            break;
+        }
+
+        case XeTeX_is_exclusive_feature:
+        {
+            CFArrayRef features = CTFontCopyFeatures(font);
+            if (features) {
+                CFBooleanRef value;
+                CFDictionaryRef feature = findDictionaryInArrayWithIdentifier(features, kCTFontFeatureTypeIdentifierKey, param);
+                Boolean found = CFDictionaryGetValueIfPresent(feature, kCTFontFeatureTypeExclusiveKey, (const void **)&value);
+                if (found)
+                    rval = CFBooleanGetValue(value);
+                CFRelease(features);
+            }
+            break;
+        }
+
+        case XeTeX_count_selectors:
+        {
+            CFArrayRef features = CTFontCopyFeatures(font);
+            if (features) {
+                CFDictionaryRef feature = findDictionaryInArrayWithIdentifier(features, kCTFontFeatureTypeIdentifierKey, param);
+                if (feature) {
+                    CFArrayRef selectors = CFDictionaryGetValue(feature, kCTFontFeatureTypeSelectorsKey);
+                    if (selectors)
+                        rval = CFArrayGetCount(selectors);
+                }
+                CFRelease(features);
+            }
+            break;
+        }
+    }
+#endif
+
+    return rval;
+}
+
+int
+aat_font_get_2(int what, CFDictionaryRef attributes, int param1, int param2)
+{
+    int rval = -1;
+
+#ifdef XETEX_MAC
+    CTFontRef font = fontFromAttributes(attributes);
+    CFArrayRef features = CTFontCopyFeatures(font);
+    if (features) {
+        CFDictionaryRef feature = findDictionaryInArrayWithIdentifier(features, kCTFontFeatureTypeIdentifierKey, param1);
+        if (feature) {
+            CFArrayRef selectors = CFDictionaryGetValue(feature, kCTFontFeatureTypeSelectorsKey);
+            if (selectors) {
+                CFDictionaryRef selector;
+                switch (what) {
+                    case XeTeX_selector_code:
+                        if (CFArrayGetCount(selectors) > param2) {
+                            CFNumberRef identifier;
+                            selector = CFArrayGetValueAtIndex(selectors, param2);
+                            identifier = CFDictionaryGetValue(selector, kCTFontFeatureSelectorIdentifierKey);
+                            if (identifier)
+                                CFNumberGetValue(identifier, kCFNumberIntType, &rval);
+                        }
+                        break;
+                    case XeTeX_is_default_selector:
+                        selector = findDictionaryInArrayWithIdentifier(selectors, kCTFontFeatureSelectorIdentifierKey, param2);
+                        if (selector) {
+                            CFBooleanRef isDefault;
+                            Boolean found = CFDictionaryGetValueIfPresent(selector, kCTFontFeatureSelectorDefaultKey, (const void **)&isDefault);
+                            if (found)
+                                rval = CFBooleanGetValue(isDefault);
+                        }
+                        break;
+                }
+            }
+        }
+        CFRelease(features);
+    }
+#endif
+
+    return rval;
+}
+
+int
+aat_font_get_named(int what, CFDictionaryRef attributes)
+{
+    int rval = -1;
+
+#ifdef XETEX_MAC
+    if (what == XeTeX_find_feature_by_name)
+        {
+            CTFontRef font = fontFromAttributes(attributes);
+            CFArrayRef features = CTFontCopyFeatures(font);
+            if (features) {
+                CFDictionaryRef feature = findDictionaryInArray(features, kCTFontFeatureTypeNameKey,
+                                                                name_of_file, name_length);
+                if (feature) {
+                    CFNumberRef identifier = CFDictionaryGetValue(feature, kCTFontFeatureTypeIdentifierKey);
+                    CFNumberGetValue(identifier, kCFNumberIntType, &rval);
+                }
+                CFRelease(features);
+            }
+        }
+#endif
+
+    return rval;
+}
+
+int
+aat_font_get_named_1(int what, CFDictionaryRef attributes, int param)
+{
+    int rval = -1;
+
+#ifdef XETEX_MAC
+    CTFontRef font = fontFromAttributes(attributes);
+
+    if (what == XeTeX_find_selector_by_name) {
+        CFArrayRef features = CTFontCopyFeatures(font);
+        if (features) {
+            CFDictionaryRef feature = findDictionaryInArrayWithIdentifier(features, kCTFontFeatureTypeIdentifierKey, param);
+            if (feature) {
+                CFNumberRef selector = findSelectorByName(feature, name_of_file, name_length);
+                if (selector)
+                    CFNumberGetValue(selector, kCFNumberIntType, &rval);
+            }
+            CFRelease(features);
+        }
+    }
+#endif
+
+    return rval;
+}
+
+void
+aat_print_font_name(int what, CFDictionaryRef attributes, int param1, int param2)
+{
+#ifdef XETEX_MAC
+    CFStringRef name = NULL;
+    if (what == XeTeX_feature_name || what == XeTeX_selector_name) {
+        CTFontRef font = fontFromAttributes(attributes);
+        CFArrayRef features = CTFontCopyFeatures(font);
+        if (features) {
+            CFDictionaryRef feature = findDictionaryInArrayWithIdentifier(features,
+                                                                          kCTFontFeatureTypeIdentifierKey,
+                                                                          param1);
+            if (feature) {
+                if (what == XeTeX_feature_name)
+                    name = CFDictionaryGetValue(feature, kCTFontFeatureTypeNameKey);
+                else {
+                    CFArrayRef selectors = CFDictionaryGetValue(feature, kCTFontFeatureTypeSelectorsKey);
+                    CFDictionaryRef selector = findDictionaryInArrayWithIdentifier(selectors,
+                                                                                   kCTFontFeatureSelectorIdentifierKey,
+                                                                                   param2);
+                    if (selector)
+                        name = CFDictionaryGetValue(selector, kCTFontFeatureSelectorNameKey);
+                }
+            }
+            CFRelease(features);
+        }
+    }
+
+    if (name) {
+        CFIndex len = CFStringGetLength(name);
+        UniChar* buf = xcalloc(len, sizeof(UniChar));
+        CFStringGetCharacters(name, CFRangeMake(0, len), buf);
+        print_chars(buf, len);
+        free(buf);
+    }
+#endif
+}
+
+void
+print_glyph_name(int32_t font, int32_t gid)
+{
+    const char* s;
+    int len = 0;
+#ifdef XETEX_MAC
+    if (font_area[font] == AAT_FONT_FLAG) {
+        s = GetGlyphNameFromCTFont(fontFromInteger(font), gid, &len);
+    } else
+#endif
+    if (font_area[font] == OTGR_FONT_FLAG) {
+        XeTeXLayoutEngine engine = (XeTeXLayoutEngine)font_layout_engine[font];
+        s = getGlyphName(getFont(engine), gid, &len);
+    } else {
+        _tt_abort("bad native font flag in `print_glyph_name`");
+    }
+    while (len-- > 0)
+        print_char(*s++);
+}
+
+int32_t real_get_native_word_cp(void* pNode, int side)
+{
+    memory_word* node = (memory_word*)pNode;
+    FixedPoint* locations = (FixedPoint*)native_glyph_info_ptr(node);
+    uint16_t* glyphIDs = (uint16_t*)(locations + native_glyph_count(node));
+    uint16_t glyphCount = native_glyph_count(node);
+    int32_t f = native_font(node);
+    uint16_t actual_glyph;
+
+    if (glyphCount == 0)
+        return 0;
+
+    switch (side) {
+    case LEFT_SIDE:
+        actual_glyph = *glyphIDs;
+        break;
+    case RIGHT_SIDE:
+        actual_glyph = glyphIDs[glyphCount - 1];
+        break;
+    default:
+        assert(0); // we should not reach this point
+    }
+    return get_cp_code(f, actual_glyph, side);
+}

--- a/engine/tectonic/xetex-ext.h
+++ b/engine/tectonic/xetex-ext.h
@@ -96,7 +96,7 @@ authorization from the copyright holders.
 /* For Unicode encoding form interpretation... */
 
 #ifdef XETEX_MAC
-extern const CFStringRef kXeTeXEmboldenAttributeName;
+extern CFStringRef getkXeTeXEmboldenAttributeName(void);
 #endif
 
 BEGIN_EXTERN_C

--- a/engine/tectonic/xetex-macos.c
+++ b/engine/tectonic/xetex-macos.c
@@ -532,7 +532,25 @@ createFeatureSettingDictionary(CFNumberRef featureTypeIdentifier, CFNumberRef fe
                               &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
 }
 
-const CFStringRef kXeTeXEmboldenAttributeName = CFSTR("XeTeXEmbolden");
+// CFSTR causes undefined builtin errors with c2rust
+#define CreateCFString(x) CFStringCreateWithCString(NULL, (x), kCFStringEncodingUTF8)
+
+static CFStringRef kXeTeXEmboldenAttributeName = NULL;
+static CFStringRef kLastResort = NULL;
+
+CFStringRef getkXeTeXEmboldenAttributeName(void){
+    if (kXeTeXEmboldenAttributeName == NULL) {
+        kXeTeXEmboldenAttributeName = CFStringCreateWithCString(NULL, "XeTeXEmbolden", kCFStringEncodingUTF8);
+    }
+    return kXeTeXEmboldenAttributeName;
+}
+
+CFStringRef getLastResort(void){
+    if (kLastResort == NULL) {
+        kLastResort = CFStringCreateWithCString(NULL, "LastResort", kCFStringEncodingUTF8);
+    }
+    return kLastResort;
+}
 
 void*
 loadAATfont(CTFontDescriptorRef descriptor, int32_t scaled_size, const char* cp1)
@@ -715,7 +733,7 @@ loadAATfont(CTFontDescriptorRef descriptor, int32_t scaled_size, const char* cp1
         CFNumberRef emboldenNumber;
         embolden = embolden * Fix2D(scaled_size) / 100.0;
         emboldenNumber = CFNumberCreate(NULL, kCFNumberFloatType, &embolden);
-        CFDictionaryAddValue(stringAttributes, kXeTeXEmboldenAttributeName, emboldenNumber);
+        CFDictionaryAddValue(stringAttributes, getkXeTeXEmboldenAttributeName(), emboldenNumber);
         CFRelease(emboldenNumber);
     }
 
@@ -725,7 +743,7 @@ loadAATfont(CTFontDescriptorRef descriptor, int32_t scaled_size, const char* cp1
     // Disable Core Text font fallback (cascading) with only the last resort font
     // in the cascade list.
     cascadeList = CFArrayCreateMutable(NULL, 1, &kCFTypeArrayCallBacks);
-    lastResort = CTFontDescriptorCreateWithNameAndSize(CFSTR("LastResort"), 0);
+    lastResort = CTFontDescriptorCreateWithNameAndSize(getLastResort(), 0);
     CFArrayAppendValue(cascadeList, lastResort);
     CFRelease(lastResort);
     CFDictionaryAddValue(attributes, kCTFontCascadeListAttribute, cascadeList);

--- a/engine/tectonic/xetex-xetexd.h
+++ b/engine/tectonic/xetex-xetexd.h
@@ -13,13 +13,6 @@
 #include "core-bridge.h"
 #include "xetex-constants.h"
 
-#ifdef XETEX_MAC
-/* include this here to avoid conflict between clang's emmintrin.h and
- * texmfmem.h. Should be removed once a fixed clang is widely available
- * http://llvm.org/bugs/show_bug.cgi?id=14964 */
-#include <ApplicationServices/ApplicationServices.h>
-#endif
-
 #define odd(x) ((x) & 1)
 
 /* Extra stuff used in various change files for various reasons.  */


### PR DESCRIPTION
`xetex_ext.rs` is now roughly what should be compiled with `#[cfg(target_os="macos")]` aka the new `XETEX_MAC`, but it has to go back to normal when that is not the case, so a bunch of conditional compilation blocks have to be added (with all the work since initial conversion applied). Alas, I don't have my head in that game.

fixes #25