### PR TITLE
Change time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,17 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "chrono"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "clap"
 version = "2.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -821,6 +832,15 @@ version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "num-integer"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1465,6 +1485,7 @@ dependencies = [
 name = "tectonic_dvipdfmx"
 version = "0.0.1-dev"
 dependencies = [
+ "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "libpng-sys 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1955,6 +1976,7 @@ dependencies = [
 "checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
 "checksum cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
+"checksum chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
@@ -2029,6 +2051,7 @@ dependencies = [
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum nom 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b8c256fd9471521bcb84c3cdba98921497f1a331cbc15b8030fc63b82050ce"
+"checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"

--- a/dpx/Cargo.toml
+++ b/dpx/Cargo.toml
@@ -15,6 +15,7 @@ libz-sys = { version = "1", optional = true}
 md-5 = "0.8.0"
 sha2 = "0.8.0"
 rand = "0.7.2"
+chrono = "0.4.9"
 
 [features]
 default = ['libz-sys']

--- a/dpx/src/dpx_pdfdoc.rs
+++ b/dpx/src/dpx_pdfdoc.rs
@@ -502,13 +502,18 @@ pub unsafe extern "C" fn pdf_doc_set_eop_content(mut content: *const i8, mut len
 fn asn_date() -> String {
     use chrono::prelude::*;
 
-    let timeformat = "D:%Y%m%d%H%M%S%z";
-    let time = match get_unique_time_if_given() {
-        Some(x) => DateTime::<Utc>::from(x).format(timeformat),
-        None => Local::now().format(timeformat),
-    };
-
-    format!("{}", time)
+    let timeformat = "D:%Y%m%d%H%M%S";
+    match get_unique_time_if_given() {
+        Some(x) => {
+            let x = DateTime::<Utc>::from(x);
+            format!("{}-00'00'", x.format(timeformat))
+        }
+        None => {
+            let x = Local::now();
+            let tz = format!("{}", x.format("%s"));
+            format!("{}{}'{}'", x.format(timeformat), &tz[0..3], &tz[3..])
+        }
+    }
 }
 
 unsafe extern "C" fn pdf_doc_init_docinfo(mut p: *mut pdf_doc) {


### PR DESCRIPTION
Gets rid of gmtime/gmtime_r and other functions.

Output format is not stricly compliant with the original, but not sure whether this matters much,
"D:201909201805+01'00'" vs "D:201909201805+0100"