### PR TITLE
Replace `pdf_path` & `gs_stack` with `Vec`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1426,6 +1426,7 @@ dependencies = [
 name = "tectonic_dvipdfmx"
 version = "0.0.1-dev"
 dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "libpng-sys 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/dpx/Cargo.toml
+++ b/dpx/Cargo.toml
@@ -8,6 +8,7 @@ license = "GPL"
 
 [dependencies]
 tectonic_bridge = { version = "0.0.1-dev", path = "../bridge" }
+lazy_static = "1.4"
 libc = "0.2"
 libpng-sys = "1"
 libz-sys = { version = "1", optional = true}

--- a/dpx/src/dpx_cidtype0.rs
+++ b/dpx/src/dpx_cidtype0.rs
@@ -218,35 +218,10 @@ pub type rust_input_handle_t = *mut libc::c_void;
 use super::dpx_cid::{cid_opt, CIDFont, CIDSysInfo};
 
 use super::dpx_sfnt::sfnt;
+use super::dpx_cs_type2::cs_ginfo;
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct cs_ginfo {
-    pub flags: i32,
-    pub wx: f64,
-    pub wy: f64,
-    pub bbox: C2RustUnnamed_0,
-    pub seac: C2RustUnnamed,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct C2RustUnnamed {
-    pub asb: f64,
-    pub adx: f64,
-    pub ady: f64,
-    pub bchar: card8,
-    pub achar: card8,
-}
-pub type card8 = u8;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct C2RustUnnamed_0 {
-    pub llx: f64,
-    pub lly: f64,
-    pub urx: f64,
-    pub ury: f64,
-}
 use super::dpx_cff::cff_charsets;
+pub type card8 = u8;
 pub type card16 = u16;
 pub type s_SID = u16;
 
@@ -315,32 +290,8 @@ use super::dpx_cmap::CMap;
 /* Upper bounds of valid input code */
 
 use super::dpx_agl::agl_name;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct t1_ginfo {
-    pub use_seac: i32,
-    pub wx: f64,
-    pub wy: f64,
-    pub bbox: C2RustUnnamed_7,
-    pub seac: C2RustUnnamed_6,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct C2RustUnnamed_6 {
-    pub asb: f64,
-    pub adx: f64,
-    pub ady: f64,
-    pub bchar: card8,
-    pub achar: card8,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct C2RustUnnamed_7 {
-    pub llx: f64,
-    pub lly: f64,
-    pub urx: f64,
-    pub ury: f64,
-}
+use super::dpx_t1_char::t1_ginfo;
+
 /*
  * CID-Keyed Font support:
  *
@@ -2237,24 +2188,7 @@ unsafe extern "C" fn get_font_attr(mut font: *mut CIDFont, mut cffont: *mut cff_
         b"lambda\x00" as *const u8 as *const i8,
         0 as *const i8,
     ];
-    let mut gm: t1_ginfo = t1_ginfo {
-        use_seac: 0,
-        wx: 0.,
-        wy: 0.,
-        bbox: C2RustUnnamed_7 {
-            llx: 0.,
-            lly: 0.,
-            urx: 0.,
-            ury: 0.,
-        },
-        seac: C2RustUnnamed_6 {
-            asb: 0.,
-            adx: 0.,
-            ady: 0.,
-            bchar: 0,
-            achar: 0,
-        },
-    };
+    let mut gm = t1_ginfo::new();
     defaultwidth = 500.0f64;
     nominalwidth = 0.0f64;
     /*
@@ -2837,24 +2771,7 @@ pub unsafe extern "C" fn CIDFont_type0_t1dofont(mut font: *mut CIDFont) {
         0.0f64,
     );
     let mut cstring: *mut cff_index = 0 as *mut cff_index;
-    let mut gm: t1_ginfo = t1_ginfo {
-        use_seac: 0,
-        wx: 0.,
-        wy: 0.,
-        bbox: C2RustUnnamed_7 {
-            llx: 0.,
-            lly: 0.,
-            urx: 0.,
-            ury: 0.,
-        },
-        seac: C2RustUnnamed_6 {
-            asb: 0.,
-            adx: 0.,
-            ady: 0.,
-            bchar: 0,
-            achar: 0,
-        },
-    };
+    let mut gm = t1_ginfo::new();
     let mut max: i32 = 0i32;
     let mut widths: *mut f64 = 0 as *mut f64;
     let mut w_stat: [i32; 1001] = [0; 1001];

--- a/dpx/src/dpx_cidtype2.rs
+++ b/dpx/src/dpx_cidtype2.rs
@@ -182,26 +182,10 @@ use super::dpx_cid::{cid_opt, CIDFont, CIDSysInfo};
 
 use super::dpx_cmap::CMap;
 use super::dpx_tt_cmap::tt_cmap;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct C2RustUnnamed {
-    pub minBytesIn: size_t,
-    pub maxBytesIn: size_t,
-    pub minBytesOut: size_t,
-    pub maxBytesOut: size_t,
-}
+
 /* 2 for CID, variable for Code..  */
 /* CID (as 16-bit BE), Code ...    */
 /* Next Subtbl for LOOKUP_CONTINUE */
-
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct C2RustUnnamed_0 {
-    pub num: u32,
-    pub max: u32,
-    pub ranges: *mut rangeDef,
-}
-use super::dpx_cmap::rangeDef;
 
 use super::dpx_sfnt::sfnt;
 

--- a/dpx/src/dpx_cmap_read.rs
+++ b/dpx/src/dpx_cmap_read.rs
@@ -90,23 +90,8 @@ use super::dpx_cid::CIDSysInfo;
 /* DEBUG */
 /* Codespacerange */
 
-use super::dpx_cmap::rangeDef;
 use super::dpx_cmap::CMap;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct C2RustUnnamed {
-    pub minBytesIn: size_t,
-    pub maxBytesIn: size_t,
-    pub minBytesOut: size_t,
-    pub maxBytesOut: size_t,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct C2RustUnnamed_0 {
-    pub num: u32,
-    pub max: u32,
-    pub ranges: *mut rangeDef,
-}
+
 pub type CID = u16;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/dpx/src/dpx_cmap_write.rs
+++ b/dpx/src/dpx_cmap_write.rs
@@ -81,21 +81,7 @@ use super::dpx_cid::CIDSysInfo;
 use super::dpx_cmap::mapDef;
 use super::dpx_cmap::rangeDef;
 use super::dpx_cmap::CMap;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct C2RustUnnamed {
-    pub minBytesIn: size_t,
-    pub maxBytesIn: size_t,
-    pub minBytesOut: size_t,
-    pub maxBytesOut: size_t,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct C2RustUnnamed_0 {
-    pub num: u32,
-    pub max: u32,
-    pub ranges: *mut rangeDef,
-}
+
 /*
  * References:
  *

--- a/dpx/src/dpx_cs_type2.rs
+++ b/dpx/src/dpx_cs_type2.rs
@@ -50,6 +50,30 @@ pub struct cs_ginfo {
     pub bbox: C2RustUnnamed_0,
     pub seac: C2RustUnnamed,
 }
+
+impl cs_ginfo {
+    pub fn new() -> Self {
+        Self {
+            flags: 0,
+            wx: 0.,
+            wy: 0.,
+            bbox: C2RustUnnamed_0 {
+                llx: 0.,
+                lly: 0.,
+                urx: 0.,
+                ury: 0.,
+            },
+            seac: C2RustUnnamed {
+                asb: 0.,
+                adx: 0.,
+                ady: 0.,
+                bchar: 0,
+                achar: 0,
+            },
+        }
+    }
+}
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed {

--- a/dpx/src/dpx_dpxfile.rs
+++ b/dpx/src/dpx_dpxfile.rs
@@ -382,10 +382,10 @@ pub unsafe extern "C" fn dpx_delete_temp_file(mut tmp: *mut i8, mut force: i32) 
  */
 #[no_mangle]
 pub unsafe extern "C" fn dpx_file_apply_filter(
-    mut cmdtmpl: *const i8,
-    mut input: *const i8,
-    mut output: *const i8,
-    mut version: u8,
+    mut _cmdtmpl: *const i8,
+    mut _input: *const i8,
+    mut _output: *const i8,
+    mut _version: u8,
 ) -> i32 {
     /* Tectonic: defused */
     -1i32

--- a/dpx/src/dpx_dvi.rs
+++ b/dpx/src/dpx_dvi.rs
@@ -341,32 +341,8 @@ pub struct dvi_lr {
     pub font: i32,
     pub buf_index: u32,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct C2RustUnnamed_3 {
-    pub llx: f64,
-    pub lly: f64,
-    pub urx: f64,
-    pub ury: f64,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct t1_ginfo {
-    pub use_seac: i32,
-    pub wx: f64,
-    pub wy: f64,
-    pub bbox: C2RustUnnamed_3,
-    pub seac: C2RustUnnamed_4,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct C2RustUnnamed_4 {
-    pub asb: f64,
-    pub adx: f64,
-    pub ady: f64,
-    pub bchar: card8,
-    pub achar: card8,
-}
+
+use super::dpx_t1_char::t1_ginfo;
 
 use super::dpx_sfnt::sfnt;
 use super::dpx_tt_table::{tt_head_table, tt_hhea_table, tt_maxp_table};
@@ -2327,24 +2303,7 @@ unsafe extern "C" fn do_glyphs(mut do_actual_text: i32) {
             let mut descent: f64 = (*font).descent as f64;
             if !(*font).cffont.is_null() {
                 let mut cstrings: *mut cff_index = (*(*font).cffont).cstrings;
-                let mut gm: t1_ginfo = t1_ginfo {
-                    use_seac: 0,
-                    wx: 0.,
-                    wy: 0.,
-                    bbox: C2RustUnnamed_3 {
-                        llx: 0.,
-                        lly: 0.,
-                        urx: 0.,
-                        ury: 0.,
-                    },
-                    seac: C2RustUnnamed_4 {
-                        asb: 0.,
-                        adx: 0.,
-                        ady: 0.,
-                        bchar: 0,
-                        achar: 0,
-                    },
-                };
+                let mut gm = t1_ginfo::new();
                 /* If .notdef is not the 1st glyph in CharStrings, glyph_id given by
                 FreeType should be increased by 1 */
                 if (*(*font).cffont).is_notdef_notzero != 0 {

--- a/dpx/src/dpx_dvi.rs
+++ b/dpx/src/dpx_dvi.rs
@@ -2306,7 +2306,7 @@ unsafe extern "C" fn do_glyphs(mut do_actual_text: i32) {
     if (*font).rgba_color != 0xffffffffu32 {
         let mut color: pdf_color = pdf_color {
             num_components: 0,
-            spot_color_name: 0 as *mut i8,
+            spot_color_name: None,
             values: [0.; 4],
         };
         pdf_color_rgbcolor(

--- a/dpx/src/dpx_epdf.rs
+++ b/dpx/src/dpx_epdf.rs
@@ -1076,10 +1076,10 @@ pub unsafe extern "C" fn pdf_copy_clip(
         } else {
             let mut j: u32 = 0;
             let mut T = pdf_tmatrix::new();
-            let mut p0: pdf_coord = pdf_coord::new();
-            let mut p1: pdf_coord = pdf_coord::new();
-            let mut p2: pdf_coord = pdf_coord::new();
-            let mut p3: pdf_coord = pdf_coord::new();
+            let mut p0 = pdf_coord::new();
+            let mut p1 = pdf_coord::new();
+            let mut p2 = pdf_coord::new();
+            let mut p3 = pdf_coord::new();
             token = parse_ident(&mut clip_path, end_path);
             j = 0_u32;
             while (j as u64)

--- a/dpx/src/dpx_epdf.rs
+++ b/dpx/src/dpx_epdf.rs
@@ -89,7 +89,7 @@ pub type __off64_t = i64;
 pub type size_t = u64;
 pub type rust_input_handle_t = *mut libc::c_void;
 
-use super::dpx_pdfdev::{pdf_coord, pdf_rect, pdf_tmatrix};
+use super::dpx_pdfdev::{pdf_coord, pdf_tmatrix};
 
 use crate::dpx_pdfximage::{load_options, pdf_ximage, xform_info};
 pub const OP_CURVETO2: C2RustUnnamed_0 = 15;

--- a/dpx/src/dpx_mpost.rs
+++ b/dpx/src/dpx_mpost.rs
@@ -3259,7 +3259,7 @@ unsafe extern "C" fn do_operator(mut token: *const i8, mut x_user: f64, mut y_us
     let mut cp = pdf_coord::new();
     let mut color: pdf_color = pdf_color {
         num_components: 0,
-        spot_color_name: 0 as *mut i8,
+        spot_color_name: None,
         values: [0.; 4],
     };
     opcode = get_opcode(token);

--- a/dpx/src/dpx_mpost.rs
+++ b/dpx/src/dpx_mpost.rs
@@ -3081,7 +3081,7 @@ unsafe extern "C" fn do_currentfont() -> i32 {
 }
 unsafe extern "C" fn do_show() -> i32 {
     let mut font: *mut mp_font = 0 as *mut mp_font;
-    let mut cp: pdf_coord = pdf_coord::new();
+    let mut cp = pdf_coord::new();
     let mut text_str: *mut pdf_obj = 0 as *mut pdf_obj;
     let mut length: i32 = 0;
     let mut strptr: *mut u8 = 0 as *mut u8;
@@ -3256,7 +3256,7 @@ unsafe extern "C" fn do_operator(mut token: *const i8, mut x_user: f64, mut y_us
     let mut values: [f64; 12] = [0.; 12];
     let mut tmp: *mut pdf_obj = 0 as *mut pdf_obj;
     let mut matrix = pdf_tmatrix::new();
-    let mut cp: pdf_coord = pdf_coord::new();
+    let mut cp = pdf_coord::new();
     let mut color: pdf_color = pdf_color {
         num_components: 0,
         spot_color_name: 0 as *mut i8,

--- a/dpx/src/dpx_otl_conf.rs
+++ b/dpx/src/dpx_otl_conf.rs
@@ -619,10 +619,10 @@ unsafe extern "C" fn otl_read_conf(mut conf_name: *const i8) -> *mut pdf_obj {
 static mut otl_confs: *mut pdf_obj = 0 as *const pdf_obj as *mut pdf_obj;
 #[no_mangle]
 pub unsafe extern "C" fn otl_find_conf(mut conf_name: *const i8) -> *mut pdf_obj {
-    let mut rule: *mut pdf_obj = 0 as *mut pdf_obj;
-    let mut script: *mut pdf_obj = 0 as *mut pdf_obj;
-    let mut language: *mut pdf_obj = 0 as *mut pdf_obj;
-    let mut options: *mut pdf_obj = 0 as *mut pdf_obj;
+    let mut _rule: *mut pdf_obj = 0 as *mut pdf_obj;
+    let mut _script: *mut pdf_obj = 0 as *mut pdf_obj;
+    let mut _language: *mut pdf_obj = 0 as *mut pdf_obj;
+    let mut _options: *mut pdf_obj = 0 as *mut pdf_obj;
     0 as *mut pdf_obj
 }
 #[no_mangle]

--- a/dpx/src/dpx_pdfdev.rs
+++ b/dpx/src/dpx_pdfdev.rs
@@ -151,7 +151,7 @@ impl pdf_rect {
         }
     }
 }
-#[derive(Copy, Clone, Default, PartialEq)]
+#[derive(Copy, Clone, Default)]
 #[repr(C)]
 pub struct pdf_coord {
     pub x: f64,
@@ -162,6 +162,12 @@ impl pdf_coord {
         Self { x: 0., y: 0. }
     }
 }
+impl PartialEq for pdf_coord {
+    fn eq(&self, other: &Self) -> bool {
+        (self.x - other.x).abs() < 1e-7 && (self.y - other.y).abs() < 1e-7
+    }
+}
+
 #[derive(Copy, Clone, Default)]
 #[repr(C)]
 pub struct transform_info {
@@ -1959,10 +1965,10 @@ pub unsafe extern "C" fn pdf_dev_set_rect(
 ) {
     let mut dev_x: f64 = 0.; /* currentmatrix */
     let mut dev_y: f64 = 0.; /* 0 for B&W */
-    let mut p0: pdf_coord = pdf_coord::new();
-    let mut p1: pdf_coord = pdf_coord::new();
-    let mut p2: pdf_coord = pdf_coord::new();
-    let mut p3: pdf_coord = pdf_coord::new();
+    let mut p0 = pdf_coord::new();
+    let mut p1 = pdf_coord::new();
+    let mut p2 = pdf_coord::new();
+    let mut p3 = pdf_coord::new();
     let mut min_x: f64 = 0.;
     let mut min_y: f64 = 0.;
     let mut max_x: f64 = 0.;

--- a/dpx/src/dpx_pdfdev.rs
+++ b/dpx/src/dpx_pdfdev.rs
@@ -172,11 +172,6 @@ impl pdf_coord {
         Self { x: 0., y: 0. }
     }
 }
-impl PartialEq for pdf_coord {
-    fn eq(&self, other: &Self) -> bool {
-        (self.x - other.x).abs() < 1e-7 && (self.y - other.y).abs() < 1e-7
-    }
-}
 
 #[derive(Copy, Clone, Default)]
 #[repr(C)]

--- a/dpx/src/dpx_pdfdev.rs
+++ b/dpx/src/dpx_pdfdev.rs
@@ -227,7 +227,7 @@ pub type card8 = u8;
  */
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_0 {
+pub struct DevUnit {
     pub dvi2pts: f64,
     pub min_bp_val: i32,
     pub precision: i32,
@@ -235,7 +235,7 @@ pub struct C2RustUnnamed_0 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_1 {
+pub struct TextState {
     pub font_id: i32,
     pub offset: spt_t,
     pub ref_x: spt_t,
@@ -257,7 +257,7 @@ pub struct C2RustUnnamed_2 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_3 {
+pub struct DevParam {
     pub autorotate: i32,
     pub colormode: i32,
 }
@@ -285,8 +285,8 @@ pub unsafe extern "C" fn pdf_dev_set_verbose(mut level: i32) {
 pub unsafe extern "C" fn pdf_dev_scale() -> f64 {
     1.0f64
 }
-static mut dev_unit: C2RustUnnamed_0 = {
-    let mut init = C2RustUnnamed_0 {
+static mut dev_unit: DevUnit = {
+    let mut init = DevUnit {
         dvi2pts: 0.0f64,
         min_bp_val: 658i32,
         precision: 2i32,
@@ -522,8 +522,8 @@ pub unsafe extern "C" fn pdf_sprint_number(mut buf: *mut i8, mut value: f64) -> 
     *buf.offset(len as isize) = '\u{0}' as i32 as i8;
     len
 }
-static mut dev_param: C2RustUnnamed_3 = {
-    let mut init = C2RustUnnamed_3 {
+static mut dev_param: DevParam = {
+    let mut init = DevParam {
         autorotate: 1i32,
         colormode: 1i32,
     };
@@ -531,8 +531,8 @@ static mut dev_param: C2RustUnnamed_3 = {
 };
 static mut motion_state: i32 = 1i32;
 static mut format_buffer: [i8; 4096] = [0; 4096];
-static mut text_state: C2RustUnnamed_1 = {
-    let mut init = C2RustUnnamed_1 {
+static mut text_state: TextState = {
+    let mut init = TextState {
         font_id: -1i32,
         offset: 0i32,
         ref_x: 0i32,

--- a/dpx/src/dpx_pdfdev.rs
+++ b/dpx/src/dpx_pdfdev.rs
@@ -132,6 +132,16 @@ impl pdf_tmatrix {
             f: 0.,
         }
     }
+    pub const fn identity() -> Self {
+        Self {
+            a: 1.,
+            b: 0.,
+            c: 0.,
+            d: 1.,
+            e: 0.,
+            f: 0.,
+        }
+    }
 }
 #[derive(Copy, Clone, Default)]
 #[repr(C)]

--- a/dpx/src/dpx_pdfdoc.rs
+++ b/dpx/src/dpx_pdfdoc.rs
@@ -3034,8 +3034,8 @@ unsafe extern "C" fn pdf_doc_finish_page(mut p: *mut pdf_doc) {
 static mut bgcolor: pdf_color = {
     let mut init = pdf_color {
         num_components: 1i32,
-        spot_color_name: 0 as *const i8 as *mut i8,
-        values: [1.0f64, 0., 0., 0.],
+        spot_color_name: None,
+        values: [1., 0., 0., 0.],
     };
     init
 };

--- a/dpx/src/dpx_pdfdraw.rs
+++ b/dpx/src/dpx_pdfdraw.rs
@@ -37,6 +37,16 @@ use super::dpx_pdfcolor::{
 };
 use super::dpx_pdfdev::{pdf_sprint_coord, pdf_sprint_matrix, pdf_sprint_rect};
 
+use lazy_static::lazy_static;
+use std::sync::Mutex;
+
+lazy_static! { // TODO move to context structure
+    static ref gs_stack: Mutex<Vec<pdf_gstate>> = Mutex::new({
+        let mut v = vec![];
+        v
+    });
+}
+
 extern "C" {
     #[no_mangle]
     fn graphics_mode();
@@ -809,16 +819,6 @@ impl<T> Top<T> for Vec<T> {
     }
 }
 
-use lazy_static::lazy_static;
-use std::sync::Mutex;
-
-lazy_static! {
-    static ref gs_stack: Mutex<Vec<pdf_gstate>> = Mutex::new({
-        let mut v = vec![];
-        v
-    });
-}
-
 impl pdf_gstate {
     pub fn init() -> Self {
         Self {
@@ -839,14 +839,7 @@ impl pdf_gstate {
         }
     }
 }
-/*unsafe extern "C" fn clear_a_gstate(mut gs: *mut pdf_gstate) {
-    //clear_a_path(&mut (*gs).path);
-    memset(
-        gs as *mut libc::c_void,
-        0i32,
-        ::std::mem::size_of::<pdf_gstate>() as u64,
-    );
-}*/
+
 unsafe extern "C" fn copy_a_gstate(gs1: &mut pdf_gstate, gs2: &pdf_gstate) {
     let mut i: i32 = 0;
     gs1.cp = gs2.cp;

--- a/dpx/src/dpx_pdfdraw.rs
+++ b/dpx/src/dpx_pdfdraw.rs
@@ -29,15 +29,14 @@
     unused_mut
 )]
 
-use crate::mfree;
 use crate::warn;
 
 use super::dpx_pdfcolor::{
-    pdf_color_compare, pdf_color_copycolor, pdf_color_graycolor, pdf_color_is_valid,
+    pdf_color_compare, pdf_color_copycolor, pdf_color_graycolor_new, pdf_color_is_valid,
     pdf_color_to_string, pdf_color_type,
 };
 use super::dpx_pdfdev::{pdf_sprint_coord, pdf_sprint_matrix, pdf_sprint_rect};
-use libc::free;
+
 extern "C" {
     #[no_mangle]
     fn graphics_mode();
@@ -51,10 +50,6 @@ extern "C" {
     fn memset(_: *mut libc::c_void, _: i32, _: u64) -> *mut libc::c_void;
     #[no_mangle]
     fn sprintf(_: *mut i8, _: *const i8, _: ...) -> i32;
-    #[no_mangle]
-    fn new(size: u32) -> *mut libc::c_void;
-    #[no_mangle]
-    fn renew(p: *mut libc::c_void, size: u32) -> *mut libc::c_void;
     #[no_mangle]
     fn pdf_doc_add_page_content(buffer: *const i8, length: u32);
 }
@@ -71,7 +66,7 @@ pub struct pdf_gstate {
     pub matrix: pdf_tmatrix,
     pub strokecolor: pdf_color,
     pub fillcolor: pdf_color,
-    pub linedash: C2RustUnnamed,
+    pub linedash: LineDash,
     pub linewidth: f64,
     pub linecap: i32,
     pub linejoin: i32,
@@ -83,25 +78,22 @@ pub struct pdf_gstate {
 }
 #[derive(Clone)]
 pub struct pdf_path {
-    pub path: Vec<pa_elem>
-    /* cm,  - */
-    /* colorspace here */
-    /* d,  D  */
-    /* w,  LW */
-    /* J,  LC */
-    /* j,  LJ */
-    /* M,  ML */
-    /* i,  FL, 0 to 100 (0 for use device-default) */
-    /* internal */
-    /* bookkeeping the origin of the last transform applied */
-    /* _PDF_DRAW_H_ */
+    pub path: Vec<pa_elem>, /* cm,  - */
+                            /* colorspace here */
+                            /* d,  D  */
+                            /* w,  LW */
+                            /* J,  LC */
+                            /* j,  LJ */
+                            /* M,  ML */
+                            /* i,  FL, 0 to 100 (0 for use device-default) */
+                            /* internal */
+                            /* bookkeeping the origin of the last transform applied */
+                            /* _PDF_DRAW_H_ */
 }
 
 impl pdf_path {
     pub fn new() -> Self {
-        Self {
-            path: vec![]
-        }
+        Self { path: vec![] }
     }
     pub fn len(&self) -> usize {
         self.path.len()
@@ -114,33 +106,14 @@ pub struct pa_elem {
     pub typ: PeType,
     pub p: [pdf_coord; 3],
 }
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 #[repr(C)]
-pub struct C2RustUnnamed {
+pub struct LineDash {
     pub num_dash: i32,
     pub pattern: [f64; 16],
     pub offset: f64,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct m_stack {
-    pub size: i32,
-    pub top: *mut m_stack_elem,
-    pub bottom: *mut m_stack_elem,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct m_stack_elem {
-    pub data: *mut libc::c_void,
-    pub prev: *mut m_stack_elem,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct C2RustUnnamed_0 {
-    pub opchr: i8,
-    pub n_pts: i32,
-    pub strkey: *const i8,
-}
+
 unsafe extern "C" fn inversematrix(mut W: &mut pdf_tmatrix, mut M: &pdf_tmatrix) -> i32 {
     let mut det: f64 = 0.;
     det = M.a * M.d - M.b * M.c;
@@ -211,7 +184,7 @@ pub unsafe extern "C" fn pdf_invertmatrix(M: &mut pdf_tmatrix) {
     *M = W;
 }
 
-#[derive(Clone,Copy,Debug,PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PeType {
     MOVETO = 0,
     LINETO = 1,
@@ -256,49 +229,10 @@ impl PeType {
 }
 
 static mut fmt_buf: [i8; 1024] = [0; 1024];
-/*fn init_a_path(p: &mut pdf_path) {
-    p.num_paths = 0_u32;
-    p.max_paths = 0_u32;
-    p.path = 0 as *mut pa_elem;
-}
-extern "C" fn pdf_path__clearpath(mut p: &mut pdf_path) {
-    p.num_paths = 0_u32;
-}
-unsafe extern "C" fn pdf_path__growpath(p: &mut pdf_path, mut max_pe: u32) -> i32 {
-    if max_pe < p.max_paths {
-        return 0i32;
-    }
-    p.max_paths = if p.max_paths + 8 > max_pe {
-        p.max_paths + 8_u32
-    } else {
-        max_pe
-    };
-    p.path = renew(
-        p.path as *mut libc::c_void,
-        (p.max_paths as u64).wrapping_mul(::std::mem::size_of::<pa_elem>() as u64) as u32,
-    ) as *mut pa_elem;
-    0i32
-}*/
+
 fn clear_a_path(p: &mut pdf_path) {
     p.path = vec![];
-    /*p.path = mfree(p.path as *mut libc::c_void) as *mut pa_elem;
-    p.num_paths = 0_u32;
-    p.max_paths = 0_u32;*/
 }
-/*unsafe extern "C" fn pdf_path__copypath(p1: &mut pdf_path, p0: &pdf_path) -> i32 {
-    let mut i: u32 = 0;
-    pdf_path__growpath(p1, p0.num_paths);
-    i = 0_u32;
-    while i < p0.num_paths {
-        let pe1 = &mut *(*p1).path.offset(i as isize);
-        let pe0 = &mut *p0.path.offset(i as isize);
-        /* FIXME */
-        *pe1 = *pe0;
-        i = i + 1
-    }
-    p1.num_paths = p0.num_paths;
-    0i32
-}*/
 /* start new subpath */
 unsafe extern "C" fn pdf_path__moveto(
     pa: &mut pdf_path,
@@ -330,23 +264,26 @@ unsafe extern "C" fn pdf_path__moveto(
  * 'moveto' must be used to enforce starting new path.
  * This affects how 'closepath' is treated.
  */
-unsafe extern "C" fn pdf_path__next_pe<'a>(pa: &'a mut pdf_path, cp: &pdf_coord) -> &'a mut pa_elem {
+unsafe extern "C" fn pdf_path__next_pe<'a>(
+    pa: &'a mut pdf_path,
+    cp: &pdf_coord,
+) -> &'a mut pa_elem {
     if pa.path.is_empty() {
         let mut pe = pa_elem::default();
         pe.p[0] = *cp;
         pa.path.push(pe);
         pa.path.push(pa_elem::default());
         let len = pa.len();
-        return &mut pa.path[len-1];
+        return &mut pa.path[len - 1];
     }
     let len = pa.len();
-    let mut pe = &mut pa.path[len-1];
+    let mut pe = &mut pa.path[len - 1];
     match pe.typ {
         PeType::MOVETO => {
             pe.p[0] = *cp;
         }
         PeType::LINETO => {
-            if  &pe.p[0] != cp {
+            if &pe.p[0] != cp {
                 let mut pe = pa_elem::default();
                 pe.p[0] = *cp;
                 pa.path.push(pe);
@@ -375,7 +312,7 @@ unsafe extern "C" fn pdf_path__next_pe<'a>(pa: &'a mut pdf_path, cp: &pdf_coord)
     }
     pa.path.push(pa_elem::default());
     let len = pa.len();
-    return &mut pa.path[len-1];
+    return &mut pa.path[len - 1];
 }
 unsafe extern "C" fn pdf_path__transform(pa: &mut pdf_path, M: &pdf_tmatrix) -> i32 {
     let mut n = 0;
@@ -659,17 +596,8 @@ unsafe extern "C" fn pdf_dev__rectshape(
     let mut p = pdf_coord::new();
     let mut wd: f64 = 0.;
     let mut ht: f64 = 0.;
-    assert!(
-        (opchr as i32 == 'f' as i32
-            || opchr as i32 == 'F' as i32
-            || opchr as i32 == 's' as i32
-            || opchr as i32 == 'S' as i32
-            || opchr as i32 == 'b' as i32
-            || opchr as i32 == 'B' as i32
-            || opchr as i32 == 'W' as i32
-            || opchr as i32 == ' ' as i32)
-    );
-    isclip = if opchr as i32 == 'W' as i32 || opchr as i32 == ' ' as i32 {
+    assert!([b'f', b'F', b's', b'S', b'b', b'B', b'W', b' '].contains(&(opchr as u8)));
+    isclip = if opchr == b'W' as i8 || opchr == b' ' as i8 {
         1i32
     } else {
         0i32
@@ -717,38 +645,38 @@ unsafe extern "C" fn pdf_dev__rectshape(
     ht = r.ury - r.lly;
     let fresh18 = len;
     len = len + 1;
-    *buf.offset(fresh18 as isize) = ' ' as i32 as i8;
+    *buf.offset(fresh18 as isize) = b' ' as i8;
     len += pdf_sprint_coord(buf.offset(len as isize), &mut p);
     let fresh19 = len;
     len = len + 1;
-    *buf.offset(fresh19 as isize) = ' ' as i32 as i8;
+    *buf.offset(fresh19 as isize) = b' ' as i8;
     len += pdf_sprint_length(buf.offset(len as isize), wd);
     let fresh20 = len;
     len = len + 1;
-    *buf.offset(fresh20 as isize) = ' ' as i32 as i8;
+    *buf.offset(fresh20 as isize) = b' ' as i8;
     len += pdf_sprint_length(buf.offset(len as isize), ht);
     let fresh21 = len;
     len = len + 1;
-    *buf.offset(fresh21 as isize) = ' ' as i32 as i8;
+    *buf.offset(fresh21 as isize) = b' ' as i8;
     let fresh22 = len;
     len = len + 1;
-    *buf.offset(fresh22 as isize) = 'r' as i32 as i8;
+    *buf.offset(fresh22 as isize) = b'r' as i8;
     let fresh23 = len;
     len = len + 1;
-    *buf.offset(fresh23 as isize) = 'e' as i32 as i8;
-    if opchr as i32 != ' ' as i32 {
+    *buf.offset(fresh23 as isize) = b'e' as i8;
+    if opchr != b' ' as i8 {
         let fresh24 = len;
         len = len + 1;
-        *buf.offset(fresh24 as isize) = ' ' as i32 as i8;
+        *buf.offset(fresh24 as isize) = b' ' as i8;
         let fresh25 = len;
         len = len + 1;
         *buf.offset(fresh25 as isize) = opchr;
         let fresh26 = len;
         len = len + 1;
-        *buf.offset(fresh26 as isize) = ' ' as i32 as i8;
+        *buf.offset(fresh26 as isize) = b' ' as i8;
         let fresh27 = len;
         len = len + 1;
-        *buf.offset(fresh27 as isize) = (if isclip != 0 { 'n' as i32 } else { 'Q' as i32 }) as i8
+        *buf.offset(fresh27 as isize) = (if isclip != 0 { b'n' } else { b'Q' }) as i8
     }
     pdf_doc_add_page_content(buf, len as u32);
     0i32
@@ -774,21 +702,11 @@ unsafe extern "C" fn pdf_dev__flushpath(
     let mut isrect: i32 = 0;
     let mut i: i32 = 0;
     let mut j: i32 = 0;
-    assert!((opchr as i32 == 'f' as i32
-                || opchr as i32 == 'F' as i32
-                || opchr as i32 == 's' as i32
-                || opchr as i32 == 'S' as i32
-                || opchr as i32 == 'b' as i32
-                || opchr as i32 == 'B' as i32
-                || opchr as i32 == 'W' as i32
-                || opchr as i32 == ' ' as i32)
-    );
-    isclip = if opchr as i32 == 'W' as i32 {
-        1i32
-    } else {
-        0i32
-    };
-    if /*pa.num_paths <= 0_u32 &&*/ path_added == 0i32 {
+    assert!([b'f', b'F', b's', b'S', b'b', b'B', b'W', b' '].contains(&(opchr as u8)));
+    isclip = if opchr == b'W' as i8 { 1i32 } else { 0i32 };
+    if
+    /*pa.num_paths <= 0_u32 &&*/
+    path_added == 0i32 {
         return 0i32;
     }
     path_added = 0i32;
@@ -818,12 +736,14 @@ unsafe extern "C" fn pdf_dev__flushpath(
         len = 0i32
     } else {
         for pe in pa.path.iter_mut() {
-            n_pts = if /* !pe.is_null() &&*/ pe.typ != PeType::TERMINATE {
+            n_pts = if
+            /* !pe.is_null() &&*/
+            pe.typ != PeType::TERMINATE {
                 pe.typ.n_pts() as i32
             } else {
                 0i32
             };
-            for (j, pt) in (0..n_pts).zip(pe.p.iter_mut()) {
+            for (_j, pt) in (0..n_pts).zip(pe.p.iter_mut()) {
                 let fresh32 = len;
                 len = len + 1;
                 *b.offset(fresh32 as isize) = ' ' as i32 as i8;
@@ -834,12 +754,13 @@ unsafe extern "C" fn pdf_dev__flushpath(
             *b.offset(fresh33 as isize) = ' ' as i32 as i8;
             let fresh34 = len;
             len = len + 1;
-            *b.offset(fresh34 as isize) =
-                if /* !pe.is_null() &&*/ pe.typ != PeType::TERMINATE {
-                    pe.typ.opchr()
-                } else {
-                    b' ' as i8
-                };
+            *b.offset(fresh34 as isize) = if
+            /* !pe.is_null() &&*/
+            pe.typ != PeType::TERMINATE {
+                pe.typ.opchr()
+            } else {
+                b' ' as i8
+            };
             if len + 128i32 > b_len {
                 pdf_doc_add_page_content(b, len as u32);
                 len = 0i32
@@ -872,233 +793,176 @@ unsafe extern "C" fn pdf_dev__flushpath(
     pdf_doc_add_page_content(b, len as u32);
     0i32
 }
-unsafe extern "C" fn m_stack_init(mut stack: *mut m_stack) {
-    assert!(!stack.is_null());
-    (*stack).size = 0i32;
-    (*stack).top = 0 as *mut m_stack_elem;
-    (*stack).bottom = 0 as *mut m_stack_elem;
+
+trait Top<T> {
+    fn top(&mut self) -> &mut T;
 }
-unsafe extern "C" fn m_stack_push(mut stack: *mut m_stack, mut data: *mut libc::c_void) {
-    let mut elem: *mut m_stack_elem = 0 as *mut m_stack_elem;
-    assert!(!stack.is_null());
-    elem = new((1_u64).wrapping_mul(::std::mem::size_of::<m_stack_elem>() as u64) as u32)
-        as *mut m_stack_elem;
-    (*elem).prev = (*stack).top;
-    (*elem).data = data;
-    (*stack).top = elem;
-    if (*stack).size == 0i32 {
-        (*stack).bottom = elem
+
+impl<T> Top<T> for Vec<T> {
+    fn top(&mut self) -> &mut T {
+        let last = self.len() - 1;
+        &mut self[last]
     }
-    (*stack).size += 1;
 }
-unsafe extern "C" fn m_stack_pop(mut stack: *mut m_stack) -> *mut libc::c_void {
-    let mut elem: *mut m_stack_elem = 0 as *mut m_stack_elem;
-    let mut data: *mut libc::c_void = 0 as *mut libc::c_void;
-    assert!(!stack.is_null());
-    if (*stack).size == 0i32 {
-        return 0 as *mut libc::c_void;
+
+use lazy_static::lazy_static;
+use std::sync::Mutex;
+
+lazy_static! {
+    static ref gs_stack: Mutex<Vec<pdf_gstate>> = Mutex::new({
+        let mut v = vec![];
+        v
+    });
+}
+
+impl pdf_gstate {
+    pub fn init() -> Self {
+        Self {
+            cp: pdf_coord::new(),
+            matrix: pdf_tmatrix::identity(),
+            strokecolor: pdf_color_graycolor_new(0.).unwrap(),
+            fillcolor: pdf_color_graycolor_new(0.).unwrap(),
+            linedash: LineDash::default(),
+            linecap: 0,
+            linejoin: 0,
+            linewidth: 1.,
+            miterlimit: 10.,
+            flatness: 1,
+            /* Internal variables */
+            flags: 0,
+            path: pdf_path::new(),
+            pt_fixee: pdf_coord::new(),
+        }
     }
-    data = (*(*stack).top).data;
-    elem = (*stack).top;
-    (*stack).top = (*elem).prev;
-    if (*stack).size == 1i32 {
-        (*stack).bottom = 0 as *mut m_stack_elem
-    }
-    free(elem as *mut libc::c_void);
-    (*stack).size -= 1;
-    data
 }
-unsafe extern "C" fn m_stack_top(mut stack: *mut m_stack) -> *mut libc::c_void {
-    let mut data: *mut libc::c_void = 0 as *mut libc::c_void;
-    assert!(!stack.is_null());
-    if (*stack).size == 0i32 {
-        return 0 as *mut libc::c_void;
-    }
-    data = (*(*stack).top).data;
-    data
-}
-static mut gs_stack: m_stack = m_stack {
-    size: 0,
-    top: 0 as *const m_stack_elem as *mut m_stack_elem,
-    bottom: 0 as *const m_stack_elem as *mut m_stack_elem,
-};
-unsafe extern "C" fn init_a_gstate(mut gs: *mut pdf_gstate) {
-    (*gs).cp.x = 0.0f64;
-    (*gs).cp.y = 0.0f64;
-    (*gs).matrix.a = 1.0f64;
-    (*gs).matrix.b = 0.0f64;
-    (*gs).matrix.c = 0.0f64;
-    (*gs).matrix.d = 1.0f64;
-    (*gs).matrix.e = 0.0f64;
-    (*gs).matrix.f = 0.0f64;
-    pdf_color_graycolor(&mut (*gs).strokecolor, 0.0f64);
-    pdf_color_graycolor(&mut (*gs).fillcolor, 0.0f64);
-    (*gs).linedash.num_dash = 0i32;
-    (*gs).linedash.offset = 0i32 as f64;
-    (*gs).linecap = 0i32;
-    (*gs).linejoin = 0i32;
-    (*gs).linewidth = 1.0f64;
-    (*gs).miterlimit = 10.0f64;
-    (*gs).flatness = 1i32;
-    /* Internal variables */
-    (*gs).flags = 0i32;
-    (*gs).path = pdf_path::new();
-    (*gs).pt_fixee.x = 0i32 as f64;
-    (*gs).pt_fixee.y = 0i32 as f64;
-}
-unsafe extern "C" fn clear_a_gstate(mut gs: *mut pdf_gstate) {
-    clear_a_path(&mut (*gs).path);
+/*unsafe extern "C" fn clear_a_gstate(mut gs: *mut pdf_gstate) {
+    //clear_a_path(&mut (*gs).path);
     memset(
         gs as *mut libc::c_void,
         0i32,
         ::std::mem::size_of::<pdf_gstate>() as u64,
     );
-}
-unsafe extern "C" fn copy_a_gstate(mut gs1: *mut pdf_gstate, mut gs2: *mut pdf_gstate) {
+}*/
+unsafe extern "C" fn copy_a_gstate(gs1: &mut pdf_gstate, gs2: &pdf_gstate) {
     let mut i: i32 = 0;
-    assert!(!gs1.is_null() && !gs2.is_null());
-    (*gs1).cp = (*gs2).cp;
-    (*gs1).matrix = (*gs2).matrix;
+    gs1.cp = gs2.cp;
+    gs1.matrix = gs2.matrix;
     /* TODO:
      * Path should be linked list and gsave only
      * record starting point within path rather than
      * copying whole path.
      */
-    (*gs1).path = (*gs2).path.clone(); /* Initial state */
-    (*gs1).linedash.num_dash = (*gs2).linedash.num_dash;
+    gs1.path = gs2.path.clone(); /* Initial state */
+    gs1.linedash.num_dash = gs2.linedash.num_dash;
     i = 0i32;
-    while i < (*gs2).linedash.num_dash {
-        (*gs1).linedash.pattern[i as usize] = (*gs2).linedash.pattern[i as usize];
+    while i < gs2.linedash.num_dash {
+        gs1.linedash.pattern[i as usize] = gs2.linedash.pattern[i as usize];
         i += 1
     }
-    (*gs1).linedash.offset = (*gs2).linedash.offset;
-    (*gs1).linecap = (*gs2).linecap;
-    (*gs1).linejoin = (*gs2).linejoin;
-    (*gs1).linewidth = (*gs2).linewidth;
-    (*gs1).miterlimit = (*gs2).miterlimit;
-    (*gs1).flatness = (*gs2).flatness;
-    pdf_color_copycolor(&mut (*gs1).fillcolor, &mut (*gs2).fillcolor);
-    pdf_color_copycolor(&mut (*gs1).strokecolor, &mut (*gs2).strokecolor);
-    (*gs1).pt_fixee.x = (*gs2).pt_fixee.x;
-    (*gs1).pt_fixee.y = (*gs2).pt_fixee.y;
+    gs1.linedash.offset = gs2.linedash.offset;
+    gs1.linecap = gs2.linecap;
+    gs1.linejoin = gs2.linejoin;
+    gs1.linewidth = gs2.linewidth;
+    gs1.miterlimit = gs2.miterlimit;
+    gs1.flatness = gs2.flatness;
+    pdf_color_copycolor(&mut gs1.fillcolor, &gs2.fillcolor);
+    pdf_color_copycolor(&mut gs1.strokecolor, &gs2.strokecolor);
+    gs1.pt_fixee.x = gs2.pt_fixee.x;
+    gs1.pt_fixee.y = gs2.pt_fixee.y;
 }
 #[no_mangle]
 pub unsafe extern "C" fn pdf_dev_init_gstates() {
-    let mut gs: *mut pdf_gstate = 0 as *mut pdf_gstate;
-    m_stack_init(&mut gs_stack);
-    gs = new((1_u64).wrapping_mul(::std::mem::size_of::<pdf_gstate>() as u64) as u32)
-        as *mut pdf_gstate;
-    init_a_gstate(gs);
-    m_stack_push(&mut gs_stack, gs as *mut libc::c_void);
+    let mut stack = gs_stack.lock().unwrap();
+    *stack = vec![];
+    let gs = pdf_gstate::init();
+    stack.push(gs);
 }
 #[no_mangle]
 pub unsafe extern "C" fn pdf_dev_clear_gstates() {
-    let mut gs: *mut pdf_gstate = 0 as *mut pdf_gstate;
-    if gs_stack.size > 1i32 {
+    let mut stack = gs_stack.lock().unwrap();
+
+    if stack.len() > 1 {
         /* at least 1 elem. */
         warn!("GS stack depth is not zero at the end of the document."); /* op: q */
     }
-    loop {
-        gs = m_stack_pop(&mut gs_stack) as *mut pdf_gstate;
-        if gs.is_null() {
-            break;
-        }
-        clear_a_gstate(gs);
-        free(gs as *mut libc::c_void);
-    }
+    *stack = vec![];
 }
 #[no_mangle]
 pub unsafe extern "C" fn pdf_dev_gsave() -> i32 {
-    let mut gs0: *mut pdf_gstate = 0 as *mut pdf_gstate;
-    let mut gs1: *mut pdf_gstate = 0 as *mut pdf_gstate;
-    gs0 = m_stack_top(&mut gs_stack) as *mut pdf_gstate;
-    gs1 = new((1_u64).wrapping_mul(::std::mem::size_of::<pdf_gstate>() as u64) as u32)
-        as *mut pdf_gstate;
-    init_a_gstate(gs1);
-    copy_a_gstate(gs1, gs0);
-    m_stack_push(&mut gs_stack, gs1 as *mut libc::c_void);
+    let mut stack = gs_stack.lock().unwrap();
+    let gs0 = stack.top();
+
+    let mut gs1 = pdf_gstate::init();
+    copy_a_gstate(&mut gs1, gs0);
+    stack.push(gs1);
+
     pdf_doc_add_page_content(b" q\x00" as *const u8 as *const i8, 2_u32);
     0i32
 }
 #[no_mangle]
 pub unsafe extern "C" fn pdf_dev_grestore() -> i32 {
-    let mut gs: *mut pdf_gstate = 0 as *mut pdf_gstate;
-    if gs_stack.size <= 1i32 {
+    let mut stack = gs_stack.lock().unwrap();
+    if stack.len() <= 1 {
         /* Initial state at bottom */
         warn!("Too many grestores."); /* op: Q */
         return -1i32;
     }
-    gs = m_stack_pop(&mut gs_stack) as *mut pdf_gstate;
-    clear_a_gstate(gs);
-    free(gs as *mut libc::c_void);
+    let _gs = stack.pop();
     pdf_doc_add_page_content(b" Q\x00" as *const u8 as *const i8, 2_u32);
     pdf_dev_reset_fonts(0i32);
     0i32
 }
 #[no_mangle]
 pub unsafe extern "C" fn pdf_dev_push_gstate() -> i32 {
-    let mut gss: *mut m_stack = &mut gs_stack;
-    let mut gs0: *mut pdf_gstate = 0 as *mut pdf_gstate;
-    gs0 = new((1_u64).wrapping_mul(::std::mem::size_of::<pdf_gstate>() as u64) as u32)
-        as *mut pdf_gstate;
-    init_a_gstate(gs0);
-    m_stack_push(gss, gs0 as *mut libc::c_void);
+    let mut stack = gs_stack.lock().unwrap();
+
+    let gs0 = pdf_gstate::init();
+    stack.push(gs0);
+
     0i32
 }
 #[no_mangle]
 pub unsafe extern "C" fn pdf_dev_pop_gstate() -> i32 {
-    let mut gss: *mut m_stack = &mut gs_stack;
-    let mut gs: *mut pdf_gstate = 0 as *mut pdf_gstate;
-    if (*gss).size <= 1i32 {
+    let mut gss = gs_stack.lock().unwrap();
+    if gss.len() <= 1 {
         /* Initial state at bottom */
         warn!("Too many grestores.");
         return -1i32;
     }
-    gs = m_stack_pop(gss) as *mut pdf_gstate;
-    clear_a_gstate(gs);
-    free(gs as *mut libc::c_void);
+    let _gs = gss.pop();
     0i32
 }
 #[no_mangle]
-pub unsafe extern "C" fn pdf_dev_current_depth() -> i32 {
-    return gs_stack.size - 1i32;
+pub extern "C" fn pdf_dev_current_depth() -> usize {
+    let stack = gs_stack.lock().unwrap();
+    stack.len() - 1
     /* 0 means initial state */
 }
 #[no_mangle]
-pub unsafe extern "C" fn pdf_dev_grestore_to(mut depth: i32) {
-    let mut gss: *mut m_stack = &mut gs_stack; /* op: Q */
-    let mut gs: *mut pdf_gstate = 0 as *mut pdf_gstate;
-    assert!(depth >= 0i32);
-    if (*gss).size > depth + 1i32 {
+pub unsafe extern "C" fn pdf_dev_grestore_to(mut depth: usize) {
+    let mut gss = gs_stack.lock().unwrap(); /* op: Q */
+    assert!(depth >= 0);
+    if gss.len() > depth + 1 {
         warn!("Closing pending transformations at end of page/XObject.");
     }
-    while (*gss).size > depth + 1i32 {
+    while gss.len() > depth + 1 {
         pdf_doc_add_page_content(b" Q\x00" as *const u8 as *const i8, 2_u32);
-        gs = m_stack_pop(gss) as *mut pdf_gstate;
-        clear_a_gstate(gs);
-        free(gs as *mut libc::c_void);
+        let _gs = gss.pop();
     }
     pdf_dev_reset_fonts(0i32);
 }
 #[no_mangle]
 pub unsafe extern "C" fn pdf_dev_currentpoint(p: &mut pdf_coord) -> i32 {
-    let mut gss: *mut m_stack = &mut gs_stack;
-    let mut gs: *mut pdf_gstate = m_stack_top(gss) as *mut pdf_gstate;
-    let mut cpt = &mut (*gs).cp;
-    *p = cpt.clone();
+    let mut gss = gs_stack.lock().unwrap();
+    let gs = gss.top();
+    *p = gs.cp.clone();
     0i32
 }
 #[no_mangle]
 pub unsafe extern "C" fn pdf_dev_currentmatrix(M: &mut pdf_tmatrix) -> i32 {
-    let mut gss: *mut m_stack = &mut gs_stack;
-    let mut gs: *mut pdf_gstate = m_stack_top(gss) as *mut pdf_gstate;
-    let CTM = &mut (*gs).matrix;
-    M.a = CTM.a;
-    M.b = CTM.b;
-    M.c = CTM.c;
-    M.d = CTM.d;
-    M.e = CTM.e;
-    M.f = CTM.f;
+    let mut gss = gs_stack.lock().unwrap();
+    let gs = gss.top();
+    *M = gs.matrix.clone();
     0i32
 }
 /*
@@ -1109,12 +973,13 @@ pub unsafe extern "C" fn pdf_dev_currentmatrix(M: &mut pdf_tmatrix) -> i32 {
  */
 #[no_mangle]
 pub unsafe extern "C" fn pdf_dev_set_color(color: &pdf_color, mut mask: i8, mut force: i32) {
+    let mut stack = gs_stack.lock().unwrap();
     let mut len: i32 = 0;
-    let mut gs: *mut pdf_gstate = m_stack_top(&mut gs_stack) as *mut pdf_gstate;
-    let mut current = if mask as i32 != 0 {
-        &mut (*gs).fillcolor
+    let mut gs = stack.top();
+    let current = if mask as i32 != 0 {
+        &mut gs.fillcolor
     } else {
-        &mut (*gs).strokecolor
+        &mut gs.strokecolor
     };
     assert!(pdf_color_is_valid(color));
     if !(pdf_dev_get_param(2i32) != 0 && (force != 0 || pdf_color_compare(color, current) != 0)) {
@@ -1154,11 +1019,11 @@ pub unsafe extern "C" fn pdf_dev_set_color(color: &pdf_color, mut mask: i8, mut 
 }
 #[no_mangle]
 pub unsafe extern "C" fn pdf_dev_concat(M: &pdf_tmatrix) -> i32 {
-    let mut gss: *mut m_stack = &mut gs_stack;
-    let mut gs: *mut pdf_gstate = m_stack_top(gss) as *mut pdf_gstate;
-    let mut cpa = &mut (*gs).path;
-    let cpt = &mut (*gs).cp;
-    let mut CTM = &mut (*gs).matrix;
+    let mut gss = gs_stack.lock().unwrap();
+    let gs = gss.top();
+    let cpa = &mut gs.path;
+    let cpt = &mut gs.cp;
+    let CTM = &mut gs.matrix;
     let mut W = pdf_tmatrix::new();
     let mut buf: *mut i8 = fmt_buf.as_mut_ptr();
     let mut len: i32 = 0i32;
@@ -1222,11 +1087,11 @@ pub unsafe extern "C" fn pdf_dev_concat(M: &pdf_tmatrix) -> i32 {
  */
 #[no_mangle]
 pub unsafe extern "C" fn pdf_dev_setmiterlimit(mut mlimit: f64) -> i32 {
-    let mut gss: *mut m_stack = &mut gs_stack; /* op: M */
-    let mut gs: *mut pdf_gstate = m_stack_top(gss) as *mut pdf_gstate; /* op: J */
+    let mut gss = gs_stack.lock().unwrap(); /* op: M */
+    let gs = gss.top(); /* op: J */
     let mut len: i32 = 0i32; /* op: j */
     let mut buf: *mut i8 = fmt_buf.as_mut_ptr(); /* op: w */
-    if (*gs).miterlimit != mlimit {
+    if gs.miterlimit != mlimit {
         let fresh49 = len; /* op: */
         len = len + 1; /* op: */
         *buf.offset(fresh49 as isize) = ' ' as i32 as i8; /* op: */
@@ -1238,43 +1103,43 @@ pub unsafe extern "C" fn pdf_dev_setmiterlimit(mut mlimit: f64) -> i32 {
         len = len + 1;
         *buf.offset(fresh51 as isize) = 'M' as i32 as i8;
         pdf_doc_add_page_content(buf, len as u32);
-        (*gs).miterlimit = mlimit
+        gs.miterlimit = mlimit
     }
     0i32
 }
 #[no_mangle]
 pub unsafe extern "C" fn pdf_dev_setlinecap(mut capstyle: i32) -> i32 {
-    let mut gss: *mut m_stack = &mut gs_stack;
-    let mut gs: *mut pdf_gstate = m_stack_top(gss) as *mut pdf_gstate;
+    let mut gss = gs_stack.lock().unwrap();
+    let gs = gss.top();
     let mut len: i32 = 0i32;
     let mut buf: *mut i8 = fmt_buf.as_mut_ptr();
-    if (*gs).linecap != capstyle {
+    if gs.linecap != capstyle {
         len = sprintf(buf, b" %d J\x00" as *const u8 as *const i8, capstyle);
         pdf_doc_add_page_content(buf, len as u32);
-        (*gs).linecap = capstyle
+        gs.linecap = capstyle
     }
     0i32
 }
 #[no_mangle]
 pub unsafe extern "C" fn pdf_dev_setlinejoin(mut joinstyle: i32) -> i32 {
-    let mut gss: *mut m_stack = &mut gs_stack;
-    let mut gs: *mut pdf_gstate = m_stack_top(gss) as *mut pdf_gstate;
+    let mut gss = gs_stack.lock().unwrap();
+    let gs = gss.top();
     let mut len: i32 = 0i32;
     let mut buf: *mut i8 = fmt_buf.as_mut_ptr();
-    if (*gs).linejoin != joinstyle {
+    if gs.linejoin != joinstyle {
         len = sprintf(buf, b" %d j\x00" as *const u8 as *const i8, joinstyle);
         pdf_doc_add_page_content(buf, len as u32);
-        (*gs).linejoin = joinstyle
+        gs.linejoin = joinstyle
     }
     0i32
 }
 #[no_mangle]
 pub unsafe extern "C" fn pdf_dev_setlinewidth(mut width: f64) -> i32 {
-    let mut gss: *mut m_stack = &mut gs_stack;
-    let mut gs: *mut pdf_gstate = m_stack_top(gss) as *mut pdf_gstate;
+    let mut gss = gs_stack.lock().unwrap();
+    let gs = gss.top();
     let mut len: i32 = 0i32;
     let mut buf: *mut i8 = fmt_buf.as_mut_ptr();
-    if (*gs).linewidth != width {
+    if gs.linewidth != width {
         let fresh52 = len;
         len = len + 1;
         *buf.offset(fresh52 as isize) = ' ' as i32 as i8;
@@ -1286,7 +1151,7 @@ pub unsafe extern "C" fn pdf_dev_setlinewidth(mut width: f64) -> i32 {
         len = len + 1;
         *buf.offset(fresh54 as isize) = 'w' as i32 as i8;
         pdf_doc_add_page_content(buf, len as u32);
-        (*gs).linewidth = width
+        gs.linewidth = width
     }
     0i32
 }
@@ -1296,20 +1161,20 @@ pub unsafe extern "C" fn pdf_dev_setdash(
     mut pattern: *mut f64,
     mut offset: f64,
 ) -> i32 {
-    let mut gss: *mut m_stack = &mut gs_stack;
-    let mut gs: *mut pdf_gstate = m_stack_top(gss) as *mut pdf_gstate;
+    let mut gss = gs_stack.lock().unwrap();
+    let gs = gss.top();
     let mut len: i32 = 0i32;
     let mut buf: *mut i8 = fmt_buf.as_mut_ptr();
     let mut i: i32 = 0;
-    (*gs).linedash.num_dash = count;
-    (*gs).linedash.offset = offset;
+    gs.linedash.num_dash = count;
+    gs.linedash.offset = offset;
     pdf_doc_add_page_content(b" [\x00" as *const u8 as *const i8, 2_u32);
     i = 0i32;
     while i < count {
         *buf.offset(0) = ' ' as i32 as i8;
         len = pdf_sprint_length(buf.offset(1), *pattern.offset(i as isize));
         pdf_doc_add_page_content(buf, (len + 1i32) as u32);
-        (*gs).linedash.pattern[i as usize] = *pattern.offset(i as isize);
+        gs.linedash.pattern[i as usize] = *pattern.offset(i as isize);
         i += 1
     }
     pdf_doc_add_page_content(b"] \x00" as *const u8 as *const i8, 2_u32);
@@ -1321,23 +1186,23 @@ pub unsafe extern "C" fn pdf_dev_setdash(
 /* ZSYUEDVEDEOF */
 #[no_mangle]
 pub unsafe extern "C" fn pdf_dev_clip() -> i32 {
-    let mut gss: *mut m_stack = &mut gs_stack;
-    let mut gs: *mut pdf_gstate = m_stack_top(gss) as *mut pdf_gstate;
-    let mut cpa = &mut (*gs).path;
+    let mut gss = gs_stack.lock().unwrap();
+    let gs = gss.top();
+    let cpa = &mut gs.path;
     pdf_dev__flushpath(cpa, 'W' as i32 as i8, 0i32, 0i32)
 }
 #[no_mangle]
 pub unsafe extern "C" fn pdf_dev_eoclip() -> i32 {
-    let mut gss: *mut m_stack = &mut gs_stack;
-    let mut gs: *mut pdf_gstate = m_stack_top(gss) as *mut pdf_gstate;
-    let mut cpa = &mut (*gs).path;
+    let mut gss = gs_stack.lock().unwrap();
+    let gs = gss.top();
+    let cpa = &mut gs.path;
     pdf_dev__flushpath(cpa, 'W' as i32 as i8, 1i32, 0i32)
 }
 #[no_mangle]
 pub unsafe extern "C" fn pdf_dev_flushpath(mut p_op: i8, mut fill_rule: i32) -> i32 {
-    let mut gss: *mut m_stack = &mut gs_stack;
-    let mut gs: *mut pdf_gstate = m_stack_top(gss) as *mut pdf_gstate;
-    let mut cpa = &mut (*gs).path;
+    let mut gss = gs_stack.lock().unwrap();
+    let gs = gss.top();
+    let cpa = &mut gs.path;
     let mut error: i32 = 0i32;
     /* last arg 'ignore_rule' is only for single object
      * that can be converted to a rect where fill rule
@@ -1350,9 +1215,9 @@ pub unsafe extern "C" fn pdf_dev_flushpath(mut p_op: i8, mut fill_rule: i32) -> 
 }
 #[no_mangle]
 pub unsafe extern "C" fn pdf_dev_newpath() -> i32 {
-    let mut gss: *mut m_stack = &mut gs_stack;
-    let mut gs: *mut pdf_gstate = m_stack_top(gss) as *mut pdf_gstate;
-    let mut p = &mut (*gs).path;
+    let mut gss = gs_stack.lock().unwrap();
+    let gs = gss.top();
+    let p = &mut gs.path;
     if !p.path.is_empty() {
         p.path.clear();
     }
@@ -1362,10 +1227,10 @@ pub unsafe extern "C" fn pdf_dev_newpath() -> i32 {
 }
 #[no_mangle]
 pub unsafe extern "C" fn pdf_dev_moveto(mut x: f64, mut y: f64) -> i32 {
-    let mut gss: *mut m_stack = &mut gs_stack;
-    let mut gs: *mut pdf_gstate = m_stack_top(gss) as *mut pdf_gstate;
-    let mut cpa = &mut (*gs).path;
-    let mut cpt = &mut (*gs).cp;
+    let mut gss = gs_stack.lock().unwrap();
+    let gs = gss.top();
+    let cpa = &mut gs.path;
+    let cpt = &mut gs.cp;
     let mut p = pdf_coord::new();
     p.x = x;
     p.y = y;
@@ -1374,10 +1239,10 @@ pub unsafe extern "C" fn pdf_dev_moveto(mut x: f64, mut y: f64) -> i32 {
 }
 #[no_mangle]
 pub unsafe extern "C" fn pdf_dev_rmoveto(mut x: f64, mut y: f64) -> i32 {
-    let mut gss: *mut m_stack = &mut gs_stack;
-    let mut gs: *mut pdf_gstate = m_stack_top(gss) as *mut pdf_gstate;
-    let mut cpa = &mut (*gs).path;
-    let mut cpt = &mut (*gs).cp;
+    let mut gss = gs_stack.lock().unwrap();
+    let gs = gss.top();
+    let cpa = &mut gs.path;
+    let cpt = &mut gs.cp;
     let p = pdf_coord {
         x: cpt.x + x,
         y: cpt.y + y,
@@ -1387,20 +1252,20 @@ pub unsafe extern "C" fn pdf_dev_rmoveto(mut x: f64, mut y: f64) -> i32 {
 }
 #[no_mangle]
 pub unsafe extern "C" fn pdf_dev_lineto(mut x: f64, mut y: f64) -> i32 {
-    let mut gss: *mut m_stack = &mut gs_stack;
-    let mut gs: *mut pdf_gstate = m_stack_top(gss) as *mut pdf_gstate;
-    let mut cpa = &mut (*gs).path;
-    let mut cpt = &mut (*gs).cp;
+    let mut gss = gs_stack.lock().unwrap();
+    let gs = gss.top();
+    let cpa = &mut gs.path;
+    let cpt = &mut gs.cp;
     let p0 = pdf_coord { x, y };
     pdf_path__lineto(cpa, cpt, &p0)
 }
 #[no_mangle]
 pub unsafe extern "C" fn pdf_dev_rlineto(mut x: f64, mut y: f64) -> i32 {
-    let mut gss: *mut m_stack = &mut gs_stack;
-    let mut gs: *mut pdf_gstate = m_stack_top(gss) as *mut pdf_gstate;
-    let mut cpa = &mut (*gs).path;
-    let mut cpt = &mut (*gs).cp;
-    let mut p0 = pdf_coord {
+    let mut gss = gs_stack.lock().unwrap();
+    let gs = gss.top();
+    let cpa = &mut gs.path;
+    let cpt = &mut gs.cp;
+    let p0 = pdf_coord {
         x: x + cpt.x,
         y: y + cpt.y,
     };
@@ -1415,10 +1280,10 @@ pub unsafe extern "C" fn pdf_dev_curveto(
     mut x2: f64,
     mut y2: f64,
 ) -> i32 {
-    let mut gss: *mut m_stack = &mut gs_stack;
-    let mut gs: *mut pdf_gstate = m_stack_top(gss) as *mut pdf_gstate;
-    let mut cpa = &mut (*gs).path;
-    let mut cpt = &mut (*gs).cp;
+    let mut gss = gs_stack.lock().unwrap();
+    let gs = gss.top();
+    let cpa = &mut gs.path;
+    let cpt = &mut gs.cp;
     let p0 = pdf_coord { x: x0, y: y0 };
     let p1 = pdf_coord { x: x1, y: y1 };
     let p2 = pdf_coord { x: x2, y: y2 };
@@ -1431,10 +1296,10 @@ pub unsafe extern "C" fn pdf_dev_vcurveto(
     mut x1: f64,
     mut y1: f64,
 ) -> i32 {
-    let mut gss: *mut m_stack = &mut gs_stack;
-    let mut gs: *mut pdf_gstate = m_stack_top(gss) as *mut pdf_gstate;
-    let mut cpa = &mut (*gs).path;
-    let mut cpt = &mut (*gs).cp;
+    let mut gss = gs_stack.lock().unwrap();
+    let gs = gss.top();
+    let cpa = &mut gs.path;
+    let cpt = &mut gs.cp;
     let cpt_clone = cpt.clone();
     let p0 = pdf_coord { x: x0, y: y0 };
     let p1 = pdf_coord { x: x1, y: y1 };
@@ -1447,10 +1312,10 @@ pub unsafe extern "C" fn pdf_dev_ycurveto(
     mut x1: f64,
     mut y1: f64,
 ) -> i32 {
-    let mut gss: *mut m_stack = &mut gs_stack;
-    let mut gs: *mut pdf_gstate = m_stack_top(gss) as *mut pdf_gstate;
-    let mut cpa = &mut (*gs).path;
-    let mut cpt = &mut (*gs).cp;
+    let mut gss = gs_stack.lock().unwrap();
+    let gs = gss.top();
+    let cpa = &mut gs.path;
+    let cpt = &mut gs.cp;
     let p0 = pdf_coord { x: x0, y: y0 };
     let p1 = pdf_coord { x: x1, y: y1 };
     pdf_path__curveto(cpa, cpt, &p0, &p1, &p1)
@@ -1464,10 +1329,10 @@ pub unsafe extern "C" fn pdf_dev_rcurveto(
     mut x2: f64,
     mut y2: f64,
 ) -> i32 {
-    let mut gss: *mut m_stack = &mut gs_stack;
-    let mut gs: *mut pdf_gstate = m_stack_top(gss) as *mut pdf_gstate;
-    let mut cpa = &mut (*gs).path;
-    let mut cpt = &mut (*gs).cp;
+    let mut gss = gs_stack.lock().unwrap();
+    let gs = gss.top();
+    let cpa = &mut gs.path;
+    let cpt = &mut gs.cp;
     let p0 = pdf_coord {
         x: x0 + cpt.x,
         y: y0 + cpt.y,
@@ -1484,49 +1349,58 @@ pub unsafe extern "C" fn pdf_dev_rcurveto(
 }
 #[no_mangle]
 pub unsafe extern "C" fn pdf_dev_closepath() -> i32 {
-    let mut gss: *mut m_stack = &mut gs_stack;
-    let mut gs: *mut pdf_gstate = m_stack_top(gss) as *mut pdf_gstate;
-    let mut cpt = &mut (*gs).cp;
-    let mut cpa = &mut (*gs).path;
+    let mut gss = gs_stack.lock().unwrap();
+    let gs = gss.top();
+    let cpt = &mut gs.cp;
+    let cpa = &mut gs.path;
     pdf_path__closepath(cpa, cpt)
 }
 #[no_mangle]
 pub unsafe extern "C" fn pdf_dev_dtransform(p: &mut pdf_coord, mut M: Option<&pdf_tmatrix>) {
-    let mut gss: *mut m_stack = &mut gs_stack;
-    let mut gs: *mut pdf_gstate = m_stack_top(gss) as *mut pdf_gstate;
-    let mut CTM = &mut (*gs).matrix;
-    pdf_coord__dtransform(p, if let Some(m) = M { m } else { CTM });
+    if let Some(m) = M {
+        pdf_coord__dtransform(p, m);
+    } else {
+        let mut gss = gs_stack.lock().unwrap();
+        let gs = gss.top();
+        pdf_coord__dtransform(p, &mut gs.matrix);
+    }
 }
 #[no_mangle]
 pub unsafe extern "C" fn pdf_dev_idtransform(p: &mut pdf_coord, M: Option<&pdf_tmatrix>) {
-    let mut gss: *mut m_stack = &mut gs_stack;
-    let mut gs: *mut pdf_gstate = m_stack_top(gss) as *mut pdf_gstate;
-    let mut CTM = &mut (*gs).matrix;
-    pdf_coord__idtransform(p, if let Some(m) = M { m } else { CTM });
+    if let Some(m) = M {
+        pdf_coord__idtransform(p, m);
+    } else {
+        let mut gss = gs_stack.lock().unwrap();
+        let gs = gss.top();
+        pdf_coord__idtransform(p, &mut gs.matrix);
+    }
 }
 #[no_mangle]
 pub unsafe extern "C" fn pdf_dev_transform(p: &mut pdf_coord, M: Option<&pdf_tmatrix>) {
-    let mut gss: *mut m_stack = &mut gs_stack;
-    let mut gs: *mut pdf_gstate = m_stack_top(gss) as *mut pdf_gstate;
-    let mut CTM = &mut (*gs).matrix;
-    pdf_coord__transform(p, if let Some(m) = M { m } else { CTM });
+    if let Some(m) = M {
+        pdf_coord__transform(p, m);
+    } else {
+        let mut gss = gs_stack.lock().unwrap();
+        let gs = gss.top();
+        pdf_coord__transform(p, &mut gs.matrix);
+    }
 }
 #[no_mangle]
 pub unsafe extern "C" fn pdf_dev_arc(c_x: f64, c_y: f64, r: f64, a_0: f64, a_1: f64) -> i32 {
-    let mut gss: *mut m_stack = &mut gs_stack;
-    let mut gs: *mut pdf_gstate = m_stack_top(gss) as *mut pdf_gstate;
-    let mut cpa = &mut (*gs).path;
-    let mut cpt = &mut (*gs).cp;
+    let mut gss = gs_stack.lock().unwrap();
+    let gs = gss.top();
+    let cpa = &mut gs.path;
+    let cpt = &mut gs.cp;
     let mut c = pdf_coord { x: c_x, y: c_y };
     pdf_path__elliptarc(cpa, cpt, &mut c, r, r, 0.0f64, a_0, a_1, 1i32)
 }
 /* *negative* arc */
 #[no_mangle]
 pub unsafe extern "C" fn pdf_dev_arcn(c_x: f64, c_y: f64, r: f64, a_0: f64, a_1: f64) -> i32 {
-    let mut gss: *mut m_stack = &mut gs_stack;
-    let mut gs: *mut pdf_gstate = m_stack_top(gss) as *mut pdf_gstate;
-    let mut cpa = &mut (*gs).path;
-    let mut cpt = &mut (*gs).cp;
+    let mut gss = gs_stack.lock().unwrap();
+    let gs = gss.top();
+    let cpa = &mut gs.path;
+    let cpt = &mut gs.cp;
     let mut c = pdf_coord { x: c_x, y: c_y };
     pdf_path__elliptarc(cpa, cpt, &mut c, r, r, 0.0f64, a_0, a_1, -1i32)
 }
@@ -1541,10 +1415,10 @@ pub unsafe extern "C" fn pdf_dev_arcx(
     a_d: i32,
     xar: f64,
 ) -> i32 {
-    let mut gss: *mut m_stack = &mut gs_stack;
-    let mut gs: *mut pdf_gstate = m_stack_top(gss) as *mut pdf_gstate;
-    let mut cpa = &mut (*gs).path;
-    let mut cpt = &mut (*gs).cp;
+    let mut gss = gs_stack.lock().unwrap();
+    let gs = gss.top();
+    let cpa = &mut gs.path;
+    let cpt = &mut gs.cp;
     let mut c = pdf_coord { x: c_x, y: c_y };
     pdf_path__elliptarc(cpa, cpt, &mut c, r_x, r_y, xar, a_0, a_1, a_d)
 }
@@ -1558,10 +1432,10 @@ pub unsafe extern "C" fn pdf_dev_bspline(
     x2: f64,
     y2: f64,
 ) -> i32 {
-    let mut gss: *mut m_stack = &mut gs_stack;
-    let mut gs: *mut pdf_gstate = m_stack_top(gss) as *mut pdf_gstate;
-    let mut cpa = &mut (*gs).path;
-    let mut cpt = &mut (*gs).cp;
+    let mut gss = gs_stack.lock().unwrap();
+    let gs = gss.top();
+    let cpa = &mut gs.path;
+    let cpt = &mut gs.cp;
     let p1 = pdf_coord {
         x: x0 + 2. * (x1 - x0) / 3.,
         y: y0 + 2. * (y1 - y0) / 3.,
@@ -1606,10 +1480,10 @@ pub unsafe extern "C" fn pdf_dev_rectadd(x: f64, y: f64, w: f64, h: f64) -> i32 
 }
 #[no_mangle]
 pub unsafe extern "C" fn pdf_dev_set_fixed_point(mut x: f64, mut y: f64) {
-    let mut gss: *mut m_stack = &mut gs_stack;
-    let mut gs: *mut pdf_gstate = m_stack_top(gss) as *mut pdf_gstate;
-    (*gs).pt_fixee.x = x;
-    (*gs).pt_fixee.y = y;
+    let mut gss = gs_stack.lock().unwrap();
+    let gs = gss.top();
+    gs.pt_fixee.x = x;
+    gs.pt_fixee.y = y;
 }
 /* m -> n x m */
 /* Path Construction */
@@ -1626,8 +1500,7 @@ pub unsafe extern "C" fn pdf_dev_set_fixed_point(mut x: f64, mut y: f64) {
  */
 #[no_mangle]
 pub unsafe extern "C" fn pdf_dev_get_fixed_point(p: &mut pdf_coord) {
-    let mut gss: *mut m_stack = &mut gs_stack;
-    let mut gs: *mut pdf_gstate = m_stack_top(gss) as *mut pdf_gstate;
-    p.x = (*gs).pt_fixee.x;
-    p.y = (*gs).pt_fixee.y;
+    let mut gss = gs_stack.lock().unwrap();
+    let gs = gss.top();
+    *p = gs.pt_fixee.clone();
 }

--- a/dpx/src/dpx_pdfobj.rs
+++ b/dpx/src/dpx_pdfobj.rs
@@ -1849,7 +1849,7 @@ unsafe extern "C" fn filter_PNG15_apply_filter(
                 as u32 as u32;
             /* Type 3 -- Average */
             let mut tmp: libc::c_int =
-                (((up + left) / 2i32) as libc::c_double).floor() as libc::c_int;
+                (((up + left) / 2i32) as f64).floor() as libc::c_int;
             sum[3] = (sum[3] as libc::c_uint)
                 .wrapping_add((*p.offset(i as isize) as libc::c_int - tmp).abs() as libc::c_uint)
                 as u32 as u32;
@@ -1934,7 +1934,7 @@ unsafe extern "C" fn filter_PNG15_apply_filter(
                         0i32
                     };
                     let mut tmp_0: libc::c_int =
-                        (((up_1 + left_1) / 2i32) as libc::c_double).floor() as libc::c_int;
+                        (((up_1 + left_1) / 2i32) as f64).floor() as libc::c_int;
                     *pp.offset((i + 1i32) as isize) =
                         (*p.offset(i as isize) as libc::c_int - tmp_0) as libc::c_uchar;
                     i += 1
@@ -2203,22 +2203,22 @@ unsafe extern "C" fn filter_create_predictor_dict(
     pdf_add_dict(
         parms,
         pdf_new_name(b"BitsPerComponent\x00" as *const u8 as *const i8),
-        pdf_new_number(bpc as libc::c_double),
+        pdf_new_number(bpc as f64),
     );
     pdf_add_dict(
         parms,
         pdf_new_name(b"Colors\x00" as *const u8 as *const i8),
-        pdf_new_number(colors as libc::c_double),
+        pdf_new_number(colors as f64),
     );
     pdf_add_dict(
         parms,
         pdf_new_name(b"Columns\x00" as *const u8 as *const i8),
-        pdf_new_number(columns as libc::c_double),
+        pdf_new_number(columns as f64),
     );
     pdf_add_dict(
         parms,
         pdf_new_name(b"Predictor\x00" as *const u8 as *const i8),
-        pdf_new_number(predictor as libc::c_double),
+        pdf_new_number(predictor as f64),
     );
     return parms;
 }
@@ -2950,7 +2950,7 @@ unsafe extern "C" fn filter_decoded(
                                 0i32
                             };
                             let mut tmp: libc::c_int =
-                                (((up + left) / 2i32) as libc::c_double).floor() as libc::c_int;
+                                (((up + left) / 2i32) as f64).floor() as libc::c_int;
                             *buf.offset(i as isize) = (*p.offset(i as isize) as libc::c_int + tmp
                                 & 0xffi32)
                                 as libc::c_uchar;

--- a/dpx/src/dpx_pdfparse.rs
+++ b/dpx/src/dpx_pdfparse.rs
@@ -79,11 +79,11 @@ pub type size_t = u64;
 /* PDF */
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_0 {
+pub struct ParserState {
     pub tainted: i32,
 }
-static mut parser_state: C2RustUnnamed_0 = {
-    let mut init = C2RustUnnamed_0 { tainted: 0i32 };
+static mut parser_state: ParserState = {
+    let mut init = ParserState { tainted: 0i32 };
     init
 };
 static mut save: *const i8 = 0 as *const i8;

--- a/dpx/src/dpx_pdfximage.rs
+++ b/dpx/src/dpx_pdfximage.rs
@@ -637,10 +637,10 @@ pub unsafe extern "C" fn pdf_ximage_set_form(
     mut resource: *mut pdf_obj,
 ) {
     let info = form_info;
-    let mut p1: pdf_coord = pdf_coord::new();
-    let mut p2: pdf_coord = pdf_coord::new();
-    let mut p3: pdf_coord = pdf_coord::new();
-    let mut p4: pdf_coord = pdf_coord::new();
+    let mut p1 = pdf_coord::new();
+    let mut p2 = pdf_coord::new();
+    let mut p3 = pdf_coord::new();
+    let mut p4 = pdf_coord::new();
     (*I).subtype = 0i32;
     /* Image's attribute "bbox" here is affected by /Rotate entry of included
      * PDF page.

--- a/dpx/src/dpx_spc_color.rs
+++ b/dpx/src/dpx_spc_color.rs
@@ -73,7 +73,7 @@ unsafe extern "C" fn spc_handler_color_push(mut spe: *mut spc_env, mut args: *mu
     let mut error: i32 = 0;
     let mut colorspec: pdf_color = pdf_color {
         num_components: 0,
-        spot_color_name: 0 as *mut i8,
+        spot_color_name: None,
         values: [0.; 4],
     };
     error = spc_util_read_colorspec(spe, &mut colorspec, args, 1i32);
@@ -97,7 +97,7 @@ unsafe extern "C" fn spc_handler_color_default(
     let mut error: i32 = 0;
     let mut colorspec: pdf_color = pdf_color {
         num_components: 0,
-        spot_color_name: 0 as *mut i8,
+        spot_color_name: None,
         values: [0.; 4],
     };
     error = spc_util_read_colorspec(spe, &mut colorspec, args, 1i32);
@@ -112,7 +112,7 @@ unsafe extern "C" fn spc_handler_background(mut spe: *mut spc_env, mut args: *mu
     let mut error: i32 = 0;
     let mut colorspec = pdf_color {
         num_components: 0,
-        spot_color_name: 0 as *mut i8,
+        spot_color_name: None,
         values: [0.; 4],
     };
     error = spc_util_read_colorspec(spe, &mut colorspec, args, 1i32);

--- a/dpx/src/dpx_spc_dvips.rs
+++ b/dpx/src/dpx_spc_dvips.rs
@@ -39,7 +39,7 @@ use crate::dpx_pdfobj::pdf_obj;
 use crate::{ttstub_input_close, ttstub_input_open};
 
 use super::dpx_pdfdev::{
-    pdf_dev_put_image, pdf_rect, pdf_tmatrix, transform_info, transform_info_clear,
+    pdf_dev_put_image, pdf_tmatrix, transform_info, transform_info_clear,
 };
 use super::dpx_spc_util::spc_util_read_dimtrns;
 use libc::free;

--- a/dpx/src/dpx_spc_dvips.rs
+++ b/dpx/src/dpx_spc_dvips.rs
@@ -38,9 +38,7 @@ use super::dpx_pdfximage::pdf_ximage_findresource;
 use crate::dpx_pdfobj::pdf_obj;
 use crate::{ttstub_input_close, ttstub_input_open};
 
-use super::dpx_pdfdev::{
-    pdf_dev_put_image, pdf_tmatrix, transform_info, transform_info_clear,
-};
+use super::dpx_pdfdev::{pdf_dev_put_image, pdf_tmatrix, transform_info, transform_info_clear};
 use super::dpx_spc_util::spc_util_read_dimtrns;
 use libc::free;
 extern "C" {

--- a/dpx/src/dpx_spc_html.rs
+++ b/dpx/src/dpx_spc_html.rs
@@ -492,7 +492,7 @@ unsafe extern "C" fn html_open_dest(
     let mut error: i32 = 0;
     let mut array: *mut pdf_obj = 0 as *mut pdf_obj;
     let mut page_ref: *mut pdf_obj = 0 as *mut pdf_obj;
-    let mut cp: pdf_coord = pdf_coord::new();
+    let mut cp = pdf_coord::new();
     cp.x = (*spe).x_user;
     cp.y = (*spe).y_user;
     pdf_dev_transform(&mut cp, None);

--- a/dpx/src/dpx_spc_misc.rs
+++ b/dpx/src/dpx_spc_misc.rs
@@ -31,7 +31,7 @@
 
 use super::dpx_mpost::mps_scan_bbox;
 use super::dpx_pdfdev::{
-    pdf_dev_put_image, pdf_rect, pdf_tmatrix, transform_info, transform_info_clear,
+    pdf_dev_put_image, transform_info, transform_info_clear,
 };
 use super::dpx_pdfximage::pdf_ximage_findresource;
 use crate::dpx_pdfobj::pdf_obj;

--- a/dpx/src/dpx_spc_misc.rs
+++ b/dpx/src/dpx_spc_misc.rs
@@ -30,9 +30,7 @@
 )]
 
 use super::dpx_mpost::mps_scan_bbox;
-use super::dpx_pdfdev::{
-    pdf_dev_put_image, transform_info, transform_info_clear,
-};
+use super::dpx_pdfdev::{pdf_dev_put_image, transform_info, transform_info_clear};
 use super::dpx_pdfximage::pdf_ximage_findresource;
 use crate::dpx_pdfobj::pdf_obj;
 use crate::{ttstub_input_close, ttstub_input_open};

--- a/dpx/src/dpx_spc_pdfm.rs
+++ b/dpx/src/dpx_spc_pdfm.rs
@@ -952,19 +952,19 @@ unsafe extern "C" fn spc_handler_pdfm_bcolor(mut spe: *mut spc_env, mut ap: *mut
     let mut error: i32 = 0;
     let mut fc: pdf_color = pdf_color {
         num_components: 0,
-        spot_color_name: 0 as *mut i8,
+        spot_color_name: None,
         values: [0.; 4],
     };
     let mut sc: pdf_color = pdf_color {
         num_components: 0,
-        spot_color_name: 0 as *mut i8,
+        spot_color_name: None,
         values: [0.; 4],
     };
     let (psc, pfc) = pdf_color_get_current();
-    error = spc_util_read_pdfcolor(spe, &mut fc, ap, pfc);
+    error = spc_util_read_pdfcolor(spe, &mut fc, ap, Some(pfc));
     if error == 0 {
         if (*ap).curptr < (*ap).endptr {
-            error = spc_util_read_pdfcolor(spe, &mut sc, ap, psc)
+            error = spc_util_read_pdfcolor(spe, &mut sc, ap, Some(psc))
         } else {
             pdf_color_copycolor(&mut sc, &mut fc);
         }
@@ -988,19 +988,19 @@ unsafe extern "C" fn spc_handler_pdfm_scolor(mut spe: *mut spc_env, mut ap: *mut
     let mut error: i32 = 0;
     let mut fc: pdf_color = pdf_color {
         num_components: 0,
-        spot_color_name: 0 as *mut i8,
+        spot_color_name: None,
         values: [0.; 4],
     };
     let mut sc: pdf_color = pdf_color {
         num_components: 0,
-        spot_color_name: 0 as *mut i8,
+        spot_color_name: None,
         values: [0.; 4],
     };
     let (psc, pfc) = pdf_color_get_current();
-    error = spc_util_read_pdfcolor(spe, &mut fc, ap, pfc);
+    error = spc_util_read_pdfcolor(spe, &mut fc, ap, Some(pfc));
     if error == 0 {
         if (*ap).curptr < (*ap).endptr {
-            error = spc_util_read_pdfcolor(spe, &mut sc, ap, psc)
+            error = spc_util_read_pdfcolor(spe, &mut sc, ap, Some(psc))
         } else {
             pdf_color_copycolor(&mut sc, &mut fc);
         }
@@ -2105,10 +2105,10 @@ unsafe extern "C" fn spc_handler_pdfm_bgcolor(
     let mut error: i32 = 0;
     let mut colorspec = pdf_color {
         num_components: 0,
-        spot_color_name: 0 as *mut i8,
+        spot_color_name: None,
         values: [0.; 4],
     };
-    error = spc_util_read_pdfcolor(spe, &mut colorspec, args, 0 as *mut pdf_color);
+    error = spc_util_read_pdfcolor(spe, &mut colorspec, args, None);
     if error != 0 {
         spc_warn(
             spe,

--- a/dpx/src/dpx_spc_pdfm.rs
+++ b/dpx/src/dpx_spc_pdfm.rs
@@ -825,7 +825,7 @@ unsafe extern "C" fn spc_handler_pdfm_annot(mut spe: *mut spc_env, mut args: *mu
     let mut annot_dict: *mut pdf_obj = 0 as *mut pdf_obj;
     let mut rect = pdf_rect::new();
     let mut ident: *mut i8 = 0 as *mut i8;
-    let mut cp: pdf_coord = pdf_coord::new();
+    let mut cp = pdf_coord::new();
     let mut ti = transform_info::new();
     skip_white(&mut (*args).curptr, (*args).endptr);
     if *(*args).curptr.offset(0) as i32 == '@' as i32 {
@@ -1177,7 +1177,7 @@ unsafe extern "C" fn spc_handler_pdfm_bead(mut spe: *mut spc_env, mut args: *mut
     let mut rect = pdf_rect::new();
     let mut page_no: i32 = 0;
     let mut ti = transform_info::new();
-    let mut cp: pdf_coord = pdf_coord::new();
+    let mut cp = pdf_coord::new();
     skip_white(&mut (*args).curptr, (*args).endptr);
     if *(*args).curptr.offset(0) as i32 != '@' as i32 {
         spc_warn(

--- a/dpx/src/dpx_spc_pdfm.rs
+++ b/dpx/src/dpx_spc_pdfm.rs
@@ -242,7 +242,6 @@ pub struct tounicode {
 
 use super::dpx_dpxutil::ht_table;
 
-use super::dpx_dpxutil::ht_entry;
 pub type hval_free_func = Option<unsafe extern "C" fn(_: *mut libc::c_void) -> ()>;
 
 use super::dpx_fontmap::fontmap_rec;

--- a/dpx/src/dpx_spc_tpic.rs
+++ b/dpx/src/dpx_spc_tpic.rs
@@ -581,7 +581,7 @@ unsafe extern "C" fn spc_handler_tpic_pa(mut spe: *mut spc_env, mut ap: *mut spc
 unsafe extern "C" fn spc_handler_tpic_fp(mut spe: *mut spc_env, mut ap: *mut spc_arg) -> i32
 /* , void *dp) */ {
     let mut tp: *mut spc_tpic_ = &mut _tpic_state;
-    let mut cp: pdf_coord = pdf_coord::new();
+    let mut cp = pdf_coord::new();
     let mut pg: i32 = 0;
     assert!(!spe.is_null() && !ap.is_null() && !tp.is_null());
     if (*tp).num_points <= 1i32 {
@@ -597,7 +597,7 @@ unsafe extern "C" fn spc_handler_tpic_fp(mut spe: *mut spc_env, mut ap: *mut spc
 unsafe extern "C" fn spc_handler_tpic_ip(mut spe: *mut spc_env, mut ap: *mut spc_arg) -> i32
 /* , void *dp) */ {
     let mut tp: *mut spc_tpic_ = &mut _tpic_state;
-    let mut cp: pdf_coord = pdf_coord::new();
+    let mut cp = pdf_coord::new();
     let mut pg: i32 = 0;
     assert!(!spe.is_null() && !ap.is_null() && !tp.is_null());
     if (*tp).num_points <= 1i32 {
@@ -615,7 +615,7 @@ unsafe extern "C" fn spc_handler_tpic_da(mut spe: *mut spc_env, mut ap: *mut spc
     let mut tp: *mut spc_tpic_ = &mut _tpic_state;
     let mut q: *mut i8 = 0 as *mut i8;
     let mut da: f64 = 0.0f64;
-    let mut cp: pdf_coord = pdf_coord::new();
+    let mut cp = pdf_coord::new();
     let mut pg: i32 = 0;
     assert!(!spe.is_null() && !ap.is_null() && !tp.is_null());
     skip_blank(&mut (*ap).curptr, (*ap).endptr);
@@ -639,7 +639,7 @@ unsafe extern "C" fn spc_handler_tpic_dt(mut spe: *mut spc_env, mut ap: *mut spc
     let mut tp: *mut spc_tpic_ = &mut _tpic_state;
     let mut q: *mut i8 = 0 as *mut i8;
     let mut da: f64 = 0.0f64;
-    let mut cp: pdf_coord = pdf_coord::new();
+    let mut cp = pdf_coord::new();
     let mut pg: i32 = 0;
     assert!(!spe.is_null() && !ap.is_null() && !tp.is_null());
     skip_blank(&mut (*ap).curptr, (*ap).endptr);
@@ -663,7 +663,7 @@ unsafe extern "C" fn spc_handler_tpic_sp(mut spe: *mut spc_env, mut ap: *mut spc
     let mut tp: *mut spc_tpic_ = &mut _tpic_state;
     let mut q: *mut i8 = 0 as *mut i8;
     let mut da: f64 = 0.0f64;
-    let mut cp: pdf_coord = pdf_coord::new();
+    let mut cp = pdf_coord::new();
     let mut pg: i32 = 0;
     assert!(!spe.is_null() && !ap.is_null() && !tp.is_null());
     skip_blank(&mut (*ap).curptr, (*ap).endptr);
@@ -686,7 +686,7 @@ unsafe extern "C" fn spc_handler_tpic_ar(mut spe: *mut spc_env, mut ap: *mut spc
 /* , void *dp) */ {
     let mut tp: *mut spc_tpic_ = &mut _tpic_state;
     let mut v: [f64; 6] = [0.; 6];
-    let mut cp: pdf_coord = pdf_coord::new();
+    let mut cp = pdf_coord::new();
     let mut pg: i32 = 0;
     let mut q: *mut i8 = 0 as *mut i8;
     let mut i: i32 = 0;
@@ -727,7 +727,7 @@ unsafe extern "C" fn spc_handler_tpic_ia(mut spe: *mut spc_env, mut ap: *mut spc
 /* , void *dp) */ {
     let mut tp: *mut spc_tpic_ = &mut _tpic_state;
     let mut v: [f64; 6] = [0.; 6];
-    let mut cp: pdf_coord = pdf_coord::new();
+    let mut cp = pdf_coord::new();
     let mut pg: i32 = 0;
     let mut q: *mut i8 = 0 as *mut i8;
     let mut i: i32 = 0;

--- a/dpx/src/dpx_spc_tpic.rs
+++ b/dpx/src/dpx_spc_tpic.rs
@@ -284,7 +284,7 @@ unsafe extern "C" fn set_fillstyle(mut g: f64, mut a: f64, mut f_ais: i32) -> i3
     } /* get stroking and fill colors */
     let mut new_fc: pdf_color = pdf_color {
         num_components: 0,
-        spot_color_name: 0 as *mut i8,
+        spot_color_name: None,
         values: [0.; 4],
     };
     let (sc, fc) = pdf_color_get_current();

--- a/dpx/src/dpx_spc_util.rs
+++ b/dpx/src/dpx_spc_util.rs
@@ -64,7 +64,7 @@ use super::dpx_pdfdev::{pdf_tmatrix, transform_info};
 use super::dpx_specials::{spc_arg, spc_env};
 
 /* Color names */
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 #[repr(C)]
 pub struct colordef_ {
     pub key: *const i8,
@@ -368,7 +368,7 @@ pub unsafe extern "C" fn spc_util_read_pdfcolor(
     mut spe: *mut spc_env,
     colorspec: &mut pdf_color,
     mut ap: *mut spc_arg,
-    mut defaultcolor: *mut pdf_color,
+    defaultcolor: Option<&pdf_color>,
 ) -> i32 {
     let mut error: i32 = 0i32;
     assert!(!spe.is_null() && !ap.is_null());
@@ -377,9 +377,11 @@ pub unsafe extern "C" fn spc_util_read_pdfcolor(
         return -1i32;
     }
     error = spc_read_color_pdf(spe, colorspec, ap);
-    if error < 0i32 && !defaultcolor.is_null() {
-        pdf_color_copycolor(colorspec, defaultcolor);
-        error = 0i32
+    if error < 0i32 {
+        if let Some(dc) = defaultcolor {
+            pdf_color_copycolor(colorspec, dc);
+            error = 0i32
+        }
     }
     error
 }
@@ -1112,7 +1114,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.15f64, 0.00f64, 0.69f64, 0.00f64],
                 };
                 init
@@ -1126,7 +1128,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.00f64, 0.00f64, 1.00f64, 0.00f64],
                 };
                 init
@@ -1140,7 +1142,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.00f64, 0.10f64, 0.84f64, 0.00f64],
                 };
                 init
@@ -1154,7 +1156,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.00f64, 0.29f64, 0.84f64, 0.00f64],
                 };
                 init
@@ -1168,7 +1170,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.00f64, 0.32f64, 0.52f64, 0.00f64],
                 };
                 init
@@ -1182,7 +1184,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.00f64, 0.50f64, 0.70f64, 0.00f64],
                 };
                 init
@@ -1196,7 +1198,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.00f64, 0.46f64, 0.50f64, 0.00f64],
                 };
                 init
@@ -1210,7 +1212,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.00f64, 0.42f64, 1.00f64, 0.00f64],
                 };
                 init
@@ -1224,7 +1226,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.00f64, 0.61f64, 0.87f64, 0.00f64],
                 };
                 init
@@ -1238,7 +1240,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.00f64, 0.51f64, 1.00f64, 0.00f64],
                 };
                 init
@@ -1252,7 +1254,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.00f64, 0.75f64, 1.00f64, 0.24f64],
                 };
                 init
@@ -1266,7 +1268,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.00f64, 0.77f64, 0.87f64, 0.00f64],
                 };
                 init
@@ -1280,7 +1282,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.00f64, 0.85f64, 0.87f64, 0.35f64],
                 };
                 init
@@ -1294,7 +1296,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.00f64, 0.87f64, 0.68f64, 0.32f64],
                 };
                 init
@@ -1308,7 +1310,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.00f64, 0.89f64, 0.94f64, 0.28f64],
                 };
                 init
@@ -1322,7 +1324,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.00f64, 1.00f64, 1.00f64, 0.00f64],
                 };
                 init
@@ -1336,7 +1338,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.00f64, 1.00f64, 0.50f64, 0.00f64],
                 };
                 init
@@ -1350,7 +1352,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.00f64, 1.00f64, 0.13f64, 0.00f64],
                 };
                 init
@@ -1364,7 +1366,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.00f64, 0.96f64, 0.39f64, 0.00f64],
                 };
                 init
@@ -1378,7 +1380,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.00f64, 0.53f64, 0.38f64, 0.00f64],
                 };
                 init
@@ -1392,7 +1394,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.00f64, 0.63f64, 0.00f64, 0.00f64],
                 };
                 init
@@ -1406,7 +1408,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.00f64, 1.00f64, 0.00f64, 0.00f64],
                 };
                 init
@@ -1420,7 +1422,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.00f64, 0.81f64, 0.00f64, 0.00f64],
                 };
                 init
@@ -1434,7 +1436,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.00f64, 0.82f64, 0.00f64, 0.00f64],
                 };
                 init
@@ -1448,7 +1450,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.34f64, 0.90f64, 0.00f64, 0.02f64],
                 };
                 init
@@ -1462,7 +1464,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.07f64, 0.90f64, 0.00f64, 0.34f64],
                 };
                 init
@@ -1476,7 +1478,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.47f64, 0.91f64, 0.00f64, 0.08f64],
                 };
                 init
@@ -1490,7 +1492,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.00f64, 0.48f64, 0.00f64, 0.00f64],
                 };
                 init
@@ -1504,7 +1506,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.12f64, 0.59f64, 0.00f64, 0.00f64],
                 };
                 init
@@ -1518,7 +1520,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.32f64, 0.64f64, 0.00f64, 0.00f64],
                 };
                 init
@@ -1532,7 +1534,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.40f64, 0.80f64, 0.20f64, 0.00f64],
                 };
                 init
@@ -1546,7 +1548,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.45f64, 0.86f64, 0.00f64, 0.00f64],
                 };
                 init
@@ -1560,7 +1562,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.50f64, 1.00f64, 0.00f64, 0.00f64],
                 };
                 init
@@ -1574,7 +1576,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.79f64, 0.88f64, 0.00f64, 0.00f64],
                 };
                 init
@@ -1588,7 +1590,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.75f64, 0.90f64, 0.00f64, 0.00f64],
                 };
                 init
@@ -1602,7 +1604,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.86f64, 0.91f64, 0.00f64, 0.04f64],
                 };
                 init
@@ -1616,7 +1618,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.57f64, 0.55f64, 0.00f64, 0.00f64],
                 };
                 init
@@ -1630,7 +1632,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.62f64, 0.57f64, 0.23f64, 0.00f64],
                 };
                 init
@@ -1644,7 +1646,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.65f64, 0.13f64, 0.00f64, 0.00f64],
                 };
                 init
@@ -1658,7 +1660,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.98f64, 0.13f64, 0.00f64, 0.43f64],
                 };
                 init
@@ -1672,7 +1674,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.94f64, 0.54f64, 0.00f64, 0.00f64],
                 };
                 init
@@ -1686,7 +1688,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [1.00f64, 0.50f64, 0.00f64, 0.00f64],
                 };
                 init
@@ -1700,7 +1702,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [1.00f64, 1.00f64, 0.00f64, 0.00f64],
                 };
                 init
@@ -1714,7 +1716,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.94f64, 0.11f64, 0.00f64, 0.00f64],
                 };
                 init
@@ -1728,7 +1730,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [1.00f64, 0.00f64, 0.00f64, 0.00f64],
                 };
                 init
@@ -1742,7 +1744,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.96f64, 0.00f64, 0.00f64, 0.00f64],
                 };
                 init
@@ -1756,7 +1758,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.62f64, 0.00f64, 0.12f64, 0.00f64],
                 };
                 init
@@ -1770,7 +1772,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.85f64, 0.00f64, 0.20f64, 0.00f64],
                 };
                 init
@@ -1784,7 +1786,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.86f64, 0.00f64, 0.34f64, 0.02f64],
                 };
                 init
@@ -1798,7 +1800,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.82f64, 0.00f64, 0.30f64, 0.00f64],
                 };
                 init
@@ -1812,7 +1814,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.85f64, 0.00f64, 0.33f64, 0.00f64],
                 };
                 init
@@ -1826,7 +1828,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [1.00f64, 0.00f64, 0.50f64, 0.00f64],
                 };
                 init
@@ -1840,7 +1842,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.99f64, 0.00f64, 0.52f64, 0.00f64],
                 };
                 init
@@ -1854,7 +1856,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.69f64, 0.00f64, 0.50f64, 0.00f64],
                 };
                 init
@@ -1868,7 +1870,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [1.00f64, 0.00f64, 1.00f64, 0.00f64],
                 };
                 init
@@ -1882,7 +1884,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.91f64, 0.00f64, 0.88f64, 0.12f64],
                 };
                 init
@@ -1896,7 +1898,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.92f64, 0.00f64, 0.59f64, 0.25f64],
                 };
                 init
@@ -1910,7 +1912,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.50f64, 0.00f64, 1.00f64, 0.00f64],
                 };
                 init
@@ -1924,7 +1926,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.44f64, 0.00f64, 0.74f64, 0.00f64],
                 };
                 init
@@ -1938,7 +1940,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.26f64, 0.00f64, 0.76f64, 0.00f64],
                 };
                 init
@@ -1952,7 +1954,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.64f64, 0.00f64, 0.95f64, 0.40f64],
                 };
                 init
@@ -1966,7 +1968,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.00f64, 0.72f64, 1.00f64, 0.45f64],
                 };
                 init
@@ -1980,7 +1982,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.00f64, 0.83f64, 1.00f64, 0.70f64],
                 };
                 init
@@ -1994,7 +1996,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.00f64, 0.81f64, 1.00f64, 0.60f64],
                 };
                 init
@@ -2008,7 +2010,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 4i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.14f64, 0.42f64, 0.56f64, 0.00f64],
                 };
                 init
@@ -2022,7 +2024,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 1i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.5f64, 0., 0., 0.],
                 };
                 init
@@ -2036,7 +2038,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 1i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.0f64, 0., 0., 0.],
                 };
                 init
@@ -2050,7 +2052,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 1i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [1.0f64, 0., 0., 0.],
                 };
                 init
@@ -2064,7 +2066,7 @@ static mut colordefs: [colordef_; 69] = [
             color: {
                 let mut init = pdf_color {
                     num_components: 0i32,
-                    spot_color_name: 0 as *const i8 as *mut i8,
+                    spot_color_name: None,
                     values: [0.0f64, 0., 0., 0.],
                 };
                 init

--- a/dpx/src/dpx_spc_xtx.rs
+++ b/dpx/src/dpx_spc_xtx.rs
@@ -283,7 +283,7 @@ unsafe extern "C" fn spc_handler_xtx_backgroundcolor(
     let mut error: i32 = 0;
     let mut colorspec = pdf_color {
         num_components: 0,
-        spot_color_name: 0 as *mut i8,
+        spot_color_name: None,
         values: [0.; 4],
     };
     error = spc_util_read_colorspec(spe, &mut colorspec, args, 0i32);

--- a/dpx/src/dpx_spc_xtx.rs
+++ b/dpx/src/dpx_spc_xtx.rs
@@ -145,7 +145,7 @@ pub unsafe extern "C" fn spc_handler_xtx_do_transform(
         let mut init = pdf_tmatrix::new();
         init
     };
-    let mut pt: pdf_coord = pdf_coord::new();
+    let mut pt = pdf_coord::new();
     /* Create transformation matrix */
     M.a = a;
     M.b = b;

--- a/dpx/src/dpx_specials.rs
+++ b/dpx/src/dpx_specials.rs
@@ -329,7 +329,7 @@ unsafe extern "C" fn ispageref(mut key: *const i8) -> i32 {
 #[no_mangle]
 pub unsafe extern "C" fn spc_lookup_reference(mut key: *const i8) -> *mut pdf_obj {
     let mut value: *mut pdf_obj = 0 as *mut pdf_obj;
-    let mut cp: pdf_coord = pdf_coord::new();
+    let mut cp = pdf_coord::new();
     let mut k: i32 = 0;
     assert!(!named_objects.is_null());
     if key.is_null() {
@@ -400,7 +400,7 @@ pub unsafe extern "C" fn spc_lookup_reference(mut key: *const i8) -> *mut pdf_ob
 #[no_mangle]
 pub unsafe extern "C" fn spc_lookup_object(mut key: *const i8) -> *mut pdf_obj {
     let mut value: *mut pdf_obj = 0 as *mut pdf_obj;
-    let mut cp: pdf_coord = pdf_coord::new();
+    let mut cp = pdf_coord::new();
     let mut k: i32 = 0;
     assert!(!named_objects.is_null());
     if key.is_null() {
@@ -767,7 +767,7 @@ unsafe extern "C" fn print_error(mut name: *const i8, mut spe: *mut spc_env, mut
     let mut ebuf: [i8; 64] = [0; 64];
     let mut i: i32 = 0;
     let mut pg: i32 = (*spe).pg;
-    let mut c: pdf_coord = pdf_coord::new();
+    let mut c = pdf_coord::new();
     c.x = (*spe).x_user;
     c.y = (*spe).y_user;
     pdf_dev_transform(&mut c, None);

--- a/dpx/src/dpx_specials.rs
+++ b/dpx/src/dpx_specials.rs
@@ -228,7 +228,6 @@ pub struct spc_handler {
     pub exec: spc_handler_fn_ptr,
 }
 
-use super::dpx_dpxutil::ht_entry;
 use super::dpx_dpxutil::ht_table;
 pub type hval_free_func = Option<unsafe extern "C" fn(_: *mut libc::c_void) -> ()>;
 

--- a/dpx/src/dpx_t1_char.rs
+++ b/dpx/src/dpx_t1_char.rs
@@ -63,6 +63,28 @@ pub struct t1_ginfo {
     pub bbox: C2RustUnnamed_0,
     pub seac: C2RustUnnamed,
 }
+impl t1_ginfo {
+    pub fn new() -> Self {
+        Self {
+            use_seac: 0,
+            wx: 0.,
+            wy: 0.,
+            bbox: C2RustUnnamed_0 {
+                llx: 0.,
+                lly: 0.,
+                urx: 0.,
+                ury: 0.,
+            },
+            seac: C2RustUnnamed {
+                asb: 0.,
+                adx: 0.,
+                ady: 0.,
+                bchar: 0,
+                achar: 0,
+            },
+        }
+    }
+}
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed {

--- a/dpx/src/dpx_type0.rs
+++ b/dpx/src/dpx_type0.rs
@@ -152,14 +152,6 @@ pub struct font_cache {
     pub fonts: *mut Type0Font,
 }
 use super::dpx_cmap::CMap;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct C2RustUnnamed {
-    pub minBytesIn: size_t,
-    pub maxBytesIn: size_t,
-    pub minBytesOut: size_t,
-    pub maxBytesOut: size_t,
-}
 
 static mut __verbose: i32 = 0i32;
 #[no_mangle]

--- a/dpx/src/dpx_type1.rs
+++ b/dpx/src/dpx_type1.rs
@@ -159,32 +159,9 @@ pub type s_SID = u16;
 use super::dpx_cff::cff_encoding;
 use super::dpx_cff::cff_map;
 use super::dpx_cff::cff_range1;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct t1_ginfo {
-    pub use_seac: i32,
-    pub wx: f64,
-    pub wy: f64,
-    pub bbox: C2RustUnnamed_3,
-    pub seac: C2RustUnnamed_2,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct C2RustUnnamed_2 {
-    pub asb: f64,
-    pub adx: f64,
-    pub ady: f64,
-    pub bchar: card8,
-    pub achar: card8,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct C2RustUnnamed_3 {
-    pub llx: f64,
-    pub lly: f64,
-    pub urx: f64,
-    pub ury: f64,
-}
+
+use super::dpx_t1_char::t1_ginfo;
+
 /* tectonic/core-strutils.h: miscellaneous C string utilities
    Copyright 2016-2018 the Tectonic Project
    Licensed under the MIT License.
@@ -290,24 +267,7 @@ unsafe extern "C" fn get_font_attr(mut font: *mut pdf_font, mut cffont: *mut cff
         b"lambda\x00" as *const u8 as *const i8,
         0 as *const i8,
     ];
-    let mut gm: t1_ginfo = t1_ginfo {
-        use_seac: 0,
-        wx: 0.,
-        wy: 0.,
-        bbox: C2RustUnnamed_3 {
-            llx: 0.,
-            lly: 0.,
-            urx: 0.,
-            ury: 0.,
-        },
-        seac: C2RustUnnamed_2 {
-            asb: 0.,
-            adx: 0.,
-            ady: 0.,
-            bchar: 0,
-            achar: 0,
-        },
-    };
+    let mut gm = t1_ginfo::new();
     defaultwidth = 500.0f64;
     nominalwidth = 0.0f64;
     /*
@@ -1181,24 +1141,7 @@ pub unsafe extern "C" fn pdf_font_load_type1(mut font: *mut pdf_font) -> i32 {
      * used already).
      */
     let mut cstring: *mut cff_index = 0 as *mut cff_index;
-    let mut gm: t1_ginfo = t1_ginfo {
-        use_seac: 0,
-        wx: 0.,
-        wy: 0.,
-        bbox: C2RustUnnamed_3 {
-            llx: 0.,
-            lly: 0.,
-            urx: 0.,
-            ury: 0.,
-        },
-        seac: C2RustUnnamed_2 {
-            asb: 0.,
-            adx: 0.,
-            ady: 0.,
-            bchar: 0,
-            achar: 0,
-        },
-    };
+    let mut gm = t1_ginfo::new();
     let mut gid_0: card16 = 0;
     let mut gid_orig: card16 = 0;
     let mut dstlen_max: i32 = 0;

--- a/dpx/src/dpx_type1c.rs
+++ b/dpx/src/dpx_type1c.rs
@@ -212,32 +212,8 @@ use super::dpx_cff::cff_charsets;
 use super::dpx_cff::cff_font;
 use super::dpx_sfnt::sfnt;
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct cs_ginfo {
-    pub flags: i32,
-    pub wx: f64,
-    pub wy: f64,
-    pub bbox: C2RustUnnamed_3,
-    pub seac: C2RustUnnamed_2,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct C2RustUnnamed_2 {
-    pub asb: f64,
-    pub adx: f64,
-    pub ady: f64,
-    pub bchar: card8,
-    pub achar: card8,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct C2RustUnnamed_3 {
-    pub llx: f64,
-    pub lly: f64,
-    pub urx: f64,
-    pub ury: f64,
-}
+use super::dpx_cs_type2::cs_ginfo;
+
 /* tectonic/core-strutils.h: miscellaneous C string utilities
    Copyright 2016-2018 the Tectonic Project
    Licensed under the MIT License.
@@ -486,24 +462,7 @@ pub unsafe extern "C" fn pdf_font_load_type1c(mut font: *mut pdf_font) -> i32 {
     let mut num_glyphs: card16 = 0;
     let mut cs_count: card16 = 0;
     let mut code: card16 = 0;
-    let mut ginfo: cs_ginfo = cs_ginfo {
-        flags: 0,
-        wx: 0.,
-        wy: 0.,
-        bbox: C2RustUnnamed_3 {
-            llx: 0.,
-            lly: 0.,
-            urx: 0.,
-            ury: 0.,
-        },
-        seac: C2RustUnnamed_2 {
-            asb: 0.,
-            adx: 0.,
-            ady: 0.,
-            bchar: 0,
-            achar: 0,
-        },
-    };
+    let mut ginfo = cs_ginfo::new();
     let mut nominal_width: f64 = 0.;
     let mut default_width: f64 = 0.;
     let mut notdef_width: f64 = 0.;

--- a/dpx/src/lib.rs
+++ b/dpx/src/lib.rs
@@ -1,6 +1,8 @@
 #![feature(extern_types)]
 #![feature(ptr_wrapping_offset_from)]
 #![feature(c_variadic)]
+#![feature(const_transmute)]
+#![allow(unused_unsafe)]
 
 extern crate tectonic_bridge as bridge;
 use bridge::*;
@@ -8,9 +10,9 @@ use bridge::*;
 #[macro_export]
 macro_rules! info(
     ($($arg:tt)*) => {
-        if !(crate::dpx_error::_dpx_quietness > 0) {
+        if !(unsafe{crate::dpx_error::_dpx_quietness} > 0) {
             print!($($arg)*);
-            crate::dpx_error::_last_message_type = crate::dpx_error::DPX_MESG_INFO;
+            unsafe{crate::dpx_error::_last_message_type = crate::dpx_error::DPX_MESG_INFO;}
         }
     };
 );
@@ -18,13 +20,13 @@ macro_rules! info(
 #[macro_export]
 macro_rules! warn(
     ($($arg:tt)*) => {
-        if !(crate::dpx_error::_dpx_quietness > 1) {
-            if crate::dpx_error::_last_message_type as u32 == crate::dpx_error::DPX_MESG_INFO as u32 {
+        if !(unsafe{crate::dpx_error::_dpx_quietness} > 1) {
+            if unsafe{crate::dpx_error::_last_message_type as u32 == crate::dpx_error::DPX_MESG_INFO as u32} {
                 println!("");
             }
             print!("warning: ");
             println!($($arg)*);
-            crate::dpx_error::_last_message_type = crate::dpx_error::DPX_MESG_WARN;
+            unsafe{crate::dpx_error::_last_message_type = crate::dpx_error::DPX_MESG_WARN;}
         }
     };
 );

--- a/dpx/src/lib.rs
+++ b/dpx/src/lib.rs
@@ -2,7 +2,13 @@
 #![feature(ptr_wrapping_offset_from)]
 #![feature(c_variadic)]
 #![feature(const_transmute)]
-#![allow(unused_unsafe)]
+#![allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_mut,
+    unused_unsafe
+)]
 
 extern crate tectonic_bridge as bridge;
 use bridge::*;

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -8,7 +8,8 @@
     non_snake_case,
     non_upper_case_globals,
     unused_assignments,
-    unused_mut
+    unused_mut,
+    unused_unsafe
 )]
 #[macro_use]
 extern crate tectonic_bridge as bridge;

--- a/engine/src/xetex_pic.rs
+++ b/engine/src/xetex_pic.rs
@@ -379,10 +379,10 @@ unsafe extern "C" fn pdf_get_rect(
     let mut page: *mut pdf_obj = 0 as *mut pdf_obj;
     let mut bbox = pdf_rect::new();
     let mut matrix = pdf_tmatrix::new();
-    let mut p1: pdf_coord = pdf_coord::new();
-    let mut p2: pdf_coord = pdf_coord::new();
-    let mut p3: pdf_coord = pdf_coord::new();
-    let mut p4: pdf_coord = pdf_coord::new();
+    let mut p1 = pdf_coord::new();
+    let mut p2 = pdf_coord::new();
+    let mut p3 = pdf_coord::new();
+    let mut p4 = pdf_coord::new();
     pf = pdf_open(filename, handle);
     if pf.is_null() {
         /* TODO: issue warning */


### PR DESCRIPTION
use `Option<CString>` for `spot_color_name` in `pdf_color` and other changes in `dpx_pdfdraw.rs`

~Note: `issue393_ungetc` test doesn't pass now. Panics on empty `gs_stack`. I think it is not my fault.~
