### PR TITLE
use Display formatter for C strings

### DIFF
--- a/dpx/src/dpx_agl.rs
+++ b/dpx/src/dpx_agl.rs
@@ -29,12 +29,14 @@
     unused_mut
 )]
 
+use crate::DisplayExt;
 use crate::{info, warn};
 use crate::{streq_ptr, strstartswith};
+use std::ffi::CStr;
 
 use super::dpx_dpxfile::dpx_tt_open;
 use super::dpx_dpxutil::{ht_append_table, ht_clear_table, ht_init_table, ht_lookup_table};
-use super::dpx_error::{dpx_message, dpx_warning};
+use super::dpx_error::dpx_warning;
 use super::dpx_mem::new;
 use super::dpx_mfileio::tt_mfgets;
 use super::dpx_pdfparse::{parse_ident, skip_white};
@@ -800,7 +802,7 @@ unsafe extern "C" fn agl_load_listfile(mut filename: *const i8, mut is_predef: i
         return -1i32;
     }
     if verbose != 0 {
-        dpx_message(b"<AGL:%s\x00" as *const u8 as *const i8, filename);
+        info!("<AGL:{}", CStr::from_ptr(filename).display());
     }
     loop {
         p = tt_mfgets(wbuf.as_mut_ptr(), 1024i32, handle);
@@ -826,9 +828,9 @@ unsafe extern "C" fn agl_load_listfile(mut filename: *const i8, mut is_predef: i
         name = parse_ident(&mut p, nextptr);
         skip_white(&mut p, endptr);
         if name.is_null() || *p.offset(0) as i32 != ';' as i32 {
-            dpx_warning(
-                b"Invalid AGL entry: %s\x00" as *const u8 as *const i8,
-                wbuf.as_mut_ptr(),
+            warn!(
+                "Invalid AGL entry: {}",
+                CStr::from_ptr(wbuf.as_ptr()).display()
             );
             free(name as *mut libc::c_void);
         } else {
@@ -851,9 +853,9 @@ unsafe extern "C" fn agl_load_listfile(mut filename: *const i8, mut is_predef: i
                 }
             }
             if n_unicodes == 0i32 {
-                dpx_warning(
-                    b"AGL entry ignored (no mapping): %s\x00" as *const u8 as *const i8,
-                    wbuf.as_mut_ptr(),
+                warn!(
+                    "AGL entry ignored (no mapping): {}",
+                    CStr::from_ptr(wbuf.as_ptr()).display(),
                 );
                 free(name as *mut libc::c_void);
             } else {
@@ -885,17 +887,17 @@ unsafe extern "C" fn agl_load_listfile(mut filename: *const i8, mut is_predef: i
                 }
                 if verbose > 3i32 {
                     if !(*agln).suffix.is_null() {
-                        dpx_message(
-                            b"agl: %s [%s.%s] -->\x00" as *const u8 as *const i8,
-                            name,
-                            (*agln).name,
-                            (*agln).suffix,
+                        info!(
+                            "agl: {} [{}.{}] -->",
+                            CStr::from_ptr(name).display(),
+                            CStr::from_ptr((*agln).name).display(),
+                            CStr::from_ptr((*agln).suffix).display(),
                         );
                     } else {
-                        dpx_message(
-                            b"agl: %s [%s] -->\x00" as *const u8 as *const i8,
-                            name,
-                            (*agln).name,
+                        info!(
+                            "agl: {} [{}] -->",
+                            CStr::from_ptr(name).display(),
+                            CStr::from_ptr((*agln).name).display(),
                         );
                     }
                     i = 0i32;
@@ -1100,9 +1102,9 @@ pub unsafe extern "C" fn agl_sput_UTF16BE(
              * Glyph names starting with a underscore or two subsequent
              * underscore in glyph name not allowed?
              */
-            dpx_warning(
-                b"Invalid glyph name component in \"%s\".\x00" as *const u8 as *const i8,
-                glyphstr,
+            warn!(
+                "Invalid glyph name component in \"{}\".",
+                CStr::from_ptr(glyphstr).display()
             );
             count += 1;
             if !fail_count.is_null() {
@@ -1147,11 +1149,11 @@ pub unsafe extern "C" fn agl_sput_UTF16BE(
                 agln0 = agl_normalized_name(name);
                 if !agln0.is_null() {
                     if verbose > 1i32 && !(*agln0).suffix.is_null() {
-                        dpx_warning(
-                            b"agl: fix %s --> %s.%s\x00" as *const u8 as *const i8,
-                            name,
-                            (*agln0).name,
-                            (*agln0).suffix,
+                        warn!(
+                            "agl: fix {} --> {}.{}",
+                            CStr::from_ptr(name).display(),
+                            CStr::from_ptr((*agln0).name).display(),
+                            CStr::from_ptr((*agln0).suffix).display(),
                         );
                     }
                     agln1 = agl_lookup_list((*agln0).name);
@@ -1170,11 +1172,10 @@ pub unsafe extern "C" fn agl_sput_UTF16BE(
                 }
             } else {
                 if verbose != 0 {
-                    dpx_warning(
-                        b"No Unicode mapping for glyph name \"%s\" found.\x00" as *const u8
-                            as *const i8,
-                        name,
-                    );
+                    warn!(
+                        "No Unicode mapping for glyph name \"{}\" found.",
+                        CStr::from_ptr(name).display()
+                    )
                 }
                 count += 1
             }
@@ -1214,9 +1215,9 @@ pub unsafe extern "C" fn agl_get_unicodes(
              * Glyph names starting with a underscore or two subsequent
              * underscore in glyph name not allowed?
              */
-            dpx_warning(
-                b"Invalid glyph name component in \"%s\".\x00" as *const u8 as *const i8,
-                glyphstr,
+            warn!(
+                "Invalid glyph name component in \"{}\".",
+                CStr::from_ptr(glyphstr).display()
             );
             return -1i32;
         /* Cannot continue */
@@ -1275,11 +1276,11 @@ pub unsafe extern "C" fn agl_get_unicodes(
                 agln0 = agl_normalized_name(name);
                 if !agln0.is_null() {
                     if verbose > 1i32 && !(*agln0).suffix.is_null() {
-                        dpx_warning(
-                            b"agl: fix %s --> %s.%s\x00" as *const u8 as *const i8,
-                            name,
-                            (*agln0).name,
-                            (*agln0).suffix,
+                        warn!(
+                            "agl: fix {} --> {}.{}",
+                            CStr::from_ptr(name).display(),
+                            CStr::from_ptr((*agln0).name).display(),
+                            CStr::from_ptr((*agln0).suffix).display(),
                         );
                     }
                     agln1 = agl_lookup_list((*agln0).name);
@@ -1300,11 +1301,10 @@ pub unsafe extern "C" fn agl_get_unicodes(
                 }
             } else {
                 if verbose > 1i32 {
-                    dpx_warning(
-                        b"No Unicode mapping for glyph name \"%s\" found.\x00" as *const u8
-                            as *const i8,
-                        name,
-                    );
+                    warn!(
+                        "No Unicode mapping for glyph name \"{}\" found.",
+                        CStr::from_ptr(name).display()
+                    )
                 }
                 free(name as *mut libc::c_void);
                 return -1i32;

--- a/dpx/src/dpx_bmpimage.rs
+++ b/dpx/src/dpx_bmpimage.rs
@@ -29,7 +29,6 @@
     unused_mut
 )]
 
-use super::dpx_error::dpx_warning;
 use super::dpx_mem::new;
 use super::dpx_numbers::tt_get_unsigned_byte;
 use super::dpx_pdfximage::{pdf_ximage_init_image_info, pdf_ximage_set_image};
@@ -177,10 +176,7 @@ pub unsafe extern "C" fn bmp_include_image(
             && hdr.bit_count as i32 != 4i32
             && hdr.bit_count as i32 != 8i32
         {
-            dpx_warning(
-                b"Unsupported palette size: %hu\x00" as *const u8 as *const i8,
-                hdr.bit_count as i32,
-            );
+            warn!("Unsupported palette size: {}", hdr.bit_count as i32,);
             return -1i32;
         }
         num_palette = hdr
@@ -196,8 +192,8 @@ pub unsafe extern "C" fn bmp_include_image(
         info.bits_per_component = 8i32;
         info.num_components = 3i32
     } else {
-        dpx_warning(
-            b"Unkown/Unsupported BMP bitCount value: %hu\x00" as *const u8 as *const i8,
+        warn!(
+            "Unkown/Unsupported BMP bitCount value: {}",
             hdr.bit_count as i32,
         );
         return -1i32;

--- a/dpx/src/dpx_cff.rs
+++ b/dpx/src/dpx_cff.rs
@@ -33,7 +33,6 @@ use crate::streq_ptr;
 use crate::warn;
 
 use super::dpx_cff_dict::{cff_dict_get, cff_dict_known, cff_dict_unpack, cff_release_dict};
-use super::dpx_error::dpx_warning;
 use super::dpx_mem::{new, renew};
 use super::dpx_numbers::{tt_get_unsigned_byte, tt_get_unsigned_pair};
 use crate::{ttstub_input_read, ttstub_input_seek};
@@ -118,7 +117,6 @@ impl Pack for CffIndex {
     fn pack(&mut self, mut dest: &mut [u8]) -> usize {
         let destlen = dest.len();
         let mut datalen: size_t = 0;
-        let mut i: u16 = 0;
         if self.count < 1 {
             if destlen < 2 {
                 panic!("Not enough space available...");
@@ -759,9 +757,9 @@ pub unsafe extern "C" fn cff_open(
         panic!("invalid offsize data");
     }
     if (*cff).header.major as i32 > 1i32 || (*cff).header.minor as i32 > 0i32 {
-        dpx_warning(
-            b"%s: CFF version %u.%u not supported.\x00" as *const u8 as *const i8,
-            b"CFF\x00" as *const u8 as *const i8,
+        warn!(
+            "{}: CFF version {}.{} not supported.",
+            "CFF",
             (*cff).header.major as i32,
             (*cff).header.minor as i32,
         );
@@ -1543,7 +1541,6 @@ pub unsafe extern "C" fn cff_read_encoding(cff: &mut cff_font) -> i32 {
 }
 #[no_mangle]
 pub unsafe extern "C" fn cff_pack_encoding(cff: &cff_font, dest: &mut [u8]) -> usize {
-    let destlen = dest.len();
     let mut len = 0_usize;
     if cff.flag & (1i32 << 3i32 | 1i32 << 4i32) != 0 || cff.encoding.is_null() {
         return 0;
@@ -1795,7 +1792,6 @@ pub unsafe extern "C" fn cff_read_charsets(cff: &mut cff_font) -> i32 {
 pub unsafe extern "C" fn cff_pack_charsets(cff: &cff_font, dest: &mut [u8]) -> usize {
     let destlen = dest.len();
     let mut len = 0;
-    let mut i: u16 = 0;
     let mut charset: *mut cff_charsets = 0 as *mut cff_charsets;
     if cff.flag & (1 << 5 | 1 << 6 | 1 << 7) != 0 || cff.charsets.is_null() {
         return 0;
@@ -2170,9 +2166,7 @@ pub unsafe extern "C" fn cff_read_fdselect(cff: &mut cff_font) -> i32 {
 }
 #[no_mangle]
 pub unsafe extern "C" fn cff_pack_fdselect(cff: &cff_font, dest: &mut [u8]) -> usize {
-    let destlen = dest.len();
     let mut len = 0;
-    let mut i: u16 = 0;
     if cff.fdselect.is_null() {
         return 0;
     }

--- a/dpx/src/dpx_cff_dict.rs
+++ b/dpx/src/dpx_cff_dict.rs
@@ -29,6 +29,9 @@
     unused_mut
 )]
 
+use crate::DisplayExt;
+use std::ffi::CStr;
+
 use super::dpx_cff::{cff_add_string, cff_get_string};
 use super::dpx_mem::{new, renew};
 use super::dpx_mfileio::work_buffer;
@@ -36,7 +39,6 @@ use crate::mfree;
 use crate::streq_ptr;
 use crate::stub_errno as errno;
 use crate::warn;
-use bridge::_tt_abort;
 use libc::{free, memset, sprintf, strcmp, strtod};
 
 pub type rust_input_handle_t = *mut libc::c_void;
@@ -885,7 +887,6 @@ unsafe extern "C" fn cff_dict_put_number(
 }
 unsafe extern "C" fn put_dict_entry(mut de: *mut cff_dict_entry, dest: &mut [u8]) -> usize {
     let mut len = 0_usize;
-    let mut i: i32 = 0;
     let mut type_0: i32 = 0;
     let mut id: i32 = 0;
     if (*de).count > 0i32 {
@@ -1048,10 +1049,10 @@ pub unsafe extern "C" fn cff_dict_get(
         }
     }
     if i == (*dict).count {
-        _tt_abort(
-            b"%s: DICT entry \"%s\" not found.\x00" as *const u8 as *const i8,
-            b"CFF\x00" as *const u8 as *const i8,
-            key,
+        panic!(
+            "{}: DICT entry \"{}\" not found.",
+            "CFF",
+            CStr::from_ptr(key).display(),
         );
     }
     value
@@ -1081,10 +1082,10 @@ pub unsafe extern "C" fn cff_dict_set(
         }
     }
     if i == (*dict).count {
-        _tt_abort(
-            b"%s: DICT entry \"%s\" not found.\x00" as *const u8 as *const i8,
-            b"CFF\x00" as *const u8 as *const i8,
-            key,
+        panic!(
+            "{}: DICT entry \"{}\" not found.",
+            "CFF",
+            CStr::from_ptr(key).display(),
         );
     };
 }

--- a/dpx/src/dpx_cmap_read.rs
+++ b/dpx/src/dpx_cmap_read.rs
@@ -38,7 +38,6 @@ use super::dpx_cmap::{
     CMap_cache_get, CMap_is_valid, CMap_set_CIDSysInfo, CMap_set_name, CMap_set_type,
     CMap_set_usecmap, CMap_set_wmode,
 };
-use super::dpx_error::dpx_message;
 use super::dpx_mem::{new, renew};
 use super::dpx_pst::pst_get_token;
 use super::dpx_pst_obj::pst_obj;
@@ -104,10 +103,7 @@ unsafe extern "C" fn ifreader_read(mut reader: *mut ifreader, mut size: size_t) 
     bytesrem = ((*reader).endptr as size_t).wrapping_sub((*reader).cursor as size_t);
     if size > (*reader).max {
         if __verbose != 0 {
-            dpx_message(
-                b"\nExtending buffer (%zu bytes)...\n\x00" as *const u8 as *const i8,
-                size,
-            );
+            info!("\nExtending buffer ({} bytes)...\n", size,);
         }
         (*reader).buf = renew(
             (*reader).buf as *mut libc::c_void,

--- a/dpx/src/dpx_cmap_write.rs
+++ b/dpx/src/dpx_cmap_write.rs
@@ -38,7 +38,6 @@ use crate::dpx_pdfobj::{
     pdf_add_dict, pdf_add_stream, pdf_copy_name, pdf_new_dict, pdf_new_name, pdf_new_number,
     pdf_new_stream, pdf_new_string, pdf_obj, pdf_stream_dict,
 };
-use bridge::_tt_abort;
 use libc::{free, memcmp, memset, sprintf, strlen};
 
 pub type size_t = u64;
@@ -228,10 +227,7 @@ unsafe extern "C" fn write_map(
         if count >= 100i32 as u64 || (*wbuf).curptr >= (*wbuf).limptr {
             let mut fmt_buf: [i8; 32] = [0; 32];
             if count > 100i32 as u64 {
-                _tt_abort(
-                    b"Unexpected error....: %zu\x00" as *const u8 as *const i8,
-                    count,
-                );
+                panic!("Unexpected error....: {}", count,);
             }
             sprintf(
                 fmt_buf.as_mut_ptr(),
@@ -585,10 +581,7 @@ pub unsafe extern "C" fn CMap_create_stream(mut cmap: *mut CMap) -> *mut pdf_obj
             /* Flush */
             let mut fmt_buf: [i8; 32] = [0; 32];
             if count > 100i32 as u64 {
-                _tt_abort(
-                    b"Unexpected error....: %zu\x00" as *const u8 as *const i8,
-                    count,
-                );
+                panic!("Unexpected error....: {}", count,);
             }
             sprintf(
                 fmt_buf.as_mut_ptr(),

--- a/dpx/src/dpx_error.rs
+++ b/dpx/src/dpx_error.rs
@@ -47,7 +47,7 @@ pub unsafe extern "C" fn shut_up(mut quietness: i32) {
 static mut _dpx_message_handle: rust_output_handle_t =
     0 as *const libc::c_void as *mut libc::c_void;
 static mut _dpx_message_buf: [i8; 1024] = [0; 1024];
-unsafe extern "C" fn _dpx_ensure_output_handle() -> rust_output_handle_t {
+pub unsafe extern "C" fn _dpx_ensure_output_handle() -> rust_output_handle_t {
     _dpx_message_handle = ttstub_output_open_stdout();
     if _dpx_message_handle.is_null() {
         panic!("xdvipdfmx cannot get output logging handle?!");

--- a/dpx/src/dpx_fontmap.rs
+++ b/dpx/src/dpx_fontmap.rs
@@ -29,6 +29,9 @@
     unused_mut
 )]
 
+use crate::DisplayExt;
+use std::ffi::CStr;
+
 use super::dpx_mfileio::work_buffer;
 use crate::mfree;
 use crate::{info, warn};
@@ -39,12 +42,11 @@ use super::dpx_dpxutil::{
     ht_clear_table, ht_init_table, ht_insert_table, ht_lookup_table, ht_remove_table,
 };
 use super::dpx_dpxutil::{parse_c_string, parse_float_decimal};
-use super::dpx_error::{dpx_message, dpx_warning};
+use super::dpx_error::dpx_warning;
 use super::dpx_mem::{new, xmalloc};
 use super::dpx_mfileio::tt_mfgets;
 use super::dpx_subfont::{release_sfd_record, sfd_get_subfont_ids};
 use crate::ttstub_input_close;
-use bridge::_tt_abort;
 use libc::{
     atof, atoi, free, memcmp, memcpy, sprintf, strcat, strchr, strcmp, strcpy, strlen, strstr,
     strtol, strtoul,
@@ -451,9 +453,9 @@ unsafe extern "C" fn fontmap_parse_mapdef_dpm(
                 }
                 (*mrec).opt.extend = atof(q);
                 if (*mrec).opt.extend <= 0.0f64 {
-                    dpx_warning(
-                        b"Invalid value for \'e\' option: %s\x00" as *const u8 as *const i8,
-                        q,
+                    warn!(
+                        "Invalid value for \'e\' option: {}",
+                        CStr::from_ptr(q).display(),
                     );
                     return -1i32;
                 }
@@ -468,9 +470,9 @@ unsafe extern "C" fn fontmap_parse_mapdef_dpm(
                 }
                 (*mrec).opt.bold = atof(q);
                 if (*mrec).opt.bold <= 0.0f64 {
-                    dpx_warning(
-                        b"Invalid value for \'b\' option: %s\x00" as *const u8 as *const i8,
-                        q,
+                    warn!(
+                        "Invalid value for \'b\' option: {}",
+                        CStr::from_ptr(q).display(),
                     );
                     return -1i32;
                 }
@@ -486,10 +488,7 @@ unsafe extern "C" fn fontmap_parse_mapdef_dpm(
                 }
                 (*mrec).opt.index = atoi(q);
                 if (*mrec).opt.index < 0i32 {
-                    dpx_warning(
-                        b"Invalid TTC index number: %s\x00" as *const u8 as *const i8,
-                        q,
-                    );
+                    warn!("Invalid TTC index number: {}", CStr::from_ptr(q).display(),);
                     return -1i32;
                 }
                 free(q as *mut libc::c_void);
@@ -503,9 +502,9 @@ unsafe extern "C" fn fontmap_parse_mapdef_dpm(
                 }
                 v = strtol(q, 0 as *mut *mut i8, 0i32) as i32;
                 if v < 0i32 || v > 16i32 {
-                    dpx_warning(
-                        b"Invalid value for option \'p\': %s\x00" as *const u8 as *const i8,
-                        q,
+                    warn!(
+                        "Invalid value for option \'p\': {}",
+                        CStr::from_ptr(q).display(),
                     );
                 } else {
                     (*mrec).opt.mapc = v << 16i32
@@ -558,9 +557,9 @@ unsafe extern "C" fn fontmap_parse_mapdef_dpm(
                         return -1i32;
                     } else {
                         if p < endptr && *p as i32 != '>' as i32 {
-                            dpx_warning(
-                                b"Invalid value for option \'m\': %s\x00" as *const u8 as *const i8,
-                                q,
+                            warn!(
+                                "Invalid value for option \'m\': {}",
+                                CStr::from_ptr(q).display(),
                             );
                             free(q as *mut libc::c_void);
                             return -1i32;
@@ -589,9 +588,9 @@ unsafe extern "C" fn fontmap_parse_mapdef_dpm(
                     }
                     r = strchr(q, ',' as i32);
                     if r.is_null() {
-                        dpx_warning(
-                            b"Invalid value for option \'m\': %s\x00" as *const u8 as *const i8,
-                            q,
+                        warn!(
+                            "Invalid value for option \'m\': {}",
+                            CStr::from_ptr(q).display(),
                         );
                         free(q as *mut libc::c_void);
                         return -1i32;
@@ -601,9 +600,9 @@ unsafe extern "C" fn fontmap_parse_mapdef_dpm(
                     rr = r;
                     skip_blank(&mut rr, r.offset(strlen(r) as isize));
                     if *rr as i32 == '\u{0}' as i32 {
-                        dpx_warning(
-                            b"Invalid value for option \'m\': %s,\x00" as *const u8 as *const i8,
-                            q,
+                        warn!(
+                            "Invalid value for option \'m\': {},",
+                            CStr::from_ptr(q).display()
                         );
                         free(q as *mut libc::c_void);
                         return -1i32;
@@ -626,9 +625,9 @@ unsafe extern "C" fn fontmap_parse_mapdef_dpm(
                         return -1i32;
                     } else {
                         if p < endptr && libc::isspace(*p as _) == 0 {
-                            dpx_warning(
-                                b"Invalid value for option \'m\': %s\x00" as *const u8 as *const i8,
-                                q,
+                            warn!(
+                                "Invalid value for option \'m\': {}",
+                                CStr::from_ptr(q).display(),
                             );
                             free(q as *mut libc::c_void);
                             return -1i32;
@@ -660,9 +659,9 @@ unsafe extern "C" fn fontmap_parse_mapdef_dpm(
                 } else if atoi(q) == 0i32 {
                     (*mrec).opt.flags &= !(1i32 << 2i32)
                 } else {
-                    dpx_warning(
-                        b"Invalid value for option \'w\': %s\x00" as *const u8 as *const i8,
-                        q,
+                    warn!(
+                        "Invalid value for option \'w\': {}",
+                        CStr::from_ptr(q).display(),
                     );
                 }
                 free(q as *mut libc::c_void);
@@ -781,10 +780,7 @@ unsafe extern "C" fn fontmap_parse_mapdef_dps(
                 skip_blank(&mut p, endptr);
             }
             _ => {
-                dpx_warning(
-                    b"Found an invalid entry: %s\x00" as *const u8 as *const i8,
-                    p,
-                );
+                warn!("Found an invalid entry: {}", CStr::from_ptr(p).display(),);
                 return -1i32;
             }
         }
@@ -910,9 +906,9 @@ pub unsafe extern "C" fn pdf_append_fontmap_record(
         return -1i32;
     }
     if verbose > 3i32 {
-        dpx_message(
-            b"fontmap>> append key=\"%s\"...\x00" as *const u8 as *const i8,
-            kp,
+        info!(
+            "fontmap>> append key=\"{}\"...",
+            CStr::from_ptr(kp).display()
         );
     }
     fnt_name = chop_sfd_name(kp, &mut sfd_name);
@@ -987,9 +983,9 @@ pub unsafe extern "C" fn pdf_remove_fontmap_record(mut kp: *const i8) -> i32 {
         return -1i32;
     }
     if verbose > 3i32 {
-        dpx_message(
-            b"fontmap>> remove key=\"%s\"...\x00" as *const u8 as *const i8,
-            kp,
+        info!(
+            "fontmap>> remove key=\"{}\"...",
+            CStr::from_ptr(kp).display()
         );
     }
     fnt_name = chop_sfd_name(kp, &mut sfd_name);
@@ -1002,9 +998,9 @@ pub unsafe extern "C" fn pdf_remove_fontmap_record(mut kp: *const i8) -> i32 {
             return -1i32;
         }
         if verbose > 3i32 {
-            dpx_message(
-                b"\nfontmap>> Expand @%s@:\x00" as *const u8 as *const i8,
-                sfd_name,
+            info!(
+                "\nfontmap>> Expand @{}@:",
+                CStr::from_ptr(sfd_name).display()
             );
         }
         loop {
@@ -1018,7 +1014,7 @@ pub unsafe extern "C" fn pdf_remove_fontmap_record(mut kp: *const i8) -> i32 {
                 continue;
             }
             if verbose > 3i32 {
-                dpx_message(b" %s\x00" as *const u8 as *const i8, tfm_name);
+                info!(" {}", CStr::from_ptr(tfm_name).display());
             }
             ht_remove_table(
                 fontmap,
@@ -1049,9 +1045,9 @@ pub unsafe extern "C" fn pdf_insert_fontmap_record(
         return 0 as *mut fontmap_rec;
     }
     if verbose > 3i32 {
-        dpx_message(
-            b"fontmap>> insert key=\"%s\"...\x00" as *const u8 as *const i8,
-            kp,
+        info!(
+            "fontmap>> insert key=\"{}\"...",
+            CStr::from_ptr(kp).display()
         );
     }
     fnt_name = chop_sfd_name(kp, &mut sfd_name);
@@ -1061,18 +1057,18 @@ pub unsafe extern "C" fn pdf_insert_fontmap_record(
         let mut n: i32 = 0i32;
         subfont_ids = sfd_get_subfont_ids(sfd_name, &mut n);
         if subfont_ids.is_null() {
-            dpx_warning(
-                b"Could not open SFD file: %s\x00" as *const u8 as *const i8,
-                sfd_name,
+            warn!(
+                "Could not open SFD file: {}",
+                CStr::from_ptr(sfd_name).display(),
             );
             free(fnt_name as *mut libc::c_void);
             free(sfd_name as *mut libc::c_void);
             return 0 as *mut fontmap_rec;
         }
         if verbose > 3i32 {
-            dpx_message(
-                b"\nfontmap>> Expand @%s@:\x00" as *const u8 as *const i8,
-                sfd_name,
+            info!(
+                "\nfontmap>> Expand @{}@:",
+                CStr::from_ptr(sfd_name).display()
             );
         }
         loop {
@@ -1086,7 +1082,7 @@ pub unsafe extern "C" fn pdf_insert_fontmap_record(
                 continue;
             }
             if verbose > 3i32 {
-                dpx_message(b" %s\x00" as *const u8 as *const i8, tfm_name);
+                info!(" {}", CStr::from_ptr(tfm_name).display());
             }
             mrec = new((1_u64).wrapping_mul(::std::mem::size_of::<fontmap_rec>() as u64) as u32)
                 as *mut fontmap_rec;
@@ -1233,9 +1229,9 @@ pub unsafe extern "C" fn pdf_load_fontmap_file(mut filename: *const i8, mut mode
         TTInputFormat::FONTMAP,
     );
     if handle.is_null() {
-        dpx_warning(
-            b"Couldn\'t open font map file \"%s\".\x00" as *const u8 as *const i8,
-            filename,
+        warn!(
+            "Couldn\'t open font map file \"{}\".",
+            CStr::from_ptr(filename).display()
         );
         return -1i32;
     }
@@ -1254,14 +1250,14 @@ pub unsafe extern "C" fn pdf_load_fontmap_file(mut filename: *const i8, mut mode
         m = is_pdfm_mapline(p);
         if format * m < 0i32 {
             /* mismatch */
-            dpx_warning(
-                b"Found a mismatched fontmap line %d from %s.\x00" as *const u8 as *const i8,
+            warn!(
+                "Found a mismatched fontmap line {} from {}.",
                 lpos,
-                filename,
+                CStr::from_ptr(filename).display(),
             );
-            dpx_warning(
-                b"-- Ignore the current input buffer: %s\x00" as *const u8 as *const i8,
-                p,
+            warn!(
+                "-- Ignore the current input buffer: {}",
+                CStr::from_ptr(p).display(),
             );
         } else {
             format += m;
@@ -1271,14 +1267,14 @@ pub unsafe extern "C" fn pdf_load_fontmap_file(mut filename: *const i8, mut mode
             /* format > 0: DVIPDFM, format <= 0: DVIPS/pdfTeX */
             error = pdf_read_fontmap_line(mrec, p, llen, format); // CHECK
             if error != 0 {
-                dpx_warning(
-                    b"Invalid map record in fontmap line %d from %s.\x00" as *const u8 as *const i8,
+                warn!(
+                    "Invalid map record in fontmap line {} from {}.",
                     lpos,
-                    filename,
+                    CStr::from_ptr(filename).display(),
                 );
-                dpx_warning(
-                    b"-- Ignore the current input buffer: %s\x00" as *const u8 as *const i8,
-                    p,
+                warn!(
+                    "-- Ignore the current input buffer: {}",
+                    CStr::from_ptr(p).display(),
                 );
                 pdf_clear_fontmap_record(mrec);
                 free(mrec as *mut libc::c_void);
@@ -1335,10 +1331,7 @@ pub unsafe extern "C" fn pdf_insert_native_fontmap_record(
         embolden,
     );
     if verbose != 0 {
-        dpx_message(
-            b"<NATIVE-FONTMAP:%s\x00" as *const u8 as *const i8,
-            fontmap_key,
-        );
+        info!("<NATIVE-FONTMAP:{}", CStr::from_ptr(fontmap_key).display(),);
     }
     mrec = new((1_u64).wrapping_mul(::std::mem::size_of::<fontmap_rec>() as u64) as u32)
         as *mut fontmap_rec;
@@ -1462,10 +1455,10 @@ unsafe extern "C" fn strip_options(mut map_name: *const i8, mut opt: *mut fontma
         /* no-embedding */
         p = p.offset(1);
         if *p as i32 == '\u{0}' as i32 {
-            _tt_abort(
-                b"Invalid map record: %s (--> %s)\x00" as *const u8 as *const i8,
-                map_name,
-                p,
+            panic!(
+                "Invalid map record: {} (--> {})",
+                CStr::from_ptr(map_name).display(),
+                CStr::from_ptr(p).display(),
             );
         }
         (*opt).flags |= 1i32 << 1i32
@@ -1473,10 +1466,10 @@ unsafe extern "C" fn strip_options(mut map_name: *const i8, mut opt: *mut fontma
     next = strchr(p, '/' as i32);
     if !next.is_null() {
         if next == p as *mut i8 {
-            _tt_abort(
-                b"Invalid map record: %s (--> %s)\x00" as *const u8 as *const i8,
-                map_name,
-                p,
+            panic!(
+                "Invalid map record: {} (--> {})",
+                CStr::from_ptr(map_name).display(),
+                CStr::from_ptr(p).display(),
             );
         }
         font_name = substr(&mut p, '/' as i32 as i8);
@@ -1485,10 +1478,10 @@ unsafe extern "C" fn strip_options(mut map_name: *const i8, mut opt: *mut fontma
         next = strchr(p, ',' as i32);
         if !next.is_null() {
             if next == p as *mut i8 {
-                _tt_abort(
-                    b"Invalid map record: %s (--> %s)\x00" as *const u8 as *const i8,
-                    map_name,
-                    p,
+                panic!(
+                    "Invalid map record: {} (--> {})",
+                    CStr::from_ptr(map_name).display(),
+                    CStr::from_ptr(p).display(),
                 );
             }
             font_name = substr(&mut p, ',' as i32 as i8);
@@ -1506,9 +1499,9 @@ unsafe extern "C" fn strip_options(mut map_name: *const i8, mut opt: *mut fontma
             (*opt).charcoll = substr(&mut p, ',' as i32 as i8);
             have_style = 1i32
         } else if *p.offset(0) as i32 == '\u{0}' as i32 {
-            _tt_abort(
-                b"Invalid map record: %s.\x00" as *const u8 as *const i8,
-                map_name,
+            panic!(
+                "Invalid map record: {}.",
+                CStr::from_ptr(map_name).display()
             );
         } else {
             (*opt).charcoll =
@@ -1520,28 +1513,28 @@ unsafe extern "C" fn strip_options(mut map_name: *const i8, mut opt: *mut fontma
     if have_style != 0 {
         if !strstartswith(p, b"BoldItalic\x00" as *const u8 as *const i8).is_null() {
             if *p.offset(10) != 0 {
-                _tt_abort(
-                    b"Invalid map record: %s (--> %s)\x00" as *const u8 as *const i8,
-                    map_name,
-                    p,
+                panic!(
+                    "Invalid map record: {} (--> {})",
+                    CStr::from_ptr(map_name).display(),
+                    CStr::from_ptr(p).display(),
                 );
             }
             (*opt).style = 3i32
         } else if !strstartswith(p, b"Bold\x00" as *const u8 as *const i8).is_null() {
             if *p.offset(4) != 0 {
-                _tt_abort(
-                    b"Invalid map record: %s (--> %s)\x00" as *const u8 as *const i8,
-                    map_name,
-                    p,
+                panic!(
+                    "Invalid map record: {} (--> {})",
+                    CStr::from_ptr(map_name).display(),
+                    CStr::from_ptr(p).display(),
                 );
             }
             (*opt).style = 1i32
         } else if !strstartswith(p, b"Italic\x00" as *const u8 as *const i8).is_null() {
             if *p.offset(6) != 0 {
-                _tt_abort(
-                    b"Invalid map record: %s (--> %s)\x00" as *const u8 as *const i8,
-                    map_name,
-                    p,
+                panic!(
+                    "Invalid map record: {} (--> {})",
+                    CStr::from_ptr(map_name).display(),
+                    CStr::from_ptr(p).display(),
                 );
             }
             (*opt).style = 2i32

--- a/dpx/src/dpx_numbers.rs
+++ b/dpx/src/dpx_numbers.rs
@@ -30,8 +30,9 @@
 )]
 
 use crate::ttstub_input_getc;
-use bridge::_tt_abort;
+use crate::DisplayExt;
 use libc::{fgetc, FILE};
+use std::ffi::CStr;
 
 pub type __off_t = i64;
 pub type __off64_t = i64;
@@ -177,10 +178,10 @@ pub unsafe extern "C" fn get_positive_quad(
 ) -> u32 {
     let mut val: i32 = get_signed_quad(file);
     if val < 0i32 {
-        _tt_abort(
-            b"Bad %s: negative %s: %d\x00" as *const u8 as *const i8,
-            type_0,
-            name,
+        panic!(
+            "Bad {}: negative {}: {}",
+            CStr::from_ptr(type_0).display(),
+            CStr::from_ptr(name).display(),
             val,
         );
     }
@@ -365,10 +366,10 @@ pub unsafe extern "C" fn tt_get_positive_quad(
 ) -> u32 {
     let mut val: i32 = tt_get_signed_quad(handle);
     if val < 0i32 {
-        _tt_abort(
-            b"Bad %s: negative %s: %d\x00" as *const u8 as *const i8,
-            type_0,
-            name,
+        panic!(
+            "Bad {}: negative {}: {}",
+            CStr::from_ptr(type_0).display(),
+            CStr::from_ptr(name).display(),
             val,
         );
     }

--- a/dpx/src/dpx_otl_opt.rs
+++ b/dpx/src/dpx_otl_opt.rs
@@ -30,6 +30,8 @@
 )]
 
 use crate::warn;
+use crate::DisplayExt;
+use std::ffi::CStr;
 
 use super::dpx_error::dpx_warning;
 use super::dpx_mem::new;
@@ -128,7 +130,7 @@ unsafe extern "C" fn parse_expr(mut pp: *mut *const i8, mut endptr: *const i8) -
                     let mut expr: *mut bt_node = 0 as *mut bt_node;
                     expr = parse_expr(pp, endptr);
                     if expr.is_null() {
-                        dpx_warning(b"Syntax error: %s\n\x00" as *const u8 as *const i8, *pp);
+                        warn!("Syntax error: {}\n", CStr::from_ptr(*pp).display());
                         return 0 as *mut bt_node;
                     }
                     if **pp as i32 != ')' as i32 {
@@ -153,7 +155,7 @@ unsafe extern "C" fn parse_expr(mut pp: *mut *const i8, mut endptr: *const i8) -
             41 => return root,
             124 | 38 => {
                 if *pp >= endptr {
-                    dpx_warning(b"Syntax error: %s\n\x00" as *const u8 as *const i8, *pp);
+                    warn!("Syntax error: {}\n", CStr::from_ptr(*pp).display());
                     bt_release_tree(root);
                     return 0 as *mut bt_node;
                 } else {
@@ -204,7 +206,7 @@ unsafe extern "C" fn parse_expr(mut pp: *mut *const i8, mut endptr: *const i8) -
                         i += 1
                     }
                 } else {
-                    dpx_warning(b"Syntax error: %s\n\x00" as *const u8 as *const i8, *pp);
+                    warn!("Syntax error: {}\n", CStr::from_ptr(*pp).display());
                     bt_release_tree(root);
                     return 0 as *mut bt_node;
                 }

--- a/dpx/src/dpx_pdfcolor.rs
+++ b/dpx/src/dpx_pdfcolor.rs
@@ -29,6 +29,8 @@
     unused_mut
 )]
 
+use crate::DisplayExt;
+
 use super::dpx_error::{dpx_message, dpx_warning};
 use super::dpx_mem::{new, renew};
 use super::dpx_numbers::sget_unsigned_pair;
@@ -1027,19 +1029,13 @@ unsafe extern "C" fn print_iccp_header(icch: &mut iccHeader, mut checksum: *mut 
     }
     info!("\n");
     if icch.creator == 0_u32 {
-        dpx_message(
-            b"pdf_color>> %s:\t(null)\n\x00" as *const u8 as *const i8,
-            b"Creator\x00" as *const u8 as *const i8,
-        );
+        info!("pdf_color>> {}:\t(null)\n", "Creator",);
     } else if libc::isprint((icch.creator >> 24i32 & 0xff_u32) as _) == 0
         || libc::isprint((icch.creator >> 16i32 & 0xff_u32) as _) == 0
         || libc::isprint((icch.creator >> 8i32 & 0xff_u32) as _) == 0
         || libc::isprint((icch.creator & 0xff_u32) as _) == 0
     {
-        dpx_message(
-            b"pdf_color>> %s:\t(invalid)\n\x00" as *const u8 as *const i8,
-            b"Creator\x00" as *const u8 as *const i8,
-        );
+        info!("pdf_color>> {}:\t(invalid)\n", "Creator",);
     } else {
         dpx_message(
             b"pdf_color>> %s:\t%c%c%c%c\n\x00" as *const u8 as *const i8,
@@ -1117,9 +1113,9 @@ pub unsafe extern "C" fn iccp_load_profile(
     iccp_init_iccHeader(&mut icch);
     if iccp_unpack_header(&mut icch, profile, proflen, 1i32) < 0i32 {
         /* check size */
-        dpx_warning(
-            b"Invalid ICC profile header in \"%s\"\x00" as *const u8 as *const i8,
-            ident,
+        warn!(
+            "Invalid ICC profile header in \"{}\"",
+            CStr::from_ptr(ident).display()
         );
         print_iccp_header(&mut icch, 0 as *mut u8);
         return -1i32;
@@ -1307,7 +1303,7 @@ unsafe extern "C" fn pdf_colorspace_defineresource(
     (*colorspace).cdata = cdata;
     (*colorspace).resource = resource;
     if verbose != 0 {
-        dpx_message(b"(ColorSpace:%s\x00" as *const u8 as *const i8, ident);
+        info!("(ColorSpace:{}", CStr::from_ptr(ident).display());
         if verbose > 1i32 {
             match subtype {
                 4 => {

--- a/dpx/src/dpx_pdfdraw.rs
+++ b/dpx/src/dpx_pdfdraw.rs
@@ -657,8 +657,6 @@ unsafe extern "C" fn pdf_dev__flushpath(
     let mut n_seg: i32 = 0; /* default to 1 in PDF */
     let mut len: i32 = 0i32;
     let mut isrect: i32 = 0;
-    let mut i: i32 = 0;
-    let mut j: i32 = 0;
     assert!(b"fFsSbBW ".contains(&(opchr as u8)));
     let isclip = if opchr == b'W' as i8 { true } else { false };
     if

--- a/dpx/src/dpx_pdfparse.rs
+++ b/dpx/src/dpx_pdfparse.rs
@@ -30,10 +30,12 @@
 )]
 
 use crate::strstartswith;
+use crate::DisplayExt;
 use crate::{info, warn};
+use std::ffi::CStr;
 
 use super::dpx_dpxutil::xtoi;
-use super::dpx_error::{dpx_message, dpx_warning};
+use super::dpx_error::dpx_message;
 use super::dpx_mem::new;
 use crate::dpx_pdfobj::{
     pdf_add_array, pdf_add_dict, pdf_add_stream, pdf_copy_name, pdf_deref_obj, pdf_file,
@@ -892,9 +894,9 @@ unsafe extern "C" fn parse_pdf_reference(
     if !name.is_null() {
         result = spc_lookup_reference(name);
         if result.is_null() {
-            dpx_warning(
-                b"Could not find the named reference (@%s).\x00" as *const u8 as *const i8,
-                name,
+            warn!(
+                "Could not find the named reference (@{}).",
+                CStr::from_ptr(name).display(),
             );
             dump(save, end);
             *start = save

--- a/dpx/src/dpx_pdfximage.rs
+++ b/dpx/src/dpx_pdfximage.rs
@@ -30,13 +30,14 @@
 )]
 
 use crate::mfree;
+use crate::DisplayExt;
 use crate::{info, warn};
 use crate::{streq_ptr, strstartswith};
+use std::ffi::CStr;
 
 use super::dpx_bmpimage::{bmp_include_image, check_for_bmp};
 use super::dpx_dpxfile::{dpx_delete_temp_file, keep_cache};
 use super::dpx_dpxutil::{max4, min4};
-use super::dpx_error::{dpx_message, dpx_warning};
 use super::dpx_jpegimage::{check_for_jpeg, jpeg_include_image};
 use super::dpx_mem::{new, renew};
 use super::dpx_mfileio::{tt_mfgets, work_buffer};
@@ -205,10 +206,9 @@ pub unsafe extern "C" fn pdf_close_images() {
                  * pages are imported from that file.
                  */
                 if _opts.verbose > 1i32 && keep_cache != 1i32 {
-                    dpx_message(
-                        b"pdf_image>> deleting temporary file \"%s\"\n\x00" as *const u8
-                            as *const i8,
-                        (*I).filename,
+                    info!(
+                        "pdf_image>> deleting temporary file \"{}\"\n",
+                        CStr::from_ptr((*I).filename).display()
                     ); /* temporary filename freed here */
                 }
                 dpx_delete_temp_file((*I).filename, 0i32);
@@ -428,14 +428,14 @@ pub unsafe extern "C" fn pdf_ximage_findresource(
      */
     handle = ttstub_input_open(ident, TTInputFormat::PICT, 0i32);
     if handle.is_null() {
-        dpx_warning(
-            b"Error locating image file \"%s\"\x00" as *const u8 as *const i8,
-            ident,
+        warn!(
+            "Error locating image file \"{}\"",
+            CStr::from_ptr(ident).display(),
         );
         return -1i32;
     }
     if _opts.verbose != 0 {
-        dpx_message(b"(Image:%s\x00" as *const u8 as *const i8, ident);
+        info!("(Image:{}", CStr::from_ptr(ident).display());
     }
     format = source_image_type(handle);
     id = load_image(ident, ident, format, handle, options);
@@ -444,9 +444,9 @@ pub unsafe extern "C" fn pdf_ximage_findresource(
         info!(")");
     }
     if id < 0i32 {
-        dpx_warning(
-            b"pdf: image inclusion failed for \"%s\".\x00" as *const u8 as *const i8,
-            ident,
+        warn!(
+            "pdf: image inclusion failed for \"{}\".",
+            CStr::from_ptr(ident).display(),
         );
     }
     id

--- a/dpx/src/dpx_tfm.rs
+++ b/dpx/src/dpx_tfm.rs
@@ -35,13 +35,13 @@ use super::dpx_numbers::{
 };
 use crate::mfree;
 use crate::streq_ptr;
+use crate::DisplayExt;
 use crate::{info, warn};
+use std::ffi::CStr;
 
-use super::dpx_error::dpx_message;
 use super::dpx_mem::{new, renew};
 use super::dpx_numbers::tt_skip_bytes;
 use crate::{ttstub_input_close, ttstub_input_get_size, ttstub_input_open, ttstub_input_seek};
-use bridge::_tt_abort;
 use libc::{free, strcat, strcmp, strcpy, strlen, strrchr};
 
 pub type __off_t = i64;
@@ -295,12 +295,12 @@ unsafe extern "C" fn tfm_check_size(mut tfm: *mut tfm_font, mut tfm_file_size: o
     /* Removed the warning message caused by EC TFM metric files.
      *
      if (tfm->wlenfile != tfm_file_size / 4) {
-     dpx_warning("TFM file size is %ld bytes but it says it is %ld bytes!",
+     warn!("TFM file size is {} bytes but it says it is {} bytes!",
      tfm_file_size, tfm->wlenfile * 4);
      if (tfm_file_size > tfm->wlenfile * 4) {
-     dpx_warning("Proceeding nervously...");
+     warn!("Proceeding nervously...");
      } else {
-     _tt_abort("Can't proceed...");
+     panic!("Can't proceed...");
      }
      }
     */
@@ -894,18 +894,18 @@ pub unsafe extern "C" fn tfm_open(mut tfm_name: *const i8, mut must_exist: i32) 
     free(ofm_name as *mut libc::c_void);
     if tfm_handle.is_null() {
         if must_exist != 0 {
-            _tt_abort(
-                b"Unable to find TFM file \"%s\".\x00" as *const u8 as *const i8,
-                tfm_name,
+            panic!(
+                "Unable to find TFM file \"{}\".",
+                CStr::from_ptr(tfm_name).display()
             );
         }
         return -1i32;
     }
     if verbose != 0 {
         if format == 1i32 {
-            dpx_message(b"(TFM:%s\x00" as *const u8 as *const i8, tfm_name);
+            info!("(TFM:{}", CStr::from_ptr(tfm_name).display());
         } else if format == 2i32 {
-            dpx_message(b"(OFM:%s\x00" as *const u8 as *const i8, tfm_name);
+            info!("(OFM:{}", CStr::from_ptr(tfm_name).display());
         }
     }
     tfm_file_size = ttstub_input_get_size(tfm_handle) as off_t;

--- a/dpx/src/dpx_truetype.rs
+++ b/dpx/src/dpx_truetype.rs
@@ -34,14 +34,15 @@ use super::dpx_sfnt::{
     sfnt_require_table, sfnt_set_table,
 };
 use crate::streq_ptr;
+use crate::DisplayExt;
 use crate::{info, warn};
+use std::ffi::CStr;
 
 use super::dpx_agl::{
     agl_chop_suffix, agl_lookup_list, agl_name_convert_unicode, agl_name_is_unicode,
     agl_suffix_to_otltag,
 };
 use super::dpx_dpxfile::{dpx_open_dfont_file, dpx_open_truetype_file};
-use super::dpx_error::{dpx_message, dpx_warning};
 use super::dpx_mem::new;
 use super::dpx_pdfencoding::{pdf_encoding_get_encoding, pdf_encoding_is_predefined};
 use super::dpx_pdffont::{
@@ -68,7 +69,6 @@ use crate::dpx_pdfobj::{
     PdfObjType,
 };
 use crate::ttstub_input_close;
-use bridge::_tt_abort;
 use libc::{atoi, free, memcpy, memmove, memset, sprintf, strchr, strcpy, strlen, strncpy};
 
 pub type rust_input_handle_t = *mut libc::c_void;
@@ -152,9 +152,9 @@ pub unsafe extern "C" fn pdf_font_open_truetype(mut font: *mut pdf_font) -> i32 
         sfont = sfnt_open(handle as rust_input_handle_t)
     }
     if sfont.is_null() {
-        dpx_warning(
-            b"Could not open TrueType font: %s\x00" as *const u8 as *const i8,
-            ident,
+        warn!(
+            "Could not open TrueType font: {}",
+            CStr::from_ptr(ident).display(),
         );
         ttstub_input_close(handle as rust_input_handle_t);
         return -1i32;
@@ -163,10 +163,7 @@ pub unsafe extern "C" fn pdf_font_open_truetype(mut font: *mut pdf_font) -> i32 
         let mut offset: u32 = 0;
         offset = ttc_read_offset(sfont, index);
         if offset == 0_u32 {
-            _tt_abort(
-                b"Invalid TTC index in %s.\x00" as *const u8 as *const i8,
-                ident,
-            );
+            panic!("Invalid TTC index in {}.", CStr::from_ptr(ident).display());
         }
         error = sfnt_read_table_directory(sfont, offset)
     } else {
@@ -215,9 +212,9 @@ pub unsafe extern "C" fn pdf_font_open_truetype(mut font: *mut pdf_font) -> i32 
         n += 1
     }
     if strlen(fontname.as_mut_ptr()) == 0 {
-        _tt_abort(
-            b"Can\'t find valid fontname for \"%s\".\x00" as *const u8 as *const i8,
-            ident,
+        panic!(
+            "Can\'t find valid fontname for \"{}\".",
+            CStr::from_ptr(ident).display()
         );
     }
     pdf_font_set_fontname(font, fontname.as_mut_ptr());
@@ -243,10 +240,9 @@ pub unsafe extern "C" fn pdf_font_open_truetype(mut font: *mut pdf_font) -> i32 
              * only to predefined encodings for this reason. Note that
              * "builtin" encoding means "MacRoman" here.
              */
-            _tt_abort(
-                b"Font file=\"%s\" can\'t be embedded due to liscence restrictions.\x00"
-                    as *const u8 as *const i8,
-                ident,
+            panic!(
+                "Font file=\"{}\" can\'t be embedded due to liscence restrictions.",
+                CStr::from_ptr(ident).display()
             );
             /* ENABLE_NOEMBED */
         }
@@ -460,11 +456,10 @@ unsafe extern "C" fn do_builtin_encoding(
             }
             gid = tt_cmap_lookup(ttcm, code as u32);
             if gid as i32 == 0i32 {
-                dpx_warning(
-                    b"Glyph for character code=0x%02x missing in font font-file=\"%s\".\x00"
-                        as *const u8 as *const i8,
+                warn!(
+                    "Glyph for character code=0x{:02x} missing in font font-file=\"{}\".",
                     code,
-                    pdf_font_get_ident(font),
+                    CStr::from_ptr(pdf_font_get_ident(font)).display(),
                 );
                 idx = 0_u16
             } else {
@@ -572,9 +567,9 @@ unsafe extern "C" fn select_gsub(mut feat: *const i8, mut gm: *mut glyph_mapper)
         return 0i32;
     }
     if verbose > 1i32 {
-        dpx_message(
-            b"\ntrutype>> Try loading OTL GSUB for \"*.*.%s\"...\x00" as *const u8 as *const i8,
-            feat,
+        info!(
+            "\ntrutype>> Try loading OTL GSUB for \"*.*.{}\"...",
+            CStr::from_ptr(feat).display()
         );
     }
     error = otl_gsub_add_feat(
@@ -805,12 +800,11 @@ unsafe extern "C" fn findcomposite(
             gm,
         );
         if error != 0 {
-            dpx_warning(
-                b"Could not resolve glyph \"%s\" (%dth component of glyph \"%s\").\x00" as *const u8
-                    as *const i8,
-                nptrs[i as usize],
+            warn!(
+                "Could not resolve glyph \"{}\" ({}th component of glyph \"{}\").",
+                CStr::from_ptr(nptrs[i as usize]).display(),
                 i,
-                glyphname,
+                CStr::from_ptr(glyphname).display(),
             );
         }
         i += 1
@@ -854,11 +848,10 @@ unsafe extern "C" fn findparanoiac(
             }
             error = selectglyph(idx, (*agln).suffix, gm, &mut idx);
             if error != 0 {
-                dpx_warning(
-                    b"Variant \"%s\" for glyph \"%s\" might not be found.\x00" as *const u8
-                        as *const i8,
-                    (*agln).suffix,
-                    (*agln).name,
+                warn!(
+                    "Variant \"{}\" for glyph \"{}\" might not be found.",
+                    CStr::from_ptr((*agln).suffix).display(),
+                    CStr::from_ptr((*agln).name).display(),
                 );
                 warn!("Using glyph name without suffix instead...");
                 error = 0i32
@@ -869,9 +862,9 @@ unsafe extern "C" fn findparanoiac(
         } else if (*agln).n_components > 1i32 {
             if verbose >= 0i32 {
                 /* give warning */
-                dpx_warning(
-                    b"Glyph \"%s\" looks like a composite glyph...\x00" as *const u8 as *const i8,
-                    (*agln).name,
+                warn!(
+                    "Glyph \"{}\" looks like a composite glyph...",
+                    CStr::from_ptr((*agln).name).display(),
                 );
             }
             error = composeuchar(
@@ -889,11 +882,10 @@ unsafe extern "C" fn findparanoiac(
                     let mut _n: i32 = 0i32;
                     let mut _p: *mut i8 = 0 as *mut i8;
                     let mut _buf: [i8; 256] = [0; 256];
-                    dpx_warning(
-                        b">> Composite glyph glyph-name=\"%s\" found at glyph-id=\"%u\".\x00"
-                            as *const u8 as *const i8,
-                        (*agln).name,
-                        idx as i32,
+                    warn!(
+                        ">> Composite glyph glyph-name=\"{}\" found at glyph-id=\"{}\".",
+                        CStr::from_ptr((*agln).name).display(),
+                        idx,
                     );
                     _p = _buf.as_mut_ptr();
                     _i = 0i32;
@@ -927,9 +919,8 @@ unsafe extern "C" fn findparanoiac(
                     let fresh4 = _n;
                     _n = _n + 1;
                     *_p.offset(fresh4 as isize) = '\u{0}' as i32 as i8;
-                    dpx_warning(b">> Input Unicode seq.=\"%s\" ==> glyph-id=\"%u\" in font-file=\"_please_try_-v_\".\x00"
-                                    as *const u8 as *const i8,
-                                _buf.as_mut_ptr(), idx as i32);
+                    warn!(">> Input Unicode seq.=\"{}\" ==> glyph-id=\"{}\" in font-file=\"_please_try_-v_\".",
+                                CStr::from_ptr(_buf.as_mut_ptr()).display(), idx);
                 }
             }
         } else {
@@ -982,11 +973,10 @@ unsafe extern "C" fn resolve_glyph(
     if error == 0 && !suffix.is_null() {
         error = selectglyph(*gid, suffix, gm, gid);
         if error != 0 {
-            dpx_warning(
-                b"Variant \"%s\" for glyph \"%s\" might not be found.\x00" as *const u8
-                    as *const i8,
-                suffix,
-                name,
+            warn!(
+                "Variant \"{}\" for glyph \"{}\" might not be found.",
+                CStr::from_ptr(suffix).display(),
+                CStr::from_ptr(name).display(),
             );
             warn!("Using glyph name without suffix instead...");
             error = 0i32
@@ -1053,9 +1043,9 @@ unsafe extern "C" fn do_custom_encoding(
     assert!(!font.is_null() && !encoding.is_null() && !usedchars.is_null() && !sfont.is_null());
     error = setup_glyph_mapper(&mut gm, sfont);
     if error != 0 {
-        dpx_warning(
-            b"No post table nor Unicode cmap found in font: %s\x00" as *const u8 as *const i8,
-            pdf_font_get_ident(font),
+        warn!(
+            "No post table nor Unicode cmap found in font: {}",
+            CStr::from_ptr(pdf_font_get_ident(font)).display(),
         );
         warn!(">> I can\'t find glyphs without this!");
         return -1i32;
@@ -1090,9 +1080,8 @@ unsafe extern "C" fn do_custom_encoding(
                 ) as i32
                     != 0
             {
-                dpx_warning(b"Character code=\"0x%02X\" mapped to \".notdef\" glyph used in font font-file=\"%s\"\x00"
-                                as *const u8 as *const i8, code,
-                            pdf_font_get_ident(font));
+                warn!("Character code=\"0x{:02X}\" mapped to \".notdef\" glyph used in font font-file=\"{}\"", code,
+                            CStr::from_ptr(pdf_font_get_ident(font)).display());
                 warn!(">> Maybe incorrect encoding specified?");
                 idx = 0_u16
             } else {
@@ -1106,17 +1095,16 @@ unsafe extern "C" fn do_custom_encoding(
                  * mapped to gid = 0.
                  */
                 if error != 0 {
-                    dpx_warning(
-                        b"Glyph \"%s\" not available in font \"%s\".\x00" as *const u8 as *const i8,
-                        *encoding.offset(code as isize),
-                        pdf_font_get_ident(font),
+                    warn!(
+                        "Glyph \"{}\" not available in font \"{}\".",
+                        CStr::from_ptr(*encoding.offset(code as isize)).display(),
+                        CStr::from_ptr(pdf_font_get_ident(font)).display(),
                     ); /* count returned. */
                 } else if verbose > 1i32 {
-                    dpx_message(
-                        b"truetype>> Glyph glyph-name=\"%s\" found at glyph-id=\"%u\".\n\x00"
-                            as *const u8 as *const i8,
-                        *encoding.offset(code as isize),
-                        gid as i32,
+                    info!(
+                        "truetype>> Glyph glyph-name=\"{}\" found at glyph-id=\"{}\".\n",
+                        CStr::from_ptr(*encoding.offset(code as isize)).display(),
+                        gid,
                     );
                 }
                 idx = tt_find_glyph(glyphs, gid);
@@ -1188,9 +1176,9 @@ pub unsafe extern "C" fn pdf_font_load_truetype(mut font: *mut pdf_font) -> i32 
     if handle.is_null() {
         handle = dpx_open_dfont_file(ident) as *mut rust_input_handle_t;
         if handle.is_null() {
-            _tt_abort(
-                b"Unable to open TrueType/dfont font file: %s\x00" as *const u8 as *const i8,
-                ident,
+            panic!(
+                "Unable to open TrueType/dfont font file: {}",
+                CStr::from_ptr(ident).display(),
             );
         }
         sfont = dfont_open(handle as rust_input_handle_t, index)
@@ -1199,9 +1187,9 @@ pub unsafe extern "C" fn pdf_font_load_truetype(mut font: *mut pdf_font) -> i32 
     }
     if sfont.is_null() {
         ttstub_input_close(handle as rust_input_handle_t);
-        _tt_abort(
-            b"Unable to open TrueType/dfont file: %s\x00" as *const u8 as *const i8,
-            ident,
+        panic!(
+            "Unable to open TrueType/dfont file: {}",
+            CStr::from_ptr(ident).display(),
         );
     } else {
         if (*sfont).type_0 != 1i32 << 0i32
@@ -1210,9 +1198,9 @@ pub unsafe extern "C" fn pdf_font_load_truetype(mut font: *mut pdf_font) -> i32 
         {
             sfnt_close(sfont);
             ttstub_input_close(handle as rust_input_handle_t);
-            _tt_abort(
-                b"Font \"%s\" not a TrueType/dfont font?\x00" as *const u8 as *const i8,
-                ident,
+            panic!(
+                "Font \"{}\" not a TrueType/dfont font?",
+                CStr::from_ptr(ident).display()
             );
         }
     }
@@ -1220,10 +1208,7 @@ pub unsafe extern "C" fn pdf_font_load_truetype(mut font: *mut pdf_font) -> i32 
         let mut offset: u32 = 0;
         offset = ttc_read_offset(sfont, index);
         if offset == 0_u32 {
-            _tt_abort(
-                b"Invalid TTC index in %s.\x00" as *const u8 as *const i8,
-                ident,
-            );
+            panic!("Invalid TTC index in {}.", CStr::from_ptr(ident).display());
         }
         error = sfnt_read_table_directory(sfont, offset)
     } else {
@@ -1232,10 +1217,9 @@ pub unsafe extern "C" fn pdf_font_load_truetype(mut font: *mut pdf_font) -> i32 
     if error != 0 {
         sfnt_close(sfont);
         ttstub_input_close(handle as rust_input_handle_t);
-        _tt_abort(
-            b"Reading SFND table dir failed for font-file=\"%s\"... Not a TrueType font?\x00"
-                as *const u8 as *const i8,
-            ident,
+        panic!(
+            "Reading SFND table dir failed for font-file=\"{}\"... Not a TrueType font?",
+            CStr::from_ptr(ident).display()
         );
     }
     /*
@@ -1250,9 +1234,9 @@ pub unsafe extern "C" fn pdf_font_load_truetype(mut font: *mut pdf_font) -> i32 
     if error != 0 {
         sfnt_close(sfont);
         ttstub_input_close(handle as rust_input_handle_t);
-        _tt_abort(
-            b"Error occured while creating font subfont for \"%s\"\x00" as *const u8 as *const i8,
-            ident,
+        panic!(
+            "Error occured while creating font subfont for \"{}\"",
+            CStr::from_ptr(ident).display()
         );
     }
     /* ENABLE_NOEMBED */
@@ -1269,11 +1253,10 @@ pub unsafe extern "C" fn pdf_font_load_truetype(mut font: *mut pdf_font) -> i32 
         {
             sfnt_close(sfont);
             ttstub_input_close(handle as rust_input_handle_t);
-            _tt_abort(
-                b"Required TrueType table \"%s\" does not exist in font: %s\x00" as *const u8
-                    as *const i8,
-                required_table[i as usize].name,
-                ident,
+            panic!(
+                "Required TrueType table \"{}\" does not exist in font: {}",
+                CStr::from_ptr(required_table[i as usize].name).display(),
+                CStr::from_ptr(ident).display(),
             );
         }
         i += 1
@@ -1283,9 +1266,9 @@ pub unsafe extern "C" fn pdf_font_load_truetype(mut font: *mut pdf_font) -> i32 
      */
     fontfile = sfnt_create_FontFile_stream(sfont); /* XXX */
     if fontfile.is_null() {
-        _tt_abort(
-            b"Could not created FontFile stream for \"%s\".\x00" as *const u8 as *const i8,
-            ident,
+        panic!(
+            "Could not created FontFile stream for \"{}\".",
+            CStr::from_ptr(ident).display()
         );
     }
     sfnt_close(sfont);

--- a/dpx/src/dpx_tt_aux.rs
+++ b/dpx/src/dpx_tt_aux.rs
@@ -29,8 +29,10 @@
     unused_mut
 )]
 
+use crate::DisplayExt;
+use std::ffi::CStr;
+
 use super::dpx_dvipdfmx::always_embed;
-use super::dpx_error::dpx_warning;
 use super::dpx_numbers::tt_get_unsigned_quad;
 use super::dpx_tt_post::{tt_read_post_table, tt_release_post_table};
 use super::dpx_tt_table::{tt_read_head_table, tt_read_os2__table};
@@ -136,28 +138,25 @@ pub unsafe extern "C" fn tt_get_fontdesc(
             *embed = 1i32
         } else if (*os2).fsType as i32 & 0x4i32 != 0 {
             if verbose > 0i32 {
-                dpx_warning(
-                    b"Font \"%s\" permits \"Preview & Print\" embedding only **\n\x00" as *const u8
-                        as *const i8,
-                    fontname,
+                warn!(
+                    "Font \"{}\" permits \"Preview & Print\" embedding only **\n",
+                    CStr::from_ptr(fontname).display(),
                 );
             }
             *embed = 1i32
         } else if always_embed != 0 {
             if verbose > 0i32 {
-                dpx_warning(
-                    b"Font \"%s\" may be subject to embedding restrictions **\n\x00" as *const u8
-                        as *const i8,
-                    fontname,
+                warn!(
+                    "Font \"{}\" may be subject to embedding restrictions **\n",
+                    CStr::from_ptr(fontname).display(),
                 );
             }
             *embed = 1i32
         } else {
             if verbose > 0i32 {
-                dpx_warning(
-                    b"Embedding of font \"%s\" disabled due to license restrictions\x00"
-                        as *const u8 as *const i8,
-                    fontname,
+                warn!(
+                    "Embedding of font \"{}\" disabled due to license restrictions",
+                    CStr::from_ptr(fontname).display(),
                 );
             }
             *embed = 0i32

--- a/dpx/src/dpx_tt_gsub.rs
+++ b/dpx/src/dpx_tt_gsub.rs
@@ -29,6 +29,9 @@
     unused_mut
 )]
 
+use crate::DisplayExt;
+use std::ffi::CStr;
+
 use super::dpx_numbers::{
     tt_get_signed_byte, tt_get_signed_pair, tt_get_unsigned_pair, tt_get_unsigned_quad,
 };
@@ -37,7 +40,7 @@ use crate::mfree;
 use crate::streq_ptr;
 use crate::{info, warn};
 
-use super::dpx_error::{dpx_message, dpx_warning};
+use super::dpx_error::dpx_message;
 use super::dpx_mem::{new, renew};
 use super::dpx_otl_opt::{
     otl_match_optrule, otl_new_opt, otl_opt, otl_parse_optstring, otl_release_opt,
@@ -1388,11 +1391,11 @@ pub unsafe extern "C" fn otl_gsub_add_feat(
     strcpy((*gsub).feature, feature);
     if verbose > 0i32 {
         info!("\n");
-        dpx_message(
-            b"otl_gsub>> Reading \"%s.%s.%s\"...\n\x00" as *const u8 as *const i8,
-            script,
-            language,
-            feature,
+        info!(
+            "otl_gsub>> Reading \"{}.{}.{}\"...\n",
+            CStr::from_ptr(script).display(),
+            CStr::from_ptr(language).display(),
+            CStr::from_ptr(feature).display(),
         );
     }
     retval = otl_gsub_read_feat(gsub, sfont);
@@ -1436,9 +1439,9 @@ unsafe extern "C" fn scan_otl_tag(
         if period < p.offset(5) {
             strncpy(script, p, period.wrapping_offset_from(p) as _);
         } else {
-            dpx_warning(
-                b"Invalid OTL script tag found: %s\x00" as *const u8 as *const i8,
-                p,
+            warn!(
+                "Invalid OTL script tag found: {}",
+                CStr::from_ptr(p).display(),
             );
             return -1i32;
         }
@@ -1449,9 +1452,9 @@ unsafe extern "C" fn scan_otl_tag(
             if period < p.offset(5) {
                 strncpy(language, p, period.wrapping_offset_from(p) as _);
             } else {
-                dpx_warning(
-                    b"Invalid OTL lanuage tag found: %s\x00" as *const u8 as *const i8,
-                    p,
+                warn!(
+                    "Invalid OTL lanuage tag found: {}",
+                    CStr::from_ptr(p).display(),
                 );
                 return -1i32;
             }

--- a/dpx/src/dpx_type0.rs
+++ b/dpx/src/dpx_type0.rs
@@ -29,6 +29,9 @@
     unused_mut
 )]
 
+use crate::DisplayExt;
+use std::ffi::CStr;
+
 use super::dpx_cid::{
     CIDFont, CIDFont_attach_parent, CIDFont_cache_close, CIDFont_cache_find, CIDFont_cache_get,
     CIDFont_get_CIDSysInfo, CIDFont_get_embedding, CIDFont_get_flag, CIDFont_get_fontname,
@@ -36,7 +39,6 @@ use super::dpx_cid::{
     CIDFont_get_subtype, CIDFont_is_ACCFont, CIDFont_is_UCSFont,
 };
 use super::dpx_cmap::{CMap_cache_get, CMap_get_CIDSysInfo, CMap_get_wmode, CMap_is_Identity};
-use super::dpx_error::{dpx_message, dpx_warning};
 use super::dpx_mem::{new, renew};
 use super::dpx_pdfencoding::pdf_load_ToUnicode_stream;
 use super::dpx_pdfresource::{pdf_defineresource, pdf_findresource, pdf_get_resource_reference};
@@ -249,9 +251,9 @@ unsafe extern "C" fn add_ToUnicode(mut font: *mut Type0Font) {
     if !tounicode.is_null() {
         pdf_add_dict((*font).fontdict, pdf_new_name("ToUnicode"), tounicode);
     } else {
-        dpx_warning(
-            b"Failed to load ToUnicode CMap for font \"%s\"\x00" as *const u8 as *const i8,
-            fontname,
+        warn!(
+            "Failed to load ToUnicode CMap for font \"{}\"",
+            CStr::from_ptr(fontname).display(),
         );
     };
 }
@@ -454,12 +456,9 @@ pub unsafe extern "C" fn Type0Font_cache_find(
     fontname = CIDFont_get_fontname(cidfont); /* skip XXXXXX+ */
     if __verbose != 0 {
         if CIDFont_get_embedding(cidfont) != 0 && strlen(fontname) > 7 {
-            dpx_message(
-                b"(CID:%s)\x00" as *const u8 as *const i8,
-                fontname.offset(7),
-            );
+            info!("(CID:{})", CStr::from_ptr(fontname.offset(7)).display());
         } else {
-            dpx_message(b"(CID:%s)\x00" as *const u8 as *const i8, fontname);
+            info!("(CID:{})", CStr::from_ptr(fontname).display());
         }
     }
     /*

--- a/dpx/src/dpx_vf.rs
+++ b/dpx/src/dpx_vf.rs
@@ -34,13 +34,14 @@ use super::dpx_numbers::{
 };
 use crate::streq_ptr;
 use crate::warn;
+use crate::DisplayExt;
+use std::ffi::CStr;
 
 use super::dpx_dvi::{
     dpx_dvi_pop, dvi_dirchg, dvi_do_special, dvi_down, dvi_locate_font, dvi_push, dvi_put,
     dvi_right, dvi_rule, dvi_set, dvi_set_font, dvi_vf_finish, dvi_vf_init, dvi_w, dvi_w0, dvi_x,
     dvi_x0, dvi_y, dvi_y0, dvi_z, dvi_z0,
 };
-use super::dpx_error::dpx_warning;
 use super::dpx_mem::{new, renew};
 use super::dpx_numbers::{sqxfw, tt_skip_bytes};
 use super::dpx_tfm::tfm_open;
@@ -335,9 +336,8 @@ pub unsafe extern "C" fn vf_locate_font(mut tex_name: *const i8, mut ptsize: spt
         return -1i32;
     }
     if verbose as i32 == 1i32 {
-        use std::ffi::CStr;
         let tex_name = CStr::from_ptr(tex_name);
-        eprint!("(VF:{}", tex_name.to_string_lossy());
+        eprint!("(VF:{}", tex_name.display());
     }
     if num_vf_fonts >= max_vf_fonts {
         resize_vf_fonts(max_vf_fonts.wrapping_add(16u32) as i32);
@@ -544,7 +544,7 @@ unsafe extern "C" fn vf_xxx(mut len: i32, mut start: *mut *mut u8, mut end: *mut
         ) == 0
         {
             if verbose != 0 {
-                dpx_warning(b"VF:%s\x00" as *const u8 as *const i8, p.offset(8));
+                warn!("VF:{}", CStr::from_ptr(p.offset(8) as *mut i8).display());
             }
         } else {
             dvi_do_special(buffer as *const libc::c_void, len);

--- a/dpx/src/lib.rs
+++ b/dpx/src/lib.rs
@@ -37,6 +37,18 @@ macro_rules! warn(
     };
 );
 
+trait DisplayExt {
+    type Adapter: core::fmt::Display;
+    fn display(self) -> Self::Adapter;
+}
+
+impl<'a> DisplayExt for &'a std::ffi::CStr {
+    type Adapter = std::borrow::Cow<'a, str>;
+    fn display(self) -> Self::Adapter {
+        self.to_string_lossy()
+    }
+}
+
 pub(crate) fn isblank(c: libc::c_int) -> libc::c_int {
     (c == ' ' as _ || c == '\t' as _) as _
 }

--- a/dpx/src/specials/tpic.rs
+++ b/dpx/src/specials/tpic.rs
@@ -32,11 +32,12 @@
 use crate::mfree;
 use crate::streq_ptr;
 use crate::warn;
+use crate::DisplayExt;
+use std::ffi::CStr;
 
 use super::{spc_arg, spc_env, spc_warn};
 
 use crate::dpx_dpxutil::{parse_c_ident, parse_c_string, parse_float_decimal};
-use crate::dpx_error::dpx_warning;
 use crate::dpx_mem::renew;
 use crate::dpx_pdfcolor::{pdf_color_brighten_color, pdf_color_get_current};
 use crate::dpx_pdfdev::pdf_dev_scale;
@@ -865,17 +866,17 @@ unsafe extern "C" fn tpic_filter_getopts(
             } else if streq_ptr(v, b"solid\x00" as *const u8 as *const i8) {
                 (*tp).mode.fill = 0i32
             } else {
-                dpx_warning(
-                    b"Invalid value for TPIC option fill-mode: %s\x00" as *const u8 as *const i8,
-                    v,
+                warn!(
+                    "Invalid value for TPIC option fill-mode: {}",
+                    CStr::from_ptr(v).display(),
                 );
                 error = -1i32
             }
         }
     } else {
-        dpx_warning(
-            b"Unrecognized option for TPIC special handler: %s\x00" as *const u8 as *const i8,
-            k,
+        warn!(
+            "Unrecognized option for TPIC special handler: {}",
+            CStr::from_ptr(k).display(),
         );
         error = -1i32
     }


### PR DESCRIPTION
Looks like `dpx` doesn't use non-ascii symbols in messages, but it needs more test, especially with different encoding.

Don't use this method in `xetex`!