### PR TITLE
replace c2rust generated harfbuzz api to harfbuzz_sys api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 
 # ignore mdbook compiled output (HTML)
 docs/book/*
+.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cookie"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,6 +393,15 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "freetype"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "servo-freetype-sys 4.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "freetype-rs"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +496,19 @@ dependencies = [
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "harfbuzz-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-text 13.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "freetype 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1312,6 +1342,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "servo-freetype-sys"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1474,6 +1513,7 @@ dependencies = [
  "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-text 13.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "freetype-rs 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "harfbuzz-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc-foundation 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1950,6 +1990,7 @@ dependencies = [
 "checksum chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "81fb25b677f8bf1eb325017cb6bb8452f87969db0fedb4f757b297bee78a7c62"
 "checksum cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
 "checksum cookie_store 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46750b3f362965f197996c4448e4a0935e791bf7d6631bfce9ee0af3d24c919c"
 "checksum core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
@@ -1974,6 +2015,7 @@ dependencies = [
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+"checksum freetype 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "11926b2b410b469d0e9399eca4cbbe237a9ef02176c485803b29216307e8e028"
 "checksum freetype-rs 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ec3da38037daa26861c2292fbfef56db472a8da08ff5268a6f5c8f28e5a9ac7"
 "checksum freetype-sys 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "12c9809038de3cf32717168cd634c51ff165f19104b696da53139f7a644bb8c4"
 "checksum fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
@@ -1985,6 +2027,7 @@ dependencies = [
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
+"checksum harfbuzz-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e1042ab0b3e7bc1ff64f7f5935778b644ff2194a1cae5ec52167127d3fd23961"
 "checksum headers 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "882ca7d8722f33ce2c2db44f95425d6267ed59ca96ce02acbe58320054ceb642"
 "checksum headers-core 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "967131279aaa9f7c20c7205b45a391638a83ab118e6509b2d0ccbe08de044237"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
@@ -2077,6 +2120,7 @@ dependencies = [
 "checksum serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "4b133a43a1ecd55d4086bd5b4dc6c1751c68b1bfbeba7a5040442022c7e7c02e"
 "checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
 "checksum serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a"
+"checksum servo-freetype-sys 4.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9232032c2e85118c0282c6562c84cab12316e655491ba0a5d1905b2320060d1b"
 "checksum sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "23962131a91661d643c98940b20fcaffe62d776a823247be80a48fcb8b6fce68"
 "checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -30,6 +30,7 @@ bitflags = "1.1.0"
 libc = "0.2"
 chrono = "0.4.9"
 #log = { version = "0.4", features = ["std"] }
+harfbuzz-sys = "^0.3"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.6.4"

--- a/engine/src/xetex_ext.rs
+++ b/engine/src/xetex_ext.rs
@@ -45,6 +45,7 @@ use bridge::_tt_abort;
 use crate::stub_stdio::strcasecmp;
 use crate::xetex_layout_engine::*;
 use libc::{memcpy, strcat, strcpy, strdup, strlen, strncpy, strstr};
+use harfbuzz_sys::{hb_tag_t, hb_tag_from_string, hb_feature_t};
 
 pub type __ssize_t = i64;
 pub type size_t = u64;

--- a/engine/src/xetex_font_info.rs
+++ b/engine/src/xetex_font_info.rs
@@ -8,6 +8,15 @@
 #![feature(const_raw_ptr_to_usize_cast, extern_types)]
 
 use crate::core_memory::xmalloc;
+use harfbuzz_sys::{hb_font_funcs_t, hb_destroy_func_t, hb_font_t, hb_codepoint_t,
+    hb_position_t, hb_bool_t, hb_font_destroy, hb_glyph_extents_t, hb_font_funcs_create,
+    hb_font_funcs_set_glyph_h_advance_func, hb_font_funcs_set_glyph_v_advance_func,
+    hb_font_funcs_set_glyph_h_origin_func, hb_font_funcs_set_glyph_v_origin_func,
+    hb_font_funcs_set_glyph_contour_point_func, hb_font_funcs_set_glyph_extents_func,
+    hb_blob_create, HB_MEMORY_MODE_WRITABLE, hb_face_t, hb_tag_t, hb_blob_t,
+    hb_font_funcs_set_glyph_name_func, hb_face_create_for_tables, hb_face_set_index,
+    hb_face_set_upem, hb_font_create, hb_face_destroy, hb_font_set_funcs,
+    hb_font_set_scale, hb_font_set_ppem};
 
 #[cfg(not(target_os = "macos"))]
 mod imp {}
@@ -25,10 +34,6 @@ extern "C" {
     pub type FT_Size_InternalRec_;
     pub type FT_Slot_InternalRec_;
     pub type FT_SubGlyphRec_;
-    pub type hb_blob_t;
-    pub type hb_face_t;
-    pub type hb_font_t;
-    pub type hb_font_funcs_t;
     pub type FT_Glyph_Class_;
     #[no_mangle]
     fn malloc(_: libc::c_ulong) -> *mut libc::c_void;
@@ -527,56 +532,7 @@ extern "C" {
         buffer: *mut FT_Byte,
         length: *mut FT_ULong,
     ) -> FT_Error;
-    #[no_mangle]
-    fn hb_blob_create(
-        data: *const libc::c_char,
-        length: libc::c_uint,
-        mode: hb_memory_mode_t,
-        user_data: *mut libc::c_void,
-        destroy: hb_destroy_func_t,
-    ) -> *mut hb_blob_t;
-    #[no_mangle]
-    fn hb_face_create_for_tables(
-        reference_table_func: hb_reference_table_func_t,
-        user_data: *mut libc::c_void,
-        destroy: hb_destroy_func_t,
-    ) -> *mut hb_face_t;
-    #[no_mangle]
-    fn hb_face_destroy(face: *mut hb_face_t);
-    #[no_mangle]
-    fn hb_face_set_index(face: *mut hb_face_t, index: libc::c_uint);
-    #[no_mangle]
-    fn hb_face_set_upem(face: *mut hb_face_t, upem: libc::c_uint);
-    #[no_mangle]
-    fn hb_font_funcs_create() -> *mut hb_font_funcs_t;
-    #[no_mangle]
-    fn hb_font_funcs_set_glyph_h_advance_func(
-        ffuncs: *mut hb_font_funcs_t,
-        func: hb_font_get_glyph_h_advance_func_t,
-        user_data: *mut libc::c_void,
-        destroy: hb_destroy_func_t,
-    );
-    #[no_mangle]
-    fn hb_font_funcs_set_glyph_v_advance_func(
-        ffuncs: *mut hb_font_funcs_t,
-        func: hb_font_get_glyph_v_advance_func_t,
-        user_data: *mut libc::c_void,
-        destroy: hb_destroy_func_t,
-    );
-    #[no_mangle]
-    fn hb_font_funcs_set_glyph_h_origin_func(
-        ffuncs: *mut hb_font_funcs_t,
-        func: hb_font_get_glyph_h_origin_func_t,
-        user_data: *mut libc::c_void,
-        destroy: hb_destroy_func_t,
-    );
-    #[no_mangle]
-    fn hb_font_funcs_set_glyph_v_origin_func(
-        ffuncs: *mut hb_font_funcs_t,
-        func: hb_font_get_glyph_v_origin_func_t,
-        user_data: *mut libc::c_void,
-        destroy: hb_destroy_func_t,
-    );
+    // TODO: NOTE: this api doesn't included in harfbuzz_sys
     #[no_mangle]
     fn hb_font_funcs_set_glyph_h_kerning_func(
         ffuncs: *mut hb_font_funcs_t,
@@ -584,42 +540,6 @@ extern "C" {
         user_data: *mut libc::c_void,
         destroy: hb_destroy_func_t,
     );
-    #[no_mangle]
-    fn hb_font_funcs_set_glyph_extents_func(
-        ffuncs: *mut hb_font_funcs_t,
-        func: hb_font_get_glyph_extents_func_t,
-        user_data: *mut libc::c_void,
-        destroy: hb_destroy_func_t,
-    );
-    #[no_mangle]
-    fn hb_font_funcs_set_glyph_contour_point_func(
-        ffuncs: *mut hb_font_funcs_t,
-        func: hb_font_get_glyph_contour_point_func_t,
-        user_data: *mut libc::c_void,
-        destroy: hb_destroy_func_t,
-    );
-    #[no_mangle]
-    fn hb_font_funcs_set_glyph_name_func(
-        ffuncs: *mut hb_font_funcs_t,
-        func: hb_font_get_glyph_name_func_t,
-        user_data: *mut libc::c_void,
-        destroy: hb_destroy_func_t,
-    );
-    #[no_mangle]
-    fn hb_font_create(face: *mut hb_face_t) -> *mut hb_font_t;
-    #[no_mangle]
-    fn hb_font_destroy(font: *mut hb_font_t);
-    #[no_mangle]
-    fn hb_font_set_funcs(
-        font: *mut hb_font_t,
-        klass: *mut hb_font_funcs_t,
-        font_data: *mut libc::c_void,
-        destroy: hb_destroy_func_t,
-    );
-    #[no_mangle]
-    fn hb_font_set_scale(font: *mut hb_font_t, x_scale: libc::c_int, y_scale: libc::c_int);
-    #[no_mangle]
-    fn hb_font_set_ppem(font: *mut hb_font_t, x_ppem: libc::c_uint, y_ppem: libc::c_uint);
     #[no_mangle]
     fn hb_font_funcs_set_glyph_func(
         ffuncs: *mut hb_font_funcs_t,
@@ -1808,49 +1728,7 @@ pub const FT_SFNT_OS2: FT_Sfnt_Tag_ = 2;
 pub const FT_SFNT_MAXP: FT_Sfnt_Tag_ = 1;
 pub const FT_SFNT_HEAD: FT_Sfnt_Tag_ = 0;
 pub type FT_Sfnt_Tag = FT_Sfnt_Tag_;
-pub type hb_bool_t = libc::c_int;
-pub type hb_codepoint_t = uint32_t;
-pub type hb_position_t = int32_t;
-pub type hb_tag_t = uint32_t;
-pub type hb_destroy_func_t = Option<unsafe extern "C" fn(_: *mut libc::c_void) -> ()>;
-pub type hb_memory_mode_t = libc::c_uint;
-pub const HB_MEMORY_MODE_READONLY_MAY_MAKE_WRITABLE: hb_memory_mode_t = 3;
-pub const HB_MEMORY_MODE_WRITABLE: hb_memory_mode_t = 2;
-pub const HB_MEMORY_MODE_READONLY: hb_memory_mode_t = 1;
-pub const HB_MEMORY_MODE_DUPLICATE: hb_memory_mode_t = 0;
-pub type hb_reference_table_func_t = Option<
-    unsafe extern "C" fn(_: *mut hb_face_t, _: hb_tag_t, _: *mut libc::c_void) -> *mut hb_blob_t,
->;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct hb_glyph_extents_t {
-    pub x_bearing: hb_position_t,
-    pub y_bearing: hb_position_t,
-    pub width: hb_position_t,
-    pub height: hb_position_t,
-}
-pub type hb_font_get_glyph_advance_func_t = Option<
-    unsafe extern "C" fn(
-        _: *mut hb_font_t,
-        _: *mut libc::c_void,
-        _: hb_codepoint_t,
-        _: *mut libc::c_void,
-    ) -> hb_position_t,
->;
-pub type hb_font_get_glyph_h_advance_func_t = hb_font_get_glyph_advance_func_t;
-pub type hb_font_get_glyph_v_advance_func_t = hb_font_get_glyph_advance_func_t;
-pub type hb_font_get_glyph_origin_func_t = Option<
-    unsafe extern "C" fn(
-        _: *mut hb_font_t,
-        _: *mut libc::c_void,
-        _: hb_codepoint_t,
-        _: *mut hb_position_t,
-        _: *mut hb_position_t,
-        _: *mut libc::c_void,
-    ) -> hb_bool_t,
->;
-pub type hb_font_get_glyph_h_origin_func_t = hb_font_get_glyph_origin_func_t;
-pub type hb_font_get_glyph_v_origin_func_t = hb_font_get_glyph_origin_func_t;
+
 pub type hb_font_get_glyph_kerning_func_t = Option<
     unsafe extern "C" fn(
         _: *mut hb_font_t,
@@ -1861,36 +1739,6 @@ pub type hb_font_get_glyph_kerning_func_t = Option<
     ) -> hb_position_t,
 >;
 pub type hb_font_get_glyph_h_kerning_func_t = hb_font_get_glyph_kerning_func_t;
-pub type hb_font_get_glyph_extents_func_t = Option<
-    unsafe extern "C" fn(
-        _: *mut hb_font_t,
-        _: *mut libc::c_void,
-        _: hb_codepoint_t,
-        _: *mut hb_glyph_extents_t,
-        _: *mut libc::c_void,
-    ) -> hb_bool_t,
->;
-pub type hb_font_get_glyph_contour_point_func_t = Option<
-    unsafe extern "C" fn(
-        _: *mut hb_font_t,
-        _: *mut libc::c_void,
-        _: hb_codepoint_t,
-        _: libc::c_uint,
-        _: *mut hb_position_t,
-        _: *mut hb_position_t,
-        _: *mut libc::c_void,
-    ) -> hb_bool_t,
->;
-pub type hb_font_get_glyph_name_func_t = Option<
-    unsafe extern "C" fn(
-        _: *mut hb_font_t,
-        _: *mut libc::c_void,
-        _: hb_codepoint_t,
-        _: *mut libc::c_char,
-        _: libc::c_uint,
-        _: *mut libc::c_void,
-    ) -> hb_bool_t,
->;
 pub type hb_font_get_glyph_func_t = Option<
     unsafe extern "C" fn(
         _: *mut hb_font_t,
@@ -1902,6 +1750,7 @@ pub type hb_font_get_glyph_func_t = Option<
     ) -> hb_bool_t,
 >;
 pub type hb_font_get_glyph_v_kerning_func_t = hb_font_get_glyph_kerning_func_t;
+
 pub type OTTag = uint32_t;
 pub type GlyphID = uint16_t;
 
@@ -2322,61 +2171,25 @@ unsafe extern "C" fn _get_font_funcs() -> *mut hb_font_funcs_t {
     );
     hb_font_funcs_set_glyph_h_advance_func(
         funcs,
-        Some(
-            _get_glyph_h_advance
-                as unsafe extern "C" fn(
-                    _: *mut hb_font_t,
-                    _: *mut libc::c_void,
-                    _: hb_codepoint_t,
-                    _: *mut libc::c_void,
-                ) -> hb_position_t,
-        ),
+        Some(_get_glyph_h_advance),
         0 as *mut libc::c_void,
         None,
     );
     hb_font_funcs_set_glyph_v_advance_func(
         funcs,
-        Some(
-            _get_glyph_v_advance
-                as unsafe extern "C" fn(
-                    _: *mut hb_font_t,
-                    _: *mut libc::c_void,
-                    _: hb_codepoint_t,
-                    _: *mut libc::c_void,
-                ) -> hb_position_t,
-        ),
+        Some(_get_glyph_v_advance),
         0 as *mut libc::c_void,
         None,
     );
     hb_font_funcs_set_glyph_h_origin_func(
         funcs,
-        Some(
-            _get_glyph_h_origin
-                as unsafe extern "C" fn(
-                    _: *mut hb_font_t,
-                    _: *mut libc::c_void,
-                    _: hb_codepoint_t,
-                    _: *mut hb_position_t,
-                    _: *mut hb_position_t,
-                    _: *mut libc::c_void,
-                ) -> hb_bool_t,
-        ),
+        Some(_get_glyph_h_origin),
         0 as *mut libc::c_void,
         None,
     );
     hb_font_funcs_set_glyph_v_origin_func(
         funcs,
-        Some(
-            _get_glyph_v_origin
-                as unsafe extern "C" fn(
-                    _: *mut hb_font_t,
-                    _: *mut libc::c_void,
-                    _: hb_codepoint_t,
-                    _: *mut hb_position_t,
-                    _: *mut hb_position_t,
-                    _: *mut libc::c_void,
-                ) -> hb_bool_t,
-        ),
+        Some(_get_glyph_v_origin),
         0 as *mut libc::c_void,
         None,
     );
@@ -2412,49 +2225,19 @@ unsafe extern "C" fn _get_font_funcs() -> *mut hb_font_funcs_t {
     );
     hb_font_funcs_set_glyph_extents_func(
         funcs,
-        Some(
-            _get_glyph_extents
-                as unsafe extern "C" fn(
-                    _: *mut hb_font_t,
-                    _: *mut libc::c_void,
-                    _: hb_codepoint_t,
-                    _: *mut hb_glyph_extents_t,
-                    _: *mut libc::c_void,
-                ) -> hb_bool_t,
-        ),
+        Some(_get_glyph_extents),
         0 as *mut libc::c_void,
         None,
     );
     hb_font_funcs_set_glyph_contour_point_func(
         funcs,
-        Some(
-            _get_glyph_contour_point
-                as unsafe extern "C" fn(
-                    _: *mut hb_font_t,
-                    _: *mut libc::c_void,
-                    _: hb_codepoint_t,
-                    _: libc::c_uint,
-                    _: *mut hb_position_t,
-                    _: *mut hb_position_t,
-                    _: *mut libc::c_void,
-                ) -> hb_bool_t,
-        ),
+        Some(_get_glyph_contour_point),
         0 as *mut libc::c_void,
         None,
     );
     hb_font_funcs_set_glyph_name_func(
         funcs,
-        Some(
-            _get_glyph_name
-                as unsafe extern "C" fn(
-                    _: *mut hb_font_t,
-                    _: *mut libc::c_void,
-                    _: hb_codepoint_t,
-                    _: *mut libc::c_char,
-                    _: libc::c_uint,
-                    _: *mut libc::c_void,
-                ) -> hb_bool_t,
-        ),
+        Some(_get_glyph_name),
         0 as *mut libc::c_void,
         None,
     );

--- a/engine/src/xetex_font_info_coretext.rs
+++ b/engine/src/xetex_font_info_coretext.rs
@@ -7,6 +7,9 @@
          unused_assignments,
          unused_mut)]
 #![feature(extern_types)]
+
+use harfbuzz_sys::hb_font_t;
+
 extern crate libc;
 extern "C" {
     pub type __CFAllocator;
@@ -55,7 +58,6 @@ extern "C" {
     pub type FT_Size_InternalRec_;
     pub type FT_Slot_InternalRec_;
     pub type FT_SubGlyphRec_;
-    pub type hb_font_t;
     pub type __CFString;
     pub type __CFArray;
     pub type __CFDictionary;

--- a/engine/src/xetex_font_manager.rs
+++ b/engine/src/xetex_font_manager.rs
@@ -27,6 +27,8 @@ use crate::xetex_layout_interface::collection_types::*;
 #[cfg(target_os = "macos")]
 use crate::xetex_layout_interface::__CTFontDescriptor;
 
+use harfbuzz_sys::{hb_font_t, hb_face_t, hb_font_get_face, hb_ot_layout_get_size_params};
+
 extern "C" {
     /* ************************************************************************/
     /* ************************************************************************/
@@ -73,8 +75,6 @@ extern "C" {
     pub type FT_Size_InternalRec_;
     pub type FT_Slot_InternalRec_;
     pub type FT_SubGlyphRec_;
-    pub type hb_face_t;
-    pub type hb_font_t;
     pub type XeTeXFont_rec;
     #[no_mangle]
     fn tan(_: libc::c_double) -> libc::c_double;
@@ -95,17 +95,6 @@ extern "C" {
     /* The internal, C/C++ interface: */
     #[no_mangle]
     fn _tt_abort(format: *const libc::c_char, _: ...) -> !;
-    #[no_mangle]
-    fn hb_font_get_face(font: *mut hb_font_t) -> *mut hb_face_t;
-    #[no_mangle]
-    fn hb_ot_layout_get_size_params(
-        face: *mut hb_face_t,
-        design_size: *mut libc::c_uint,
-        subfamily_id: *mut libc::c_uint,
-        subfamily_name_id: *mut hb_ot_name_id_t,
-        range_start: *mut libc::c_uint,
-        range_end: *mut libc::c_uint,
-    ) -> hb_bool_t;
     #[no_mangle]
     fn createFont(fontRef: PlatformFontRef, pointSize: Fixed) -> XeTeXFont;
     #[no_mangle]
@@ -1377,8 +1366,6 @@ pub const FT_SFNT_OS2: FT_Sfnt_Tag_ = 2;
 pub const FT_SFNT_MAXP: FT_Sfnt_Tag_ = 1;
 pub const FT_SFNT_HEAD: FT_Sfnt_Tag_ = 0;
 pub type FT_Sfnt_Tag = FT_Sfnt_Tag_;
-pub type hb_bool_t = libc::c_int;
-pub type hb_ot_name_id_t = libc::c_uint;
 pub type Fixed = i32;
 #[cfg(not(target_os = "macos"))]
 pub type PlatformFontRef = *mut FcPattern;

--- a/engine/src/xetex_layout_engine.rs
+++ b/engine/src/xetex_layout_engine.rs
@@ -1,3 +1,5 @@
+use harfbuzz_sys::{hb_ot_math_glyph_part_t, hb_tag_t, hb_feature_t};
+
 pub type XeTeXLayoutEngine = *mut XeTeXLayoutEngine_rec;
 /// PlatformFontRef matches C++
 #[cfg(not(target_os = "macos"))]
@@ -12,28 +14,7 @@ pub struct GlyphAssembly {
     pub count: u32,
     pub parts: *mut hb_ot_math_glyph_part_t,
 }
-pub type hb_tag_t = u32;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct hb_feature_t {
-    pub tag: hb_tag_t,
-    pub value: u32,
-    pub start: u32,
-    pub end: u32,
-}
-pub type hb_codepoint_t = u32;
-pub type hb_position_t = i32;
-pub type hb_ot_math_glyph_part_flags_t = u32;
-pub const HB_OT_MATH_GLYPH_PART_FLAG_EXTENDER: hb_ot_math_glyph_part_flags_t = 1;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct hb_ot_math_glyph_part_t {
-    pub glyph: hb_codepoint_t,
-    pub start_connector_length: hb_position_t,
-    pub end_connector_length: hb_position_t,
-    pub full_advance: hb_position_t,
-    pub flags: hb_ot_math_glyph_part_flags_t,
-}
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct GlyphBBox {
@@ -91,8 +72,6 @@ extern "C" {
     pub fn ot_part_full_advance(f: i32, a: *const GlyphAssembly, i: i32) -> i32;
     #[no_mangle]
     pub fn ot_min_connector_overlap(f: i32) -> i32;
-    #[no_mangle]
-    pub fn hb_tag_from_string(str: *const i8, len: i32) -> hb_tag_t;
     #[no_mangle]
     pub fn getCachedGlyphBBox(fontID: u16, glyphID: u16, bbox: *mut GlyphBBox) -> i32;
     #[no_mangle]

--- a/engine/src/xetex_layout_interface.rs
+++ b/engine/src/xetex_layout_interface.rs
@@ -11,6 +11,7 @@
            ptr_wrapping_offset_from)]
 
 use crate::core_memory::{xcalloc, xmalloc};
+use harfbuzz_sys::*;
 
 extern "C" {
     /* ************************************************************************/
@@ -58,12 +59,6 @@ extern "C" {
     pub type FT_Size_InternalRec_;
     pub type FT_Slot_InternalRec_;
     pub type FT_SubGlyphRec_;
-    pub type hb_language_impl_t;
-    pub type hb_unicode_funcs_t;
-    pub type hb_face_t;
-    pub type hb_font_t;
-    pub type hb_buffer_t;
-    pub type hb_shape_plan_t;
     #[cfg(target_os = "macos")]
     pub type __CTFontDescriptor;
     #[cfg(target_os = "macos")]
@@ -121,100 +116,12 @@ extern "C" {
         s: *mut *mut FcChar8,
     ) -> FcResult;
     #[no_mangle]
-    fn hb_tag_from_string(str: *const libc::c_char, len: libc::c_int) -> hb_tag_t;
-    #[no_mangle]
-    fn hb_language_from_string(str: *const libc::c_char, len: libc::c_int) -> hb_language_t;
-    #[no_mangle]
-    fn hb_language_to_string(language: hb_language_t) -> *const libc::c_char;
-    #[no_mangle]
-    fn hb_script_get_horizontal_direction(script: hb_script_t) -> hb_direction_t;
-    #[no_mangle]
-    fn hb_unicode_funcs_create(parent: *mut hb_unicode_funcs_t) -> *mut hb_unicode_funcs_t;
-    #[no_mangle]
-    fn hb_font_get_face(font: *mut hb_font_t) -> *mut hb_face_t;
-    #[no_mangle]
-    fn hb_buffer_create() -> *mut hb_buffer_t;
-    #[no_mangle]
-    fn hb_buffer_destroy(buffer: *mut hb_buffer_t);
-    #[no_mangle]
-    fn hb_buffer_set_content_type(buffer: *mut hb_buffer_t, content_type: hb_buffer_content_type_t);
-    #[no_mangle]
-    fn hb_buffer_set_unicode_funcs(
-        buffer: *mut hb_buffer_t,
-        unicode_funcs: *mut hb_unicode_funcs_t,
-    );
-    #[no_mangle]
-    fn hb_buffer_set_direction(buffer: *mut hb_buffer_t, direction: hb_direction_t);
-    #[no_mangle]
-    fn hb_buffer_set_script(buffer: *mut hb_buffer_t, script: hb_script_t);
-    #[no_mangle]
-    fn hb_buffer_get_script(buffer: *mut hb_buffer_t) -> hb_script_t;
-    #[no_mangle]
-    fn hb_buffer_set_language(buffer: *mut hb_buffer_t, language: hb_language_t);
-    #[no_mangle]
-    fn hb_buffer_get_segment_properties(
-        buffer: *mut hb_buffer_t,
-        props: *mut hb_segment_properties_t,
-    );
-    #[no_mangle]
-    fn hb_buffer_guess_segment_properties(buffer: *mut hb_buffer_t);
-    #[no_mangle]
-    fn hb_buffer_reset(buffer: *mut hb_buffer_t);
-    #[no_mangle]
-    fn hb_buffer_add_utf16(
-        buffer: *mut hb_buffer_t,
-        text: *const uint16_t,
-        text_length: libc::c_int,
-        item_offset: libc::c_uint,
-        item_length: libc::c_int,
-    );
-    #[no_mangle]
-    fn hb_buffer_get_length(buffer: *mut hb_buffer_t) -> libc::c_uint;
-    #[no_mangle]
-    fn hb_buffer_get_glyph_infos(
-        buffer: *mut hb_buffer_t,
-        length: *mut libc::c_uint,
-    ) -> *mut hb_glyph_info_t;
-    #[no_mangle]
-    fn hb_buffer_get_glyph_positions(
-        buffer: *mut hb_buffer_t,
-        length: *mut libc::c_uint,
-    ) -> *mut hb_glyph_position_t;
-    #[no_mangle]
     fn hb_unicode_funcs_set_decompose_compatibility_func(
         ufuncs: *mut hb_unicode_funcs_t,
         func: hb_unicode_decompose_compatibility_func_t,
         user_data: *mut libc::c_void,
         destroy: hb_destroy_func_t,
     );
-    #[no_mangle]
-    fn hb_shape_plan_create(
-        face: *mut hb_face_t,
-        props: *const hb_segment_properties_t,
-        user_features: *const hb_feature_t,
-        num_user_features: libc::c_uint,
-        shaper_list: *const *const libc::c_char,
-    ) -> *mut hb_shape_plan_t;
-    #[no_mangle]
-    fn hb_shape_plan_create_cached(
-        face: *mut hb_face_t,
-        props: *const hb_segment_properties_t,
-        user_features: *const hb_feature_t,
-        num_user_features: libc::c_uint,
-        shaper_list: *const *const libc::c_char,
-    ) -> *mut hb_shape_plan_t;
-    #[no_mangle]
-    fn hb_shape_plan_destroy(shape_plan: *mut hb_shape_plan_t);
-    #[no_mangle]
-    fn hb_shape_plan_execute(
-        shape_plan: *mut hb_shape_plan_t,
-        font: *mut hb_font_t,
-        buffer: *mut hb_buffer_t,
-        features: *const hb_feature_t,
-        num_features: libc::c_uint,
-    ) -> hb_bool_t;
-    #[no_mangle]
-    fn hb_shape_plan_get_shaper(shape_plan: *mut hb_shape_plan_t) -> *const libc::c_char;
     #[no_mangle]
     fn hb_ot_layout_script_find_language(
         face: *mut hb_face_t,
@@ -223,46 +130,7 @@ extern "C" {
         language_tag: hb_tag_t,
         language_index: *mut libc::c_uint,
     ) -> hb_bool_t;
-    #[no_mangle]
-    fn hb_ot_tag_to_script(tag: hb_tag_t) -> hb_script_t;
-    #[no_mangle]
-    fn hb_ot_tag_to_language(tag: hb_tag_t) -> hb_language_t;
-    #[no_mangle]
-    fn hb_ot_layout_table_get_script_tags(
-        face: *mut hb_face_t,
-        table_tag: hb_tag_t,
-        start_offset: libc::c_uint,
-        script_count: *mut libc::c_uint,
-        script_tags: *mut hb_tag_t,
-    ) -> libc::c_uint;
-    #[no_mangle]
-    fn hb_ot_layout_table_find_script(
-        face: *mut hb_face_t,
-        table_tag: hb_tag_t,
-        script_tag: hb_tag_t,
-        script_index: *mut libc::c_uint,
-    ) -> hb_bool_t;
-    #[no_mangle]
-    fn hb_ot_layout_script_get_language_tags(
-        face: *mut hb_face_t,
-        table_tag: hb_tag_t,
-        script_index: libc::c_uint,
-        start_offset: libc::c_uint,
-        language_count: *mut libc::c_uint,
-        language_tags: *mut hb_tag_t,
-    ) -> libc::c_uint;
-    #[no_mangle]
-    fn hb_ot_layout_language_get_feature_tags(
-        face: *mut hb_face_t,
-        table_tag: hb_tag_t,
-        script_index: libc::c_uint,
-        language_index: libc::c_uint,
-        start_offset: libc::c_uint,
-        feature_count: *mut libc::c_uint,
-        feature_tags: *mut hb_tag_t,
-    ) -> libc::c_uint;
-    #[no_mangle]
-    fn hb_ot_math_has_data(face: *mut hb_face_t) -> hb_bool_t;
+
     #[no_mangle]
     fn gr_face_featureval_for_lang(
         pFace: *const gr_face,
@@ -1761,226 +1629,7 @@ pub struct FT_GlyphSlotRec_ {
 }
 pub type FT_Slot_Internal = *mut FT_Slot_InternalRec_;
 pub type FT_SubGlyph = *mut FT_SubGlyphRec_;
-pub type hb_bool_t = libc::c_int;
-pub type hb_codepoint_t = uint32_t;
-pub type hb_position_t = int32_t;
-pub type hb_mask_t = uint32_t;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union _hb_var_int_t {
-    pub u32_0: uint32_t,
-    pub i32_0: int32_t,
-    pub u16_0: [uint16_t; 2],
-    pub i16_0: [int16_t; 2],
-    pub u8_0: [uint8_t; 4],
-    pub i8_0: [int8_t; 4],
-}
-pub type hb_var_int_t = _hb_var_int_t;
-pub type hb_tag_t = uint32_t;
-pub type hb_direction_t = libc::c_uint;
-pub const HB_DIRECTION_BTT: hb_direction_t = 7;
-pub const HB_DIRECTION_TTB: hb_direction_t = 6;
-pub const HB_DIRECTION_RTL: hb_direction_t = 5;
-pub const HB_DIRECTION_LTR: hb_direction_t = 4;
-pub const HB_DIRECTION_INVALID: hb_direction_t = 0;
-pub type hb_language_t = *const hb_language_impl_t;
-pub type hb_script_t = libc::c_uint;
-pub const _HB_SCRIPT_MAX_VALUE_SIGNED: hb_script_t = 2147483647;
-pub const _HB_SCRIPT_MAX_VALUE: hb_script_t = 2147483647;
-pub const HB_SCRIPT_INVALID: hb_script_t = 0;
-pub const HB_SCRIPT_WANCHO: hb_script_t = 1466132591;
-pub const HB_SCRIPT_NYIAKENG_PUACHUE_HMONG: hb_script_t = 1215131248;
-pub const HB_SCRIPT_NANDINAGARI: hb_script_t = 1315008100;
-pub const HB_SCRIPT_ELYMAIC: hb_script_t = 1164736877;
-pub const HB_SCRIPT_SOGDIAN: hb_script_t = 1399809892;
-pub const HB_SCRIPT_OLD_SOGDIAN: hb_script_t = 1399809903;
-pub const HB_SCRIPT_MEDEFAIDRIN: hb_script_t = 1298490470;
-pub const HB_SCRIPT_MAKASAR: hb_script_t = 1298230113;
-pub const HB_SCRIPT_HANIFI_ROHINGYA: hb_script_t = 1383032935;
-pub const HB_SCRIPT_GUNJALA_GONDI: hb_script_t = 1198485095;
-pub const HB_SCRIPT_DOGRA: hb_script_t = 1148151666;
-pub const HB_SCRIPT_ZANABAZAR_SQUARE: hb_script_t = 1516334690;
-pub const HB_SCRIPT_SOYOMBO: hb_script_t = 1399814511;
-pub const HB_SCRIPT_NUSHU: hb_script_t = 1316186229;
-pub const HB_SCRIPT_MASARAM_GONDI: hb_script_t = 1198485101;
-pub const HB_SCRIPT_NEWA: hb_script_t = 1315272545;
-pub const HB_SCRIPT_TANGUT: hb_script_t = 1415671399;
-pub const HB_SCRIPT_OSAGE: hb_script_t = 1332963173;
-pub const HB_SCRIPT_MARCHEN: hb_script_t = 1298231907;
-pub const HB_SCRIPT_BHAIKSUKI: hb_script_t = 1114139507;
-pub const HB_SCRIPT_ADLAM: hb_script_t = 1097100397;
-pub const HB_SCRIPT_SIGNWRITING: hb_script_t = 1399287415;
-pub const HB_SCRIPT_OLD_HUNGARIAN: hb_script_t = 1215655527;
-pub const HB_SCRIPT_MULTANI: hb_script_t = 1299541108;
-pub const HB_SCRIPT_HATRAN: hb_script_t = 1214346354;
-pub const HB_SCRIPT_ANATOLIAN_HIEROGLYPHS: hb_script_t = 1215067511;
-pub const HB_SCRIPT_AHOM: hb_script_t = 1097363309;
-pub const HB_SCRIPT_WARANG_CITI: hb_script_t = 1466004065;
-pub const HB_SCRIPT_TIRHUTA: hb_script_t = 1416196712;
-pub const HB_SCRIPT_SIDDHAM: hb_script_t = 1399415908;
-pub const HB_SCRIPT_PSALTER_PAHLAVI: hb_script_t = 1349020784;
-pub const HB_SCRIPT_PAU_CIN_HAU: hb_script_t = 1348564323;
-pub const HB_SCRIPT_PALMYRENE: hb_script_t = 1348562029;
-pub const HB_SCRIPT_PAHAWH_HMONG: hb_script_t = 1215131239;
-pub const HB_SCRIPT_OLD_PERMIC: hb_script_t = 1348825709;
-pub const HB_SCRIPT_OLD_NORTH_ARABIAN: hb_script_t = 1315009122;
-pub const HB_SCRIPT_NABATAEAN: hb_script_t = 1315070324;
-pub const HB_SCRIPT_MRO: hb_script_t = 1299345263;
-pub const HB_SCRIPT_MODI: hb_script_t = 1299145833;
-pub const HB_SCRIPT_MENDE_KIKAKUI: hb_script_t = 1298493028;
-pub const HB_SCRIPT_MANICHAEAN: hb_script_t = 1298230889;
-pub const HB_SCRIPT_MAHAJANI: hb_script_t = 1298229354;
-pub const HB_SCRIPT_LINEAR_A: hb_script_t = 1281977953;
-pub const HB_SCRIPT_KHUDAWADI: hb_script_t = 1399418468;
-pub const HB_SCRIPT_KHOJKI: hb_script_t = 1265135466;
-pub const HB_SCRIPT_GRANTHA: hb_script_t = 1198678382;
-pub const HB_SCRIPT_ELBASAN: hb_script_t = 1164730977;
-pub const HB_SCRIPT_DUPLOYAN: hb_script_t = 1148547180;
-pub const HB_SCRIPT_CAUCASIAN_ALBANIAN: hb_script_t = 1097295970;
-pub const HB_SCRIPT_BASSA_VAH: hb_script_t = 1113682803;
-pub const HB_SCRIPT_TAKRI: hb_script_t = 1415670642;
-pub const HB_SCRIPT_SORA_SOMPENG: hb_script_t = 1399812705;
-pub const HB_SCRIPT_SHARADA: hb_script_t = 1399353956;
-pub const HB_SCRIPT_MIAO: hb_script_t = 1349284452;
-pub const HB_SCRIPT_MEROITIC_HIEROGLYPHS: hb_script_t = 1298494063;
-pub const HB_SCRIPT_MEROITIC_CURSIVE: hb_script_t = 1298494051;
-pub const HB_SCRIPT_CHAKMA: hb_script_t = 1130457965;
-pub const HB_SCRIPT_MANDAIC: hb_script_t = 1298230884;
-pub const HB_SCRIPT_BRAHMI: hb_script_t = 1114792296;
-pub const HB_SCRIPT_BATAK: hb_script_t = 1113683051;
-pub const HB_SCRIPT_TAI_VIET: hb_script_t = 1415673460;
-pub const HB_SCRIPT_TAI_THAM: hb_script_t = 1281453665;
-pub const HB_SCRIPT_SAMARITAN: hb_script_t = 1398893938;
-pub const HB_SCRIPT_OLD_TURKIC: hb_script_t = 1332898664;
-pub const HB_SCRIPT_OLD_SOUTH_ARABIAN: hb_script_t = 1398895202;
-pub const HB_SCRIPT_MEETEI_MAYEK: hb_script_t = 1299473769;
-pub const HB_SCRIPT_LISU: hb_script_t = 1281979253;
-pub const HB_SCRIPT_KAITHI: hb_script_t = 1265920105;
-pub const HB_SCRIPT_JAVANESE: hb_script_t = 1247901281;
-pub const HB_SCRIPT_INSCRIPTIONAL_PARTHIAN: hb_script_t = 1349678185;
-pub const HB_SCRIPT_INSCRIPTIONAL_PAHLAVI: hb_script_t = 1349020777;
-pub const HB_SCRIPT_IMPERIAL_ARAMAIC: hb_script_t = 1098018153;
-pub const HB_SCRIPT_EGYPTIAN_HIEROGLYPHS: hb_script_t = 1164409200;
-pub const HB_SCRIPT_BAMUM: hb_script_t = 1113681269;
-pub const HB_SCRIPT_AVESTAN: hb_script_t = 1098281844;
-pub const HB_SCRIPT_VAI: hb_script_t = 1449224553;
-pub const HB_SCRIPT_SUNDANESE: hb_script_t = 1400204900;
-pub const HB_SCRIPT_SAURASHTRA: hb_script_t = 1398895986;
-pub const HB_SCRIPT_REJANG: hb_script_t = 1382706791;
-pub const HB_SCRIPT_OL_CHIKI: hb_script_t = 1332503403;
-pub const HB_SCRIPT_LYDIAN: hb_script_t = 1283023977;
-pub const HB_SCRIPT_LYCIAN: hb_script_t = 1283023721;
-pub const HB_SCRIPT_LEPCHA: hb_script_t = 1281716323;
-pub const HB_SCRIPT_KAYAH_LI: hb_script_t = 1264675945;
-pub const HB_SCRIPT_CHAM: hb_script_t = 1130914157;
-pub const HB_SCRIPT_CARIAN: hb_script_t = 1130459753;
-pub const HB_SCRIPT_PHOENICIAN: hb_script_t = 1349021304;
-pub const HB_SCRIPT_PHAGS_PA: hb_script_t = 1349017959;
-pub const HB_SCRIPT_NKO: hb_script_t = 1315663727;
-pub const HB_SCRIPT_CUNEIFORM: hb_script_t = 1483961720;
-pub const HB_SCRIPT_BALINESE: hb_script_t = 1113681001;
-pub const HB_SCRIPT_TIFINAGH: hb_script_t = 1415999079;
-pub const HB_SCRIPT_SYLOTI_NAGRI: hb_script_t = 1400466543;
-pub const HB_SCRIPT_OLD_PERSIAN: hb_script_t = 1483761007;
-pub const HB_SCRIPT_NEW_TAI_LUE: hb_script_t = 1415670901;
-pub const HB_SCRIPT_KHAROSHTHI: hb_script_t = 1265131890;
-pub const HB_SCRIPT_GLAGOLITIC: hb_script_t = 1198285159;
-pub const HB_SCRIPT_COPTIC: hb_script_t = 1131376756;
-pub const HB_SCRIPT_BUGINESE: hb_script_t = 1114990441;
-pub const HB_SCRIPT_UGARITIC: hb_script_t = 1432838514;
-pub const HB_SCRIPT_TAI_LE: hb_script_t = 1415670885;
-pub const HB_SCRIPT_SHAVIAN: hb_script_t = 1399349623;
-pub const HB_SCRIPT_OSMANYA: hb_script_t = 1332964705;
-pub const HB_SCRIPT_LINEAR_B: hb_script_t = 1281977954;
-pub const HB_SCRIPT_LIMBU: hb_script_t = 1281977698;
-pub const HB_SCRIPT_CYPRIOT: hb_script_t = 1131442804;
-pub const HB_SCRIPT_TAGBANWA: hb_script_t = 1415669602;
-pub const HB_SCRIPT_TAGALOG: hb_script_t = 1416064103;
-pub const HB_SCRIPT_HANUNOO: hb_script_t = 1214344815;
-pub const HB_SCRIPT_BUHID: hb_script_t = 1114990692;
-pub const HB_SCRIPT_OLD_ITALIC: hb_script_t = 1232363884;
-pub const HB_SCRIPT_GOTHIC: hb_script_t = 1198486632;
-pub const HB_SCRIPT_DESERET: hb_script_t = 1148416628;
-pub const HB_SCRIPT_YI: hb_script_t = 1500080489;
-pub const HB_SCRIPT_THAANA: hb_script_t = 1416126817;
-pub const HB_SCRIPT_SYRIAC: hb_script_t = 1400468067;
-pub const HB_SCRIPT_SINHALA: hb_script_t = 1399418472;
-pub const HB_SCRIPT_RUNIC: hb_script_t = 1383427698;
-pub const HB_SCRIPT_OGHAM: hb_script_t = 1332175213;
-pub const HB_SCRIPT_MYANMAR: hb_script_t = 1299803506;
-pub const HB_SCRIPT_MONGOLIAN: hb_script_t = 1299148391;
-pub const HB_SCRIPT_KHMER: hb_script_t = 1265134962;
-pub const HB_SCRIPT_ETHIOPIC: hb_script_t = 1165256809;
-pub const HB_SCRIPT_CHEROKEE: hb_script_t = 1130915186;
-pub const HB_SCRIPT_CANADIAN_SYLLABICS: hb_script_t = 1130458739;
-pub const HB_SCRIPT_BRAILLE: hb_script_t = 1114792297;
-pub const HB_SCRIPT_BOPOMOFO: hb_script_t = 1114599535;
-pub const HB_SCRIPT_TIBETAN: hb_script_t = 1416192628;
-pub const HB_SCRIPT_THAI: hb_script_t = 1416126825;
-pub const HB_SCRIPT_TELUGU: hb_script_t = 1415933045;
-pub const HB_SCRIPT_TAMIL: hb_script_t = 1415671148;
-pub const HB_SCRIPT_ORIYA: hb_script_t = 1332902241;
-pub const HB_SCRIPT_MALAYALAM: hb_script_t = 1298954605;
-pub const HB_SCRIPT_LATIN: hb_script_t = 1281455214;
-pub const HB_SCRIPT_LAO: hb_script_t = 1281453935;
-pub const HB_SCRIPT_KATAKANA: hb_script_t = 1264676449;
-pub const HB_SCRIPT_KANNADA: hb_script_t = 1265525857;
-pub const HB_SCRIPT_HIRAGANA: hb_script_t = 1214870113;
-pub const HB_SCRIPT_HEBREW: hb_script_t = 1214603890;
-pub const HB_SCRIPT_HAN: hb_script_t = 1214344809;
-pub const HB_SCRIPT_HANGUL: hb_script_t = 1214344807;
-pub const HB_SCRIPT_GURMUKHI: hb_script_t = 1198879349;
-pub const HB_SCRIPT_GUJARATI: hb_script_t = 1198877298;
-pub const HB_SCRIPT_GREEK: hb_script_t = 1198679403;
-pub const HB_SCRIPT_GEORGIAN: hb_script_t = 1197830002;
-pub const HB_SCRIPT_DEVANAGARI: hb_script_t = 1147500129;
-pub const HB_SCRIPT_CYRILLIC: hb_script_t = 1132032620;
-pub const HB_SCRIPT_BENGALI: hb_script_t = 1113943655;
-pub const HB_SCRIPT_ARMENIAN: hb_script_t = 1098018158;
-pub const HB_SCRIPT_ARABIC: hb_script_t = 1098015074;
-pub const HB_SCRIPT_UNKNOWN: hb_script_t = 1517976186;
-pub const HB_SCRIPT_INHERITED: hb_script_t = 1516858984;
-pub const HB_SCRIPT_COMMON: hb_script_t = 1517910393;
-pub type hb_destroy_func_t = Option<unsafe extern "C" fn(_: *mut libc::c_void) -> ()>;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct hb_feature_t {
-    pub tag: hb_tag_t,
-    pub value: uint32_t,
-    pub start: libc::c_uint,
-    pub end: libc::c_uint,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct hb_glyph_info_t {
-    pub codepoint: hb_codepoint_t,
-    pub mask: hb_mask_t,
-    pub cluster: uint32_t,
-    pub var1: hb_var_int_t,
-    pub var2: hb_var_int_t,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct hb_glyph_position_t {
-    pub x_advance: hb_position_t,
-    pub y_advance: hb_position_t,
-    pub x_offset: hb_position_t,
-    pub y_offset: hb_position_t,
-    pub var: hb_var_int_t,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct hb_segment_properties_t {
-    pub direction: hb_direction_t,
-    pub script: hb_script_t,
-    pub language: hb_language_t,
-    pub reserved1: *mut libc::c_void,
-    pub reserved2: *mut libc::c_void,
-}
-pub type hb_buffer_content_type_t = libc::c_uint;
-pub const HB_BUFFER_CONTENT_TYPE_GLYPHS: hb_buffer_content_type_t = 2;
-pub const HB_BUFFER_CONTENT_TYPE_UNICODE: hb_buffer_content_type_t = 1;
-pub const HB_BUFFER_CONTENT_TYPE_INVALID: hb_buffer_content_type_t = 0;
+
 pub type hb_unicode_decompose_compatibility_func_t = Option<
     unsafe extern "C" fn(
         _: *mut hb_unicode_funcs_t,
@@ -1989,6 +1638,7 @@ pub type hb_unicode_decompose_compatibility_func_t = Option<
         _: *mut libc::c_void,
     ) -> libc::c_uint,
 >;
+
 pub type OTTag = uint32_t;
 pub type GlyphID = uint16_t;
 pub type Fixed = i32;

--- a/engine/src/xetex_opentype_math.rs
+++ b/engine/src/xetex_opentype_math.rs
@@ -8,6 +8,7 @@
 #![feature(const_raw_ptr_to_usize_cast, extern_types, label_break_value)]
 
 use crate::core_memory::xmalloc;
+use harfbuzz_sys::*;
 
 extern "C" {
     pub type FT_LibraryRec_;
@@ -16,57 +17,10 @@ extern "C" {
     pub type FT_Size_InternalRec_;
     pub type FT_Slot_InternalRec_;
     pub type FT_SubGlyphRec_;
-    pub type hb_font_t;
     pub type XeTeXFont_rec;
     pub type XeTeXLayoutEngine_rec;
     #[no_mangle]
     fn free(__ptr: *mut libc::c_void);
-    #[no_mangle]
-    fn hb_ot_math_get_constant(
-        font: *mut hb_font_t,
-        constant: hb_ot_math_constant_t,
-    ) -> hb_position_t;
-    #[no_mangle]
-    fn hb_ot_math_get_glyph_italics_correction(
-        font: *mut hb_font_t,
-        glyph: hb_codepoint_t,
-    ) -> hb_position_t;
-    #[no_mangle]
-    fn hb_ot_math_get_glyph_top_accent_attachment(
-        font: *mut hb_font_t,
-        glyph: hb_codepoint_t,
-    ) -> hb_position_t;
-    #[no_mangle]
-    fn hb_ot_math_get_glyph_kerning(
-        font: *mut hb_font_t,
-        glyph: hb_codepoint_t,
-        kern: hb_ot_math_kern_t,
-        correction_height: hb_position_t,
-    ) -> hb_position_t;
-    #[no_mangle]
-    fn hb_ot_math_get_glyph_variants(
-        font: *mut hb_font_t,
-        glyph: hb_codepoint_t,
-        direction: hb_direction_t,
-        start_offset: libc::c_uint,
-        variants_count: *mut libc::c_uint,
-        variants: *mut hb_ot_math_glyph_variant_t,
-    ) -> libc::c_uint;
-    #[no_mangle]
-    fn hb_ot_math_get_min_connector_overlap(
-        font: *mut hb_font_t,
-        direction: hb_direction_t,
-    ) -> hb_position_t;
-    #[no_mangle]
-    fn hb_ot_math_get_glyph_assembly(
-        font: *mut hb_font_t,
-        glyph: hb_codepoint_t,
-        direction: hb_direction_t,
-        start_offset: libc::c_uint,
-        parts_count: *mut libc::c_uint,
-        parts: *mut hb_ot_math_glyph_part_t,
-        italics_correction: *mut hb_position_t,
-    ) -> libc::c_uint;
     #[no_mangle]
     fn getFont(engine: XeTeXLayoutEngine) -> XeTeXFont;
     #[no_mangle]
@@ -1304,94 +1258,9 @@ pub struct FT_GlyphSlotRec_ {
 }
 pub type FT_Slot_Internal = *mut FT_Slot_InternalRec_;
 pub type FT_SubGlyph = *mut FT_SubGlyphRec_;
-pub type hb_codepoint_t = uint32_t;
-pub type hb_position_t = int32_t;
-pub type hb_direction_t = libc::c_uint;
-pub const HB_DIRECTION_BTT: hb_direction_t = 7;
-pub const HB_DIRECTION_TTB: hb_direction_t = 6;
-pub const HB_DIRECTION_RTL: hb_direction_t = 5;
-pub const HB_DIRECTION_LTR: hb_direction_t = 4;
-pub const HB_DIRECTION_INVALID: hb_direction_t = 0;
-pub type hb_ot_math_constant_t = libc::c_uint;
-pub const HB_OT_MATH_CONSTANT_RADICAL_DEGREE_BOTTOM_RAISE_PERCENT: hb_ot_math_constant_t = 55;
-pub const HB_OT_MATH_CONSTANT_RADICAL_KERN_AFTER_DEGREE: hb_ot_math_constant_t = 54;
-pub const HB_OT_MATH_CONSTANT_RADICAL_KERN_BEFORE_DEGREE: hb_ot_math_constant_t = 53;
-pub const HB_OT_MATH_CONSTANT_RADICAL_EXTRA_ASCENDER: hb_ot_math_constant_t = 52;
-pub const HB_OT_MATH_CONSTANT_RADICAL_RULE_THICKNESS: hb_ot_math_constant_t = 51;
-pub const HB_OT_MATH_CONSTANT_RADICAL_DISPLAY_STYLE_VERTICAL_GAP: hb_ot_math_constant_t = 50;
-pub const HB_OT_MATH_CONSTANT_RADICAL_VERTICAL_GAP: hb_ot_math_constant_t = 49;
-pub const HB_OT_MATH_CONSTANT_UNDERBAR_EXTRA_DESCENDER: hb_ot_math_constant_t = 48;
-pub const HB_OT_MATH_CONSTANT_UNDERBAR_RULE_THICKNESS: hb_ot_math_constant_t = 47;
-pub const HB_OT_MATH_CONSTANT_UNDERBAR_VERTICAL_GAP: hb_ot_math_constant_t = 46;
-pub const HB_OT_MATH_CONSTANT_OVERBAR_EXTRA_ASCENDER: hb_ot_math_constant_t = 45;
-pub const HB_OT_MATH_CONSTANT_OVERBAR_RULE_THICKNESS: hb_ot_math_constant_t = 44;
-pub const HB_OT_MATH_CONSTANT_OVERBAR_VERTICAL_GAP: hb_ot_math_constant_t = 43;
-pub const HB_OT_MATH_CONSTANT_SKEWED_FRACTION_VERTICAL_GAP: hb_ot_math_constant_t = 42;
-pub const HB_OT_MATH_CONSTANT_SKEWED_FRACTION_HORIZONTAL_GAP: hb_ot_math_constant_t = 41;
-pub const HB_OT_MATH_CONSTANT_FRACTION_DENOM_DISPLAY_STYLE_GAP_MIN: hb_ot_math_constant_t = 40;
-pub const HB_OT_MATH_CONSTANT_FRACTION_DENOMINATOR_GAP_MIN: hb_ot_math_constant_t = 39;
-pub const HB_OT_MATH_CONSTANT_FRACTION_RULE_THICKNESS: hb_ot_math_constant_t = 38;
-pub const HB_OT_MATH_CONSTANT_FRACTION_NUM_DISPLAY_STYLE_GAP_MIN: hb_ot_math_constant_t = 37;
-pub const HB_OT_MATH_CONSTANT_FRACTION_NUMERATOR_GAP_MIN: hb_ot_math_constant_t = 36;
-pub const HB_OT_MATH_CONSTANT_FRACTION_DENOMINATOR_DISPLAY_STYLE_SHIFT_DOWN: hb_ot_math_constant_t =
-    35;
-pub const HB_OT_MATH_CONSTANT_FRACTION_DENOMINATOR_SHIFT_DOWN: hb_ot_math_constant_t = 34;
-pub const HB_OT_MATH_CONSTANT_FRACTION_NUMERATOR_DISPLAY_STYLE_SHIFT_UP: hb_ot_math_constant_t = 33;
-pub const HB_OT_MATH_CONSTANT_FRACTION_NUMERATOR_SHIFT_UP: hb_ot_math_constant_t = 32;
-pub const HB_OT_MATH_CONSTANT_STRETCH_STACK_GAP_BELOW_MIN: hb_ot_math_constant_t = 31;
-pub const HB_OT_MATH_CONSTANT_STRETCH_STACK_GAP_ABOVE_MIN: hb_ot_math_constant_t = 30;
-pub const HB_OT_MATH_CONSTANT_STRETCH_STACK_BOTTOM_SHIFT_DOWN: hb_ot_math_constant_t = 29;
-pub const HB_OT_MATH_CONSTANT_STRETCH_STACK_TOP_SHIFT_UP: hb_ot_math_constant_t = 28;
-pub const HB_OT_MATH_CONSTANT_STACK_DISPLAY_STYLE_GAP_MIN: hb_ot_math_constant_t = 27;
-pub const HB_OT_MATH_CONSTANT_STACK_GAP_MIN: hb_ot_math_constant_t = 26;
-pub const HB_OT_MATH_CONSTANT_STACK_BOTTOM_DISPLAY_STYLE_SHIFT_DOWN: hb_ot_math_constant_t = 25;
-pub const HB_OT_MATH_CONSTANT_STACK_BOTTOM_SHIFT_DOWN: hb_ot_math_constant_t = 24;
-pub const HB_OT_MATH_CONSTANT_STACK_TOP_DISPLAY_STYLE_SHIFT_UP: hb_ot_math_constant_t = 23;
-pub const HB_OT_MATH_CONSTANT_STACK_TOP_SHIFT_UP: hb_ot_math_constant_t = 22;
-pub const HB_OT_MATH_CONSTANT_LOWER_LIMIT_BASELINE_DROP_MIN: hb_ot_math_constant_t = 21;
-pub const HB_OT_MATH_CONSTANT_LOWER_LIMIT_GAP_MIN: hb_ot_math_constant_t = 20;
-pub const HB_OT_MATH_CONSTANT_UPPER_LIMIT_BASELINE_RISE_MIN: hb_ot_math_constant_t = 19;
-pub const HB_OT_MATH_CONSTANT_UPPER_LIMIT_GAP_MIN: hb_ot_math_constant_t = 18;
-pub const HB_OT_MATH_CONSTANT_SPACE_AFTER_SCRIPT: hb_ot_math_constant_t = 17;
-pub const HB_OT_MATH_CONSTANT_SUPERSCRIPT_BOTTOM_MAX_WITH_SUBSCRIPT: hb_ot_math_constant_t = 16;
-pub const HB_OT_MATH_CONSTANT_SUB_SUPERSCRIPT_GAP_MIN: hb_ot_math_constant_t = 15;
-pub const HB_OT_MATH_CONSTANT_SUPERSCRIPT_BASELINE_DROP_MAX: hb_ot_math_constant_t = 14;
-pub const HB_OT_MATH_CONSTANT_SUPERSCRIPT_BOTTOM_MIN: hb_ot_math_constant_t = 13;
-pub const HB_OT_MATH_CONSTANT_SUPERSCRIPT_SHIFT_UP_CRAMPED: hb_ot_math_constant_t = 12;
-pub const HB_OT_MATH_CONSTANT_SUPERSCRIPT_SHIFT_UP: hb_ot_math_constant_t = 11;
-pub const HB_OT_MATH_CONSTANT_SUBSCRIPT_BASELINE_DROP_MIN: hb_ot_math_constant_t = 10;
-pub const HB_OT_MATH_CONSTANT_SUBSCRIPT_TOP_MAX: hb_ot_math_constant_t = 9;
-pub const HB_OT_MATH_CONSTANT_SUBSCRIPT_SHIFT_DOWN: hb_ot_math_constant_t = 8;
-pub const HB_OT_MATH_CONSTANT_FLATTENED_ACCENT_BASE_HEIGHT: hb_ot_math_constant_t = 7;
-pub const HB_OT_MATH_CONSTANT_ACCENT_BASE_HEIGHT: hb_ot_math_constant_t = 6;
-pub const HB_OT_MATH_CONSTANT_AXIS_HEIGHT: hb_ot_math_constant_t = 5;
-pub const HB_OT_MATH_CONSTANT_MATH_LEADING: hb_ot_math_constant_t = 4;
-pub const HB_OT_MATH_CONSTANT_DISPLAY_OPERATOR_MIN_HEIGHT: hb_ot_math_constant_t = 3;
-pub const HB_OT_MATH_CONSTANT_DELIMITED_SUB_FORMULA_MIN_HEIGHT: hb_ot_math_constant_t = 2;
-pub const HB_OT_MATH_CONSTANT_SCRIPT_SCRIPT_PERCENT_SCALE_DOWN: hb_ot_math_constant_t = 1;
-pub const HB_OT_MATH_CONSTANT_SCRIPT_PERCENT_SCALE_DOWN: hb_ot_math_constant_t = 0;
-pub type hb_ot_math_kern_t = libc::c_uint;
-pub const HB_OT_MATH_KERN_BOTTOM_LEFT: hb_ot_math_kern_t = 3;
-pub const HB_OT_MATH_KERN_BOTTOM_RIGHT: hb_ot_math_kern_t = 2;
-pub const HB_OT_MATH_KERN_TOP_LEFT: hb_ot_math_kern_t = 1;
-pub const HB_OT_MATH_KERN_TOP_RIGHT: hb_ot_math_kern_t = 0;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct hb_ot_math_glyph_variant_t {
-    pub glyph: hb_codepoint_t,
-    pub advance: hb_position_t,
-}
-pub type hb_ot_math_glyph_part_flags_t = libc::c_uint;
+
 pub const HB_OT_MATH_GLYPH_PART_FLAG_EXTENDER: hb_ot_math_glyph_part_flags_t = 1;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct hb_ot_math_glyph_part_t {
-    pub glyph: hb_codepoint_t,
-    pub start_connector_length: hb_position_t,
-    pub end_connector_length: hb_position_t,
-    pub full_advance: hb_position_t,
-    pub flags: hb_ot_math_glyph_part_flags_t,
-}
+
 /* tectonic/xetex-core.h: core XeTeX types and #includes.
    Copyright 2016 the Tectonic Project
    Licensed under the MIT License.


### PR DESCRIPTION
@crlf0710 @ratmice Please take a look, In this commit, most `hb_` prefixed apis have been replaced by `hartbuzz_sys`, the next step I'm planning to remove those unused `self_0` in `engine/src/xetex_font_manager.rs`