### PR TITLE
update png-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,7 +665,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libpng-sys"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1527,7 +1527,7 @@ dependencies = [
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "libpng-sys 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libpng-sys 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "md-5 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2075,7 +2075,7 @@ dependencies = [
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
-"checksum libpng-sys 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "cfde556d773c4d57def2d77bb76566abb400e2006e07f068c4f532075f2d3fd0"
+"checksum libpng-sys 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "939658d8a33e52645ecfdc42500285c8b0fdeb26df10677c32abd13a1fc1d70c"
 "checksum libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
 "checksum locale 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5fdbe492a9c0238da900a1165c42fc5067161ce292678a6fe80921f30fe307fd"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"

--- a/dpx/Cargo.toml
+++ b/dpx/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL"
 [dependencies]
 tectonic_bridge = { version = "0.0.1-dev", path = "../bridge" }
 libc = "0.2"
-libpng-sys = "1"
+libpng-sys = "1.1.8"
 libz-sys = { version = "1", optional = true}
 md-5 = "0.8.0"
 sha2 = "0.8.0"

--- a/dpx/src/dpx_pngimage.rs
+++ b/dpx/src/dpx_pngimage.rs
@@ -44,12 +44,6 @@ use crate::dpx_pdfobj::{
 use crate::{ttstub_input_read, ttstub_input_seek};
 use libc::free;
 
-extern "C" {
-    // Should be removed once fixed upstream
-    #[no_mangle]
-    fn png_destroy_info_struct(png_ptr: png_const_structrp, info_ptr_ptr: png_infopp);
-}
-
 pub type __ssize_t = i64;
 pub type size_t = u64;
 pub type ssize_t = __ssize_t;


### PR DESCRIPTION
upstream patch^[0] got merged, so we can now remove the stray import

[0] https://github.com/kornelski/rust-libpng-sys/pull/8