### PR TITLE
Demacrofy

### DIFF
--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -151,6 +151,7 @@ mod core_memory {
 
 mod bibtex;
 mod xetex_aatfont;
+mod xetex_consts;
 mod xetex_engine_interface;
 mod xetex_errors;
 mod xetex_ext;

--- a/engine/src/xetex_consts.rs
+++ b/engine/src/xetex_consts.rs
@@ -153,6 +153,10 @@ pub unsafe fn LOCAL(n: placeholdertype) -> placeholdertype {
     (*(eqtb.offset((LOCAL_BASE + n) as isize))).b32.s1
 }
 
+pub unsafe fn LOCAL_set(n: placeholdertype, m: placeholdertype) {
+    (*(eqtb.offset((LOCAL_BASE + n) as isize))).b32.s1 = m
+}
+
 pub const TOKS_BASE: placeholdertype = (LOCAL_BASE + NUM_LOCALS);
 pub unsafe fn TOKS_REG(n: placeholdertype) -> placeholdertype {
     (*(eqtb.offset((TOKS_BASE + n) as isize))).b32.s1
@@ -181,25 +185,40 @@ pub const CAT_CODE_BASE: placeholdertype = (MATH_FONT_BASE + NUMBER_MATH_FONTS);
 pub unsafe fn CAT_CODE(n: placeholdertype) -> placeholdertype {
     (*(eqtb.offset((CAT_CODE_BASE + n) as isize))).b32.s1
 }
+pub unsafe fn CAT_CODE_set(n: placeholdertype, m: placeholdertype) {
+    (*(eqtb.offset((CAT_CODE_BASE + n) as isize))).b32.s1 = m;
+}
 
 pub const LC_CODE_BASE: placeholdertype = (CAT_CODE_BASE + NUMBER_USVS);
 pub unsafe fn LC_CODE(n: placeholdertype) -> placeholdertype {
     (*(eqtb.offset((LC_CODE_BASE + n) as isize))).b32.s1
+}
+pub unsafe fn LC_CODE_set(n: placeholdertype, m: placeholdertype) {
+    (*(eqtb.offset((LC_CODE_BASE + n) as isize))).b32.s1 = m
 }
 
 pub const UC_CODE_BASE: placeholdertype = (LC_CODE_BASE + NUMBER_USVS);
 pub unsafe fn UC_CODE(n: placeholdertype) -> placeholdertype {
     (*(eqtb.offset((UC_CODE_BASE + n) as isize))).b32.s1
 }
+pub unsafe fn UC_CODE_set(n: placeholdertype, m: placeholdertype) {
+    (*(eqtb.offset((UC_CODE_BASE + n) as isize))).b32.s1 = m
+}
 
 pub const SF_CODE_BASE: placeholdertype = (UC_CODE_BASE + NUMBER_USVS);
 pub unsafe fn SF_CODE(n: placeholdertype) -> placeholdertype {
     (*(eqtb.offset((SF_CODE_BASE + n) as isize))).b32.s1
 }
+pub unsafe fn SF_CODE_set(n: placeholdertype, m: placeholdertype) {
+    (*(eqtb.offset((SF_CODE_BASE + n) as isize))).b32.s1 = m
+}
 
 pub const MATH_CODE_BASE: placeholdertype = (SF_CODE_BASE + NUMBER_USVS);
 pub unsafe fn MATH_CODE(n: placeholdertype) -> placeholdertype {
     (*(eqtb.offset((MATH_CODE_BASE + n) as isize))).b32.s1
+}
+pub unsafe fn MATH_CODE_set(n: placeholdertype, m: placeholdertype) {
+    (*(eqtb.offset((MATH_CODE_BASE + n) as isize))).b32.s1 = m
 }
 
 pub const CHAR_SUB_CODE_BASE: placeholdertype = (MATH_CODE_BASE + NUMBER_USVS);
@@ -303,6 +322,10 @@ pub unsafe fn INTPAR(x: placeholdertype) -> placeholdertype {
     (*(eqtb.offset((INT_BASE + x) as isize))).b32.s1
 }
 
+pub unsafe fn INTPAR_set(x: placeholdertype, y: placeholdertype) {
+    (*(eqtb.offset((INT_BASE + x) as isize))).b32.s1 = y;
+}
+
 pub const COUNT_BASE: placeholdertype = (INT_BASE + INT_PARS);
 pub unsafe fn COUNT_REG(n: placeholdertype) -> placeholdertype {
     (*(eqtb.offset((COUNT_BASE + n) as isize))).b32.s1
@@ -311,6 +334,9 @@ pub unsafe fn COUNT_REG(n: placeholdertype) -> placeholdertype {
 pub const DEL_CODE_BASE: placeholdertype = (COUNT_BASE + NUMBER_REGS);
 pub unsafe fn DEL_CODE(n: placeholdertype) -> placeholdertype {
     (*(eqtb.offset((DEL_CODE_BASE + n) as isize))).b32.s1
+}
+pub unsafe fn DEL_CODE_set(n: placeholdertype, m: placeholdertype) {
+    (*(eqtb.offset((DEL_CODE_BASE + n) as isize))).b32.s1 = m
 }
 
 /* "region 6": current fullword dimensions like hsize */
@@ -515,137 +541,137 @@ pub const ABSORBING: placeholdertype = 5;
 
 /* commands */
 
-pub const ESCAPE: placeholdertype = 0;
+pub const ESCAPE: u16 = 0;
 /// = ESCAPE
-pub const RELAX: placeholdertype = 0;
-pub const LEFT_BRACE: placeholdertype = 1;
-pub const RIGHT_BRACE: placeholdertype = 2;
-pub const MATH_SHIFT: placeholdertype = 3;
-pub const TAB_MARK: placeholdertype = 4;
-pub const CAR_RET: placeholdertype = 5;
+pub const RELAX: u16 = 0;
+pub const LEFT_BRACE: u16 = 1;
+pub const RIGHT_BRACE: u16 = 2;
+pub const MATH_SHIFT: u16 = 3;
+pub const TAB_MARK: u16 = 4;
+pub const CAR_RET: u16 = 5;
 /// = CAR_RET
-pub const OUT_PARAM: placeholdertype = 5;
-pub const MAC_PARAM: placeholdertype = 6;
-pub const SUP_MARK: placeholdertype = 7;
-pub const SUB_MARK: placeholdertype = 8;
-pub const IGNORE: placeholdertype = 9;
+pub const OUT_PARAM: u16 = 5;
+pub const MAC_PARAM: u16 = 6;
+pub const SUP_MARK: u16 = 7;
+pub const SUB_MARK: u16 = 8;
+pub const IGNORE: u16 = 9;
 /// = IGNORE
-pub const ENDV: placeholdertype = 9;
-pub const SPACER: placeholdertype = 10;
-pub const LETTER: placeholdertype = 11;
-pub const OTHER_CHAR: placeholdertype = 12;
-pub const ACTIVE_CHAR: placeholdertype = 13;
+pub const ENDV: u16 = 9;
+pub const SPACER: u16 = 10;
+pub const LETTER: u16 = 11;
+pub const OTHER_CHAR: u16 = 12;
+pub const ACTIVE_CHAR: u16 = 13;
 /// = ACTIVE_CHAR
-pub const PAR_END: placeholdertype = 13;
+pub const PAR_END: u16 = 13;
 /// = ACTIVE_CHAR
-pub const MATCH: placeholdertype = 13;
-pub const COMMENT: placeholdertype = 14;
+pub const MATCH: u16 = 13;
+pub const COMMENT: u16 = 14;
 /// = COMMENT
-pub const END_MATCH: placeholdertype = 14;
+pub const END_MATCH: u16 = 14;
 /// = COMMENT
-pub const STOP: placeholdertype = 14;
-pub const INVALID_CHAR: placeholdertype = 15;
+pub const STOP: u16 = 14;
+pub const INVALID_CHAR: u16 = 15;
 /// = INVALID_CHAR
-pub const DELIM_NUM: placeholdertype = 15;
-pub const CHAR_NUM: placeholdertype = 16;
-pub const MATH_CHAR_NUM: placeholdertype = 17;
-pub const MARK: placeholdertype = 18;
-pub const XRAY: placeholdertype = 19;
-pub const MAKE_BOX: placeholdertype = 20;
-pub const HMOVE: placeholdertype = 21;
-pub const VMOVE: placeholdertype = 22;
-pub const UN_HBOX: placeholdertype = 23;
-pub const UN_VBOX: placeholdertype = 24;
-pub const REMOVE_ITEM: placeholdertype = 25;
-pub const HSKIP: placeholdertype = 26;
-pub const VSKIP: placeholdertype = 27;
-pub const MSKIP: placeholdertype = 28;
-pub const KERN: placeholdertype = 29;
-pub const MKERN: placeholdertype = 30;
-pub const LEADER_SHIP: placeholdertype = 31;
-pub const HALIGN: placeholdertype = 32;
-pub const VALIGN: placeholdertype = 33;
-pub const NO_ALIGN: placeholdertype = 34;
-pub const VRULE: placeholdertype = 35;
-pub const HRULE: placeholdertype = 36;
-pub const INSERT: placeholdertype = 37;
-pub const VADJUST: placeholdertype = 38;
-pub const IGNORE_SPACES: placeholdertype = 39;
-pub const AFTER_ASSIGNMENT: placeholdertype = 40;
-pub const AFTER_GROUP: placeholdertype = 41;
-pub const BREAK_PENALTY: placeholdertype = 42;
-pub const START_PAR: placeholdertype = 43;
-pub const ITAL_CORR: placeholdertype = 44;
-pub const ACCENT: placeholdertype = 45;
-pub const MATH_ACCENT: placeholdertype = 46;
-pub const DISCRETIONARY: placeholdertype = 47;
-pub const EQ_NO: placeholdertype = 48;
-pub const LEFT_RIGHT: placeholdertype = 49;
-pub const MATH_COMP: placeholdertype = 50;
-pub const LIMIT_SWITCH: placeholdertype = 51;
-pub const ABOVE: placeholdertype = 52;
-pub const MATH_STYLE: placeholdertype = 53;
-pub const MATH_CHOICE: placeholdertype = 54;
-pub const NON_SCRIPT: placeholdertype = 55;
-pub const VCENTER: placeholdertype = 56;
-pub const CASE_SHIFT: placeholdertype = 57;
-pub const MESSAGE: placeholdertype = 58;
-pub const EXTENSION: placeholdertype = 59;
-pub const IN_STREAM: placeholdertype = 60;
-pub const BEGIN_GROUP: placeholdertype = 61;
-pub const END_GROUP: placeholdertype = 62;
-pub const OMIT: placeholdertype = 63;
-pub const EX_SPACE: placeholdertype = 64;
-pub const NO_BOUNDARY: placeholdertype = 65;
-pub const RADICAL: placeholdertype = 66;
-pub const END_CS_NAME: placeholdertype = 67;
-pub const CHAR_GIVEN: placeholdertype = 68;
-pub const MIN_INTERNAL: placeholdertype = 68;
-pub const MATH_GIVEN: placeholdertype = 69;
-pub const XETEX_MATH_GIVEN: placeholdertype = 70;
-pub const LAST_ITEM: placeholdertype = 71;
-pub const MAX_NON_PREFIXED_COMMAND: placeholdertype = 71;
-pub const TOKS_REGISTER: placeholdertype = 72;
-pub const ASSIGN_TOKS: placeholdertype = 73;
-pub const ASSIGN_INT: placeholdertype = 74;
-pub const ASSIGN_DIMEN: placeholdertype = 75;
-pub const ASSIGN_GLUE: placeholdertype = 76;
-pub const ASSIGN_MU_GLUE: placeholdertype = 77;
-pub const ASSIGN_FONT_DIMEN: placeholdertype = 78;
-pub const ASSIGN_FONT_INT: placeholdertype = 79;
-pub const SET_AUX: placeholdertype = 80;
-pub const SET_PREV_GRAF: placeholdertype = 81;
-pub const SET_PAGE_DIMEN: placeholdertype = 82;
-pub const SET_PAGE_INT: placeholdertype = 83;
-pub const SET_BOX_DIMEN: placeholdertype = 84;
-pub const SET_SHAPE: placeholdertype = 85;
-pub const DEF_CODE: placeholdertype = 86;
-pub const XETEX_DEF_CODE: placeholdertype = 87;
-pub const DEF_FAMILY: placeholdertype = 88;
-pub const SET_FONT: placeholdertype = 89;
-pub const DEF_FONT: placeholdertype = 90;
-pub const MAX_INTERNAL: placeholdertype = 91;
-pub const REGISTER: placeholdertype = 91;
-pub const ADVANCE: placeholdertype = 92;
-pub const MULTIPLY: placeholdertype = 93;
-pub const DIVIDE: placeholdertype = 94;
-pub const PREFIX: placeholdertype = 95;
-pub const LET: placeholdertype = 96;
-pub const SHORTHAND_DEF: placeholdertype = 97;
-pub const READ_TO_CS: placeholdertype = 98;
-pub const DEF: placeholdertype = 99;
-pub const SET_BOX: placeholdertype = 100;
-pub const HYPH_DATA: placeholdertype = 101;
-pub const SET_INTERACTION: placeholdertype = 102;
-pub const EXPAND_AFTER: placeholdertype = 104;
-pub const NO_EXPAND: placeholdertype = 105;
-pub const INPUT: placeholdertype = 106;
-pub const IF_TEST: placeholdertype = 107;
-pub const FI_OR_ELSE: placeholdertype = 108;
-pub const CS_NAME: placeholdertype = 109;
-pub const CONVERT: placeholdertype = 110;
-pub const THE: placeholdertype = 111;
-pub const TOP_BOT_MARK: placeholdertype = 112;
+pub const DELIM_NUM: u16 = 15;
+pub const CHAR_NUM: u16 = 16;
+pub const MATH_CHAR_NUM: u16 = 17;
+pub const MARK: u16 = 18;
+pub const XRAY: u16 = 19;
+pub const MAKE_BOX: u16 = 20;
+pub const HMOVE: u16 = 21;
+pub const VMOVE: u16 = 22;
+pub const UN_HBOX: u16 = 23;
+pub const UN_VBOX: u16 = 24;
+pub const REMOVE_ITEM: u16 = 25;
+pub const HSKIP: u16 = 26;
+pub const VSKIP: u16 = 27;
+pub const MSKIP: u16 = 28;
+pub const KERN: u16 = 29;
+pub const MKERN: u16 = 30;
+pub const LEADER_SHIP: u16 = 31;
+pub const HALIGN: u16 = 32;
+pub const VALIGN: u16 = 33;
+pub const NO_ALIGN: u16 = 34;
+pub const VRULE: u16 = 35;
+pub const HRULE: u16 = 36;
+pub const INSERT: u16 = 37;
+pub const VADJUST: u16 = 38;
+pub const IGNORE_SPACES: u16 = 39;
+pub const AFTER_ASSIGNMENT: u16 = 40;
+pub const AFTER_GROUP: u16 = 41;
+pub const BREAK_PENALTY: u16 = 42;
+pub const START_PAR: u16 = 43;
+pub const ITAL_CORR: u16 = 44;
+pub const ACCENT: u16 = 45;
+pub const MATH_ACCENT: u16 = 46;
+pub const DISCRETIONARY: u16 = 47;
+pub const EQ_NO: u16 = 48;
+pub const LEFT_RIGHT: u16 = 49;
+pub const MATH_COMP: u16 = 50;
+pub const LIMIT_SWITCH: u16 = 51;
+pub const ABOVE: u16 = 52;
+pub const MATH_STYLE: u16 = 53;
+pub const MATH_CHOICE: u16 = 54;
+pub const NON_SCRIPT: u16 = 55;
+pub const VCENTER: u16 = 56;
+pub const CASE_SHIFT: u16 = 57;
+pub const MESSAGE: u16 = 58;
+pub const EXTENSION: u16 = 59;
+pub const IN_STREAM: u16 = 60;
+pub const BEGIN_GROUP: u16 = 61;
+pub const END_GROUP: u16 = 62;
+pub const OMIT: u16 = 63;
+pub const EX_SPACE: u16 = 64;
+pub const NO_BOUNDARY: u16 = 65;
+pub const RADICAL: u16 = 66;
+pub const END_CS_NAME: u16 = 67;
+pub const CHAR_GIVEN: u16 = 68;
+pub const MIN_INTERNAL: u16 = 68;
+pub const MATH_GIVEN: u16 = 69;
+pub const XETEX_MATH_GIVEN: u16 = 70;
+pub const LAST_ITEM: u16 = 71;
+pub const MAX_NON_PREFIXED_COMMAND: u16 = 71;
+pub const TOKS_REGISTER: u16 = 72;
+pub const ASSIGN_TOKS: u16 = 73;
+pub const ASSIGN_INT: u16 = 74;
+pub const ASSIGN_DIMEN: u16 = 75;
+pub const ASSIGN_GLUE: u16 = 76;
+pub const ASSIGN_MU_GLUE: u16 = 77;
+pub const ASSIGN_FONT_DIMEN: u16 = 78;
+pub const ASSIGN_FONT_INT: u16 = 79;
+pub const SET_AUX: u16 = 80;
+pub const SET_PREV_GRAF: u16 = 81;
+pub const SET_PAGE_DIMEN: u16 = 82;
+pub const SET_PAGE_INT: u16 = 83;
+pub const SET_BOX_DIMEN: u16 = 84;
+pub const SET_SHAPE: u16 = 85;
+pub const DEF_CODE: u16 = 86;
+pub const XETEX_DEF_CODE: u16 = 87;
+pub const DEF_FAMILY: u16 = 88;
+pub const SET_FONT: u16 = 89;
+pub const DEF_FONT: u16 = 90;
+pub const MAX_INTERNAL: u16 = 91;
+pub const REGISTER: u16 = 91;
+pub const ADVANCE: u16 = 92;
+pub const MULTIPLY: u16 = 93;
+pub const DIVIDE: u16 = 94;
+pub const PREFIX: u16 = 95;
+pub const LET: u16 = 96;
+pub const SHORTHAND_DEF: u16 = 97;
+pub const READ_TO_CS: u16 = 98;
+pub const DEF: u16 = 99;
+pub const SET_BOX: u16 = 100;
+pub const HYPH_DATA: u16 = 101;
+pub const SET_INTERACTION: u16 = 102;
+pub const EXPAND_AFTER: u16 = 104;
+pub const NO_EXPAND: u16 = 105;
+pub const INPUT: u16 = 106;
+pub const IF_TEST: u16 = 107;
+pub const FI_OR_ELSE: u16 = 108;
+pub const CS_NAME: u16 = 109;
+pub const CONVERT: u16 = 110;
+pub const THE: u16 = 111;
+pub const TOP_BOT_MARK: u16 = 112;
 
 /* args to SET_BOX_DIMEN */
 pub const WIDTH_OFFSET: placeholdertype = 1;

--- a/engine/src/xetex_consts.rs
+++ b/engine/src/xetex_consts.rs
@@ -1,0 +1,1107 @@
+use crate::xetex_ini::eqtb;
+
+pub type placeholdertype = i32;
+pub const MIN_HALFWORD: placeholdertype = -0x0FFFFFFF;
+pub const MAX_HALFWORD: placeholdertype = 0x3FFFFFFF;
+
+/// a null "pointer"
+pub const TEX_NULL: placeholdertype = MIN_HALFWORD;
+/// "the largest positive value that TeX knows"
+pub const TEX_INFINITY: placeholdertype = 0x7FFFFFFF;
+/// "signifies a missing item" in rule nodes */
+pub const NULL_FLAG: placeholdertype = -0x40000000;
+/// "denotes default_rule_thickness"
+pub const DEFAULT_CODE: placeholdertype = 0x40000000;
+
+/* characters
+ *
+ * TeX thinks there are only 256 character but we know better. We use UTF16
+ * codepoints. Actual Unicode character codes can exceed this, up to
+ * BIGGEST_USV. "USV" here means Unicode Scalar Value. */
+
+/// must be <= max_quarterword
+pub const BIGGEST_CHAR: placeholdertype = 0xFFFF;
+pub const BIGGEST_USV: placeholdertype = 0x10FFFF;
+pub const NUMBER_USVS: placeholdertype = (BIGGEST_USV + 1);
+pub const TOO_BIG_USV: placeholdertype = (BIGGEST_USV + 1);
+
+/* Various buffer sizes */
+
+/// max number of control sequences
+pub const HASH_SIZE: placeholdertype = 15000;
+/// "a prime number equal to about 85% of hash_size
+pub const HASH_PRIME: placeholdertype = 8501;
+
+pub const MAX_FONT_MAX: placeholdertype = 9000;
+
+pub const NUMBER_MATH_FAMILIES: placeholdertype = 256;
+pub const TEXT_SIZE: placeholdertype = 0;
+pub const SCRIPT_SIZE: placeholdertype = NUMBER_MATH_FAMILIES;
+pub const SCRIPT_SCRIPT_SIZE: placeholdertype = (2 * NUMBER_MATH_FAMILIES);
+pub const NUMBER_MATH_FONTS: placeholdertype = (3 * NUMBER_MATH_FAMILIES);
+
+pub const NUMBER_REGS: placeholdertype = 256;
+
+/// the size of our main "mem" array, minus 1; classically this is
+/// configurable, but we hardcode it.
+pub const MEM_TOP: placeholdertype = 4999999;
+
+/* fixed locations in the "mem" array */
+pub const PAGE_INS_HEAD: placeholdertype = MEM_TOP;
+pub const CONTRIB_HEAD: placeholdertype = (MEM_TOP - 1);
+pub const PAGE_HEAD: placeholdertype = (MEM_TOP - 2);
+pub const TEMP_HEAD: placeholdertype = (MEM_TOP - 3);
+pub const HOLD_HEAD: placeholdertype = (MEM_TOP - 4);
+pub const ADJUST_HEAD: placeholdertype = (MEM_TOP - 5);
+/// note: two words
+pub const ACTIVE_LIST: placeholdertype = (MEM_TOP - 7);
+pub const ALIGN_HEAD: placeholdertype = (MEM_TOP - 8);
+pub const END_SPAN: placeholdertype = (MEM_TOP - 9);
+pub const OMIT_TEMPLATE: placeholdertype = (MEM_TOP - 10);
+pub const NULL_LIST: placeholdertype = (MEM_TOP - 11);
+pub const LIG_TRICK: placeholdertype = (MEM_TOP - 12);
+/// note: same as LIG_TRICK
+pub const GARBAGE: placeholdertype = (MEM_TOP - 12);
+pub const BACKUP_HEAD: placeholdertype = (MEM_TOP - 13);
+pub const PRE_ADJUST_HEAD: placeholdertype = (MEM_TOP - 14);
+
+/* equivalents table offsets */
+
+/// "region 1": active character equivalents
+pub const ACTIVE_BASE: placeholdertype = 1;
+pub const SINGLE_BASE: placeholdertype = (ACTIVE_BASE + NUMBER_USVS);
+pub const NULL_CS: placeholdertype = (SINGLE_BASE + NUMBER_USVS);
+/// "region 2": hash table
+pub const HASH_BASE: placeholdertype = (NULL_CS + 1);
+pub const FROZEN_CONTROL_SEQUENCE: placeholdertype = (HASH_BASE + HASH_SIZE);
+pub const FROZEN_PROTECTION: placeholdertype = (FROZEN_CONTROL_SEQUENCE + 0);
+pub const FROZEN_CR: placeholdertype = (FROZEN_CONTROL_SEQUENCE + 1);
+pub const FROZEN_END_GROUP: placeholdertype = (FROZEN_CONTROL_SEQUENCE + 2);
+pub const FROZEN_RIGHT: placeholdertype = (FROZEN_CONTROL_SEQUENCE + 3);
+pub const FROZEN_FI: placeholdertype = (FROZEN_CONTROL_SEQUENCE + 4);
+pub const FROZEN_END_TEMPLATE: placeholdertype = (FROZEN_CONTROL_SEQUENCE + 5);
+pub const FROZEN_ENDV: placeholdertype = (FROZEN_CONTROL_SEQUENCE + 6);
+pub const FROZEN_RELAX: placeholdertype = (FROZEN_CONTROL_SEQUENCE + 7);
+pub const END_WRITE: placeholdertype = (FROZEN_CONTROL_SEQUENCE + 8);
+pub const FROZEN_DONT_EXPAND: placeholdertype = (FROZEN_CONTROL_SEQUENCE + 9);
+pub const FROZEN_SPECIAL: placeholdertype = (FROZEN_CONTROL_SEQUENCE + 10);
+pub const FROZEN_PRIMITIVE: placeholdertype = (FROZEN_CONTROL_SEQUENCE + 11);
+pub const FROZEN_NULL_FONT: placeholdertype = (FROZEN_CONTROL_SEQUENCE + 12);
+/// nominally minus FONT_BASE, but that's 0
+pub const FONT_ID_BASE: placeholdertype = FROZEN_NULL_FONT;
+pub const UNDEFINED_CONTROL_SEQUENCE: placeholdertype = (FROZEN_NULL_FONT + MAX_FONT_MAX + 1);
+
+/// "region 3": glue values
+pub const GLUE_BASE: placeholdertype = (UNDEFINED_CONTROL_SEQUENCE + 1);
+
+pub const GLUE_PAR__line_skip: placeholdertype = 0;
+pub const GLUE_PAR__baseline_skip: placeholdertype = 1;
+pub const GLUE_PAR__par_skip: placeholdertype = 2;
+pub const GLUE_PAR__above_display_skip: placeholdertype = 3;
+pub const GLUE_PAR__below_display_skip: placeholdertype = 4;
+pub const GLUE_PAR__above_display_short_skip: placeholdertype = 5;
+pub const GLUE_PAR__below_display_short_skip: placeholdertype = 6;
+pub const GLUE_PAR__left_skip: placeholdertype = 7;
+pub const GLUE_PAR__right_skip: placeholdertype = 8;
+pub const GLUE_PAR__top_skip: placeholdertype = 9;
+pub const GLUE_PAR__split_top_skip: placeholdertype = 10;
+pub const GLUE_PAR__tab_skip: placeholdertype = 11;
+pub const GLUE_PAR__space_skip: placeholdertype = 12;
+pub const GLUE_PAR__xspace_skip: placeholdertype = 13;
+pub const GLUE_PAR__par_fill_skip: placeholdertype = 14;
+pub const GLUE_PAR__xetex_linebreak_skip: placeholdertype = 15;
+pub const GLUE_PAR__thin_mu_skip: placeholdertype = 16;
+pub const GLUE_PAR__med_mu_skip: placeholdertype = 17;
+pub const GLUE_PAR__thick_mu_skip: placeholdertype = 18;
+pub const GLUE_PARS: placeholdertype = 19;
+
+pub unsafe fn GLUEPAR(s: placeholdertype) -> placeholdertype {
+    (*(eqtb.offset((GLUE_BASE + s) as isize))).b32.s1
+}
+
+pub const SKIP_BASE: placeholdertype = (GLUE_BASE + GLUE_PARS);
+pub unsafe fn SKIP_REG(n: placeholdertype) -> placeholdertype {
+    (*(eqtb.offset((SKIP_BASE + n) as isize))).b32.s1
+}
+
+pub const MU_SKIP_BASE: placeholdertype = (SKIP_BASE + NUMBER_REGS);
+pub unsafe fn MU_SKIP_REG(n: placeholdertype) -> placeholdertype {
+    (*(eqtb.offset((MU_SKIP_BASE + (n)) as isize))).b32.s1
+}
+
+/* "region 4": local halfword values like baselineskip. Some of these are
+ * used as arguments to ASSIGN_TOKS, SET_SHAPE, etc. */
+
+pub const LOCAL_BASE: placeholdertype = (MU_SKIP_BASE + NUMBER_REGS);
+
+pub const LOCAL__par_shape: placeholdertype = 0;
+pub const LOCAL__output_routine: placeholdertype = 1;
+pub const LOCAL__every_par: placeholdertype = 2;
+pub const LOCAL__every_math: placeholdertype = 3;
+pub const LOCAL__every_display: placeholdertype = 4;
+pub const LOCAL__every_hbox: placeholdertype = 5;
+pub const LOCAL__every_vbox: placeholdertype = 6;
+pub const LOCAL__every_job: placeholdertype = 7;
+pub const LOCAL__every_cr: placeholdertype = 8;
+pub const LOCAL__err_help: placeholdertype = 9;
+pub const LOCAL__every_eof: placeholdertype = 10;
+pub const LOCAL__xetex_inter_char: placeholdertype = 11;
+pub const LOCAL__TectonicCodaTokens: placeholdertype = 12;
+pub const NUM_LOCALS: placeholdertype = 13;
+
+pub unsafe fn LOCAL(n: placeholdertype) -> placeholdertype {
+    (*(eqtb.offset((LOCAL_BASE + n) as isize))).b32.s1
+}
+
+pub const TOKS_BASE: placeholdertype = (LOCAL_BASE + NUM_LOCALS);
+pub unsafe fn TOKS_REG(n: placeholdertype) -> placeholdertype {
+    (*(eqtb.offset((TOKS_BASE + n) as isize))).b32.s1
+}
+
+pub const ETEX_PEN_BASE: placeholdertype = (TOKS_BASE + NUMBER_REGS);
+pub const INTER_LINE_PENALTIES_LOC: placeholdertype = (ETEX_PEN_BASE + 0);
+pub const CLUB_PENALTIES_LOC: placeholdertype = (ETEX_PEN_BASE + 1);
+pub const WIDOW_PENALTIES_LOC: placeholdertype = (ETEX_PEN_BASE + 2);
+pub const DISPLAY_WIDOW_PENALTIES_LOC: placeholdertype = (ETEX_PEN_BASE + 3);
+pub const ETEX_PENS: placeholdertype = (ETEX_PEN_BASE + 4);
+
+pub const BOX_BASE: placeholdertype = ETEX_PENS;
+pub unsafe fn BOX_REG(n: placeholdertype) -> placeholdertype {
+    (*(eqtb.offset((BOX_BASE + n) as isize))).b32.s1
+}
+
+pub const CUR_FONT_LOC: placeholdertype = (BOX_BASE + NUMBER_REGS);
+pub const MATH_FONT_BASE: placeholdertype = (CUR_FONT_LOC + 1);
+
+pub unsafe fn MATH_FONT(n: placeholdertype) -> placeholdertype {
+    (*(eqtb.offset((MATH_FONT_BASE + n) as isize))).b32.s1
+}
+
+pub const CAT_CODE_BASE: placeholdertype = (MATH_FONT_BASE + NUMBER_MATH_FONTS);
+pub unsafe fn CAT_CODE(n: placeholdertype) -> placeholdertype {
+    (*(eqtb.offset((CAT_CODE_BASE + n) as isize))).b32.s1
+}
+
+pub const LC_CODE_BASE: placeholdertype = (CAT_CODE_BASE + NUMBER_USVS);
+pub unsafe fn LC_CODE(n: placeholdertype) -> placeholdertype {
+    (*(eqtb.offset((LC_CODE_BASE + n) as isize))).b32.s1
+}
+
+pub const UC_CODE_BASE: placeholdertype = (LC_CODE_BASE + NUMBER_USVS);
+pub unsafe fn UC_CODE(n: placeholdertype) -> placeholdertype {
+    (*(eqtb.offset((UC_CODE_BASE + n) as isize))).b32.s1
+}
+
+pub const SF_CODE_BASE: placeholdertype = (UC_CODE_BASE + NUMBER_USVS);
+pub unsafe fn SF_CODE(n: placeholdertype) -> placeholdertype {
+    (*(eqtb.offset((SF_CODE_BASE + n) as isize))).b32.s1
+}
+
+pub const MATH_CODE_BASE: placeholdertype = (SF_CODE_BASE + NUMBER_USVS);
+pub unsafe fn MATH_CODE(n: placeholdertype) -> placeholdertype {
+    (*(eqtb.offset((MATH_CODE_BASE + n) as isize))).b32.s1
+}
+
+pub const CHAR_SUB_CODE_BASE: placeholdertype = (MATH_CODE_BASE + NUMBER_USVS);
+pub unsafe fn CHAR_SUB_CODE(n: placeholdertype) -> placeholdertype {
+    (*(eqtb.offset((CHAR_SUB_CODE_BASE + n) as isize))).b32.s1
+}
+
+/* "region 5": current fullword integers like hyphenation penalty */
+
+pub const INT_BASE: placeholdertype = (CHAR_SUB_CODE_BASE + NUMBER_USVS);
+pub const INT_PAR__pretolerance: placeholdertype = 0;
+pub const INT_PAR__tolerance: placeholdertype = 1;
+pub const INT_PAR__line_penalty: placeholdertype = 2;
+pub const INT_PAR__hyphen_penalty: placeholdertype = 3;
+pub const INT_PAR__ex_hyphen_penalty: placeholdertype = 4;
+pub const INT_PAR__club_penalty: placeholdertype = 5;
+pub const INT_PAR__widow_penalty: placeholdertype = 6;
+pub const INT_PAR__display_widow_penalty: placeholdertype = 7;
+pub const INT_PAR__broken_penalty: placeholdertype = 8;
+pub const INT_PAR__bin_op_penalty: placeholdertype = 9;
+pub const INT_PAR__rel_penalty: placeholdertype = 10;
+pub const INT_PAR__pre_display_penalty: placeholdertype = 11;
+pub const INT_PAR__post_display_penalty: placeholdertype = 12;
+pub const INT_PAR__inter_line_penalty: placeholdertype = 13;
+pub const INT_PAR__double_hyphen_demerits: placeholdertype = 14;
+pub const INT_PAR__final_hyphen_demerits: placeholdertype = 15;
+pub const INT_PAR__adj_demerits: placeholdertype = 16;
+pub const INT_PAR__mag: placeholdertype = 17;
+pub const INT_PAR__delimiter_factor: placeholdertype = 18;
+pub const INT_PAR__looseness: placeholdertype = 19;
+pub const INT_PAR__time: placeholdertype = 20;
+pub const INT_PAR__day: placeholdertype = 21;
+pub const INT_PAR__month: placeholdertype = 22;
+pub const INT_PAR__year: placeholdertype = 23;
+pub const INT_PAR__show_box_breadth: placeholdertype = 24;
+pub const INT_PAR__show_box_depth: placeholdertype = 25;
+pub const INT_PAR__hbadness: placeholdertype = 26;
+pub const INT_PAR__vbadness: placeholdertype = 27;
+pub const INT_PAR__pausing: placeholdertype = 28;
+pub const INT_PAR__tracing_online: placeholdertype = 29;
+pub const INT_PAR__tracing_macros: placeholdertype = 30;
+pub const INT_PAR__tracing_stats: placeholdertype = 31;
+pub const INT_PAR__tracing_paragraphs: placeholdertype = 32;
+pub const INT_PAR__tracing_pages: placeholdertype = 33;
+pub const INT_PAR__tracing_output: placeholdertype = 34;
+pub const INT_PAR__tracing_lost_chars: placeholdertype = 35;
+pub const INT_PAR__tracing_commands: placeholdertype = 36;
+pub const INT_PAR__tracing_restores: placeholdertype = 37;
+pub const INT_PAR__uc_hyph: placeholdertype = 38;
+pub const INT_PAR__output_penalty: placeholdertype = 39;
+pub const INT_PAR__max_dead_cycles: placeholdertype = 40;
+pub const INT_PAR__hang_after: placeholdertype = 41;
+pub const INT_PAR__floating_penalty: placeholdertype = 42;
+pub const INT_PAR__global_defs: placeholdertype = 43;
+pub const INT_PAR__cur_fam: placeholdertype = 44;
+pub const INT_PAR__escape_char: placeholdertype = 45;
+pub const INT_PAR__default_hyphen_char: placeholdertype = 46;
+pub const INT_PAR__default_skew_char: placeholdertype = 47;
+pub const INT_PAR__end_line_char: placeholdertype = 48;
+pub const INT_PAR__new_line_char: placeholdertype = 49;
+pub const INT_PAR__language: placeholdertype = 50;
+pub const INT_PAR__left_hyphen_min: placeholdertype = 51;
+pub const INT_PAR__right_hyphen_min: placeholdertype = 52;
+pub const INT_PAR__holding_inserts: placeholdertype = 53;
+pub const INT_PAR__error_context_lines: placeholdertype = 54;
+/// TEX_INT_PARS = WEB2C_INT_BASE
+pub const INT_PAR__char_sub_def_min: placeholdertype = 55;
+pub const INT_PAR__char_sub_def_max: placeholdertype = 56;
+pub const INT_PAR__tracing_char_sub_def: placeholdertype = 57;
+/// = WEB2C_INT_PARS = ETEX_INT_BASE
+pub const INT_PAR__tracing_assigns: placeholdertype = 58;
+pub const INT_PAR__tracing_groups: placeholdertype = 59;
+pub const INT_PAR__tracing_ifs: placeholdertype = 60;
+pub const INT_PAR__tracing_scan_tokens: placeholdertype = 61;
+pub const INT_PAR__tracing_nesting: placeholdertype = 62;
+pub const INT_PAR__pre_display_correction: placeholdertype = 63;
+pub const INT_PAR__last_line_fit: placeholdertype = 64;
+pub const INT_PAR__saving_vdiscards: placeholdertype = 65;
+pub const INT_PAR__saving_hyphs: placeholdertype = 66;
+pub const INT_PAR__suppress_fontnotfound_error: placeholdertype = 67;
+pub const INT_PAR__xetex_linebreak_locale: placeholdertype = 68;
+pub const INT_PAR__xetex_linebreak_penalty: placeholdertype = 69;
+pub const INT_PAR__xetex_protrude_chars: placeholdertype = 70;
+pub const INT_PAR__texxet: placeholdertype = 71;
+pub const INT_PAR__xetex_dash_break: placeholdertype = 72;
+pub const INT_PAR__xetex_upwards: placeholdertype = 73;
+pub const INT_PAR__xetex_use_glyph_metrics: placeholdertype = 74;
+pub const INT_PAR__xetex_inter_char_tokens: placeholdertype = 75;
+pub const INT_PAR__xetex_input_normalization: placeholdertype = 76;
+pub const INT_PAR__xetex_default_input_mode: placeholdertype = 77;
+pub const INT_PAR__xetex_default_input_encoding: placeholdertype = 78;
+pub const INT_PAR__xetex_tracing_fonts: placeholdertype = 79;
+pub const INT_PAR__xetex_interword_space_shaping: placeholdertype = 80;
+pub const INT_PAR__xetex_generate_actual_text: placeholdertype = 81;
+pub const INT_PAR__xetex_hyphenatable_length: placeholdertype = 82;
+pub const INT_PAR__synctex: placeholdertype = 83;
+pub const INT_PAR__pdfoutput: placeholdertype = 84;
+pub const INT_PARS: placeholdertype = 85;
+
+pub unsafe fn INTPAR(x: placeholdertype) -> placeholdertype {
+    (*(eqtb.offset((INT_BASE + x) as isize))).b32.s1
+}
+
+pub const COUNT_BASE: placeholdertype = (INT_BASE + INT_PARS);
+pub unsafe fn COUNT_REG(n: placeholdertype) -> placeholdertype {
+    (*(eqtb.offset((COUNT_BASE + n) as isize))).b32.s1
+}
+
+pub const DEL_CODE_BASE: placeholdertype = (COUNT_BASE + NUMBER_REGS);
+pub unsafe fn DEL_CODE(n: placeholdertype) -> placeholdertype {
+    (*(eqtb.offset((DEL_CODE_BASE + n) as isize))).b32.s1
+}
+
+/* "region 6": current fullword dimensions like hsize */
+
+pub const DIMEN_BASE: placeholdertype = (DEL_CODE_BASE + NUMBER_USVS);
+pub const DIMEN_PAR__par_indent: placeholdertype = 0;
+pub const DIMEN_PAR__math_surround: placeholdertype = 1;
+pub const DIMEN_PAR__line_skip_limit: placeholdertype = 2;
+pub const DIMEN_PAR__hsize: placeholdertype = 3;
+pub const DIMEN_PAR__vsize: placeholdertype = 4;
+pub const DIMEN_PAR__max_depth: placeholdertype = 5;
+pub const DIMEN_PAR__split_max_depth: placeholdertype = 6;
+pub const DIMEN_PAR__box_max_depth: placeholdertype = 7;
+pub const DIMEN_PAR__hfuzz: placeholdertype = 8;
+pub const DIMEN_PAR__vfuzz: placeholdertype = 9;
+pub const DIMEN_PAR__delimiter_shortfall: placeholdertype = 10;
+pub const DIMEN_PAR__null_delimiter_space: placeholdertype = 11;
+pub const DIMEN_PAR__script_space: placeholdertype = 12;
+pub const DIMEN_PAR__pre_display_size: placeholdertype = 13;
+pub const DIMEN_PAR__display_width: placeholdertype = 14;
+pub const DIMEN_PAR__display_indent: placeholdertype = 15;
+pub const DIMEN_PAR__overfull_rule: placeholdertype = 16;
+pub const DIMEN_PAR__hang_indent: placeholdertype = 17;
+pub const DIMEN_PAR__h_offset: placeholdertype = 18;
+pub const DIMEN_PAR__v_offset: placeholdertype = 19;
+pub const DIMEN_PAR__emergency_stretch: placeholdertype = 20;
+pub const DIMEN_PAR__pdf_page_width: placeholdertype = 21;
+pub const DIMEN_PAR__pdf_page_height: placeholdertype = 22;
+pub const DIMEN_PARS: placeholdertype = 23;
+
+pub unsafe fn DIMENPAR(x: placeholdertype) -> placeholdertype {
+    (*(eqtb.offset((DIMEN_BASE + x as placeholdertype) as isize)))
+        .b32
+        .s1
+}
+
+pub const SCALED_BASE: placeholdertype = (DIMEN_BASE + DIMEN_PARS);
+pub unsafe fn SCALED_REG(n: placeholdertype) -> placeholdertype {
+    (*(eqtb.offset((SCALED_BASE + n) as isize))).b32.s1
+}
+
+pub const EQTB_SIZE: placeholdertype = (SCALED_BASE + NUMBER_REGS - 1);
+
+/// "really" MIN_QUARTERWORD
+pub const LEVEL_ZERO: placeholdertype = 0;
+pub const LEVEL_ONE: placeholdertype = 1;
+
+/* SET_INTERACTION */
+pub const BATCH_MODE: placeholdertype = 0;
+pub const NONSTOP_MODE: placeholdertype = 1;
+pub const SCROLL_MODE: placeholdertype = 2;
+pub const ERROR_STOP_MODE: placeholdertype = 3;
+pub const UNSPECIFIED_MODE: placeholdertype = 4;
+
+pub const LEFT_TO_RIGHT: placeholdertype = 0;
+pub const RIGHT_TO_LEFT: placeholdertype = 1;
+
+/* How many memory words are needed for storing synctex information on various
+ * kinds of nodes. This extra size is already included in the *_NODE_SIZE
+ * definitions below.
+ */
+pub const SYNCTEX_FIELD_SIZE: placeholdertype = 1;
+
+pub const HLIST_NODE: u16 = 0;
+pub const VLIST_NODE: u16 = 1;
+pub const DELTA_NODE: u16 = 2;
+pub const RULE_NODE: u16 = 2;
+pub const INS_NODE: u16 = 3;
+pub const MARK_NODE: u16 = 4;
+pub const ADJUST_NODE: u16 = 5;
+pub const LIGATURE_NODE: u16 = 6;
+pub const DISC_NODE: u16 = 7;
+pub const WHATSIT_NODE: u16 = 8;
+pub const MATH_NODE: u16 = 9;
+pub const GLUE_NODE: u16 = 10;
+pub const KERN_NODE: u16 = 11;
+pub const PENALTY_NODE: u16 = 12;
+pub const UNSET_NODE: u16 = 13;
+pub const EDGE_NODE: u16 = 14;
+pub const STYLE_NODE: u16 = 14;
+pub const CHOICE_NODE: u16 = 15;
+pub const MARGIN_KERN_NODE: u16 = 40;
+pub const NATIVE_WORD_NODE: u16 = 40;
+pub const NATIVE_WORD_NODE_AT: u16 = 41;
+/// not to be confused with GLYPH_CODE = 43!
+pub const GLYPH_NODE: u16 = 42;
+/// not to be confused with PIC_FILE_CODE = 41!
+pub const PIC_NODE: u16 = 43;
+/// not to be confused with PDF_FILE_CODE = 42!
+pub const PDF_NODE: u16 = 44;
+
+pub const IF_NODE_SIZE: placeholdertype = 2;
+pub const PASSIVE_NODE_SIZE: placeholdertype = 2;
+pub const POINTER_NODE_SIZE: placeholdertype = 2;
+pub const SMALL_NODE_SIZE: placeholdertype = 2;
+pub const SPAN_NODE_SIZE: placeholdertype = 2;
+pub const WRITE_NODE_SIZE: placeholdertype = 2;
+pub const ACTIVE_NODE_SIZE_NORMAL: placeholdertype = 3;
+pub const EDGE_NODE_SIZE: placeholdertype = 3;
+pub const MARGIN_KERN_NODE_SIZE: placeholdertype = 3;
+pub const MEDIUM_NODE_SIZE: placeholdertype = 3;
+pub const MOVEMENT_NODE_SIZE: placeholdertype = 3;
+pub const OPEN_NODE_SIZE: placeholdertype = 3;
+pub const STYLE_NODE_SIZE: placeholdertype = 3;
+pub const WORD_NODE_SIZE: placeholdertype = 3;
+pub const EXPR_NODE_SIZE: placeholdertype = 4;
+pub const GLUE_SPEC_SIZE: placeholdertype = 4;
+pub const MARK_CLASS_NODE_SIZE: placeholdertype = 4;
+pub const PAGE_INS_NODE_SIZE: placeholdertype = 4;
+pub const ACTIVE_NODE_SIZE_EXTENDED: placeholdertype = 5;
+pub const GLYPH_NODE_SIZE: placeholdertype = 5;
+pub const INS_NODE_SIZE: placeholdertype = 5;
+pub const RULE_NODE_SIZE: placeholdertype = 5;
+pub const ALIGN_STACK_NODE_SIZE: placeholdertype = 6;
+pub const NATIVE_NODE_SIZE: placeholdertype = 6;
+pub const DELTA_NODE_SIZE: placeholdertype = 7;
+pub const BOX_NODE_SIZE: placeholdertype = 8;
+pub const PIC_NODE_SIZE: placeholdertype = 9;
+pub const INDEX_NODE_SIZE: placeholdertype = 33;
+
+pub const NOAD_SIZE: placeholdertype = 4;
+pub const ACCENT_NOAD_SIZE: placeholdertype = 5;
+pub const RADICAL_NOAD_SIZE: placeholdertype = 5;
+pub const FRACTION_NOAD_SIZE: placeholdertype = 6;
+
+/* MATH_COMP and others */
+pub const ORD_NOAD: placeholdertype = 16;
+pub const OP_NOAD: placeholdertype = 17;
+pub const BIN_NOAD: placeholdertype = 18;
+pub const REL_NOAD: placeholdertype = 19;
+pub const OPEN_NOAD: placeholdertype = 20;
+pub const CLOSE_NOAD: placeholdertype = 21;
+pub const PUNCT_NOAD: placeholdertype = 22;
+pub const INNER_NOAD: placeholdertype = 23;
+pub const RADICAL_NOAD: placeholdertype = 24;
+pub const FRACTION_NOAD: placeholdertype = 25;
+pub const UNDER_NOAD: placeholdertype = 26;
+pub const OVER_NOAD: placeholdertype = 27;
+pub const ACCENT_NOAD: placeholdertype = 28;
+pub const VCENTER_NOAD: placeholdertype = 29;
+pub const LEFT_NOAD: placeholdertype = 30;
+pub const RIGHT_NOAD: placeholdertype = 31;
+
+/* args to TOP_BOT_MARK */
+pub const TOP_MARK_CODE: placeholdertype = 0;
+pub const FIRST_MARK_CODE: placeholdertype = 1;
+pub const BOT_MARK_CODE: placeholdertype = 2;
+pub const SPLIT_FIRST_MARK_CODE: placeholdertype = 3;
+pub const SPLIT_BOT_MARK_CODE: placeholdertype = 4;
+
+/* MATH_NODE stuff with L/R typesetting extras */
+pub const BEFORE: placeholdertype = 0;
+pub const AFTER: placeholdertype = 1;
+pub const BEGIN_M_CODE: placeholdertype = 2;
+pub const END_M_CODE: placeholdertype = 3;
+pub const L_CODE: placeholdertype = 4;
+pub const R_CODE: placeholdertype = 8;
+
+pub const EXPR_NONE: placeholdertype = 0;
+pub const EXPR_ADD: placeholdertype = 1;
+pub const EXPR_SUB: placeholdertype = 2;
+pub const EXPR_MULT: placeholdertype = 3;
+pub const EXPR_DIV: placeholdertype = 4;
+pub const EXPR_SCALE: placeholdertype = 5;
+
+pub const BOTTOM_LEVEL: placeholdertype = 0;
+pub const SIMPLE_GROUP: placeholdertype = 1;
+pub const HBOX_GROUP: placeholdertype = 2;
+pub const ADJUSTED_HBOX_GROUP: placeholdertype = 3;
+pub const VBOX_GROUP: placeholdertype = 4;
+pub const VTOP_GROUP: placeholdertype = 5;
+pub const ALIGN_GROUP: placeholdertype = 6;
+pub const NO_ALIGN_GROUP: placeholdertype = 7;
+pub const OUTPUT_GROUP: placeholdertype = 8;
+pub const MATH_GROUP: placeholdertype = 9;
+pub const DISC_GROUP: placeholdertype = 10;
+pub const INSERT_GROUP: placeholdertype = 11;
+pub const VCENTER_GROUP: placeholdertype = 12;
+pub const MATH_CHOICE_GROUP: placeholdertype = 13;
+pub const SEMI_SIMPLE_GROUP: placeholdertype = 14;
+pub const MATH_SHIFT_GROUP: placeholdertype = 15;
+pub const MATH_LEFT_GROUP: placeholdertype = 16;
+
+pub const SUP_CMD: placeholdertype = 0;
+pub const SUB_CMD: placeholdertype = 1;
+
+pub const FIL: placeholdertype = 1;
+pub const FILL: placeholdertype = 2;
+pub const FILLL: placeholdertype = 3;
+
+pub const LIG_TAG: placeholdertype = 1;
+pub const LIST_TAG: placeholdertype = 2;
+pub const EXT_TAG: placeholdertype = 3;
+
+/* scanner_status values: */
+pub const NORMAL: placeholdertype = 0;
+pub const SKIPPING: placeholdertype = 1;
+pub const DEFINING: placeholdertype = 2;
+pub const MATCHING: placeholdertype = 3;
+pub const ALIGNING: placeholdertype = 4;
+pub const ABSORBING: placeholdertype = 5;
+
+/* commands */
+
+pub const ESCAPE: placeholdertype = 0;
+/// = ESCAPE
+pub const RELAX: placeholdertype = 0;
+pub const LEFT_BRACE: placeholdertype = 1;
+pub const RIGHT_BRACE: placeholdertype = 2;
+pub const MATH_SHIFT: placeholdertype = 3;
+pub const TAB_MARK: placeholdertype = 4;
+pub const CAR_RET: placeholdertype = 5;
+/// = CAR_RET
+pub const OUT_PARAM: placeholdertype = 5;
+pub const MAC_PARAM: placeholdertype = 6;
+pub const SUP_MARK: placeholdertype = 7;
+pub const SUB_MARK: placeholdertype = 8;
+pub const IGNORE: placeholdertype = 9;
+/// = IGNORE
+pub const ENDV: placeholdertype = 9;
+pub const SPACER: placeholdertype = 10;
+pub const LETTER: placeholdertype = 11;
+pub const OTHER_CHAR: placeholdertype = 12;
+pub const ACTIVE_CHAR: placeholdertype = 13;
+/// = ACTIVE_CHAR
+pub const PAR_END: placeholdertype = 13;
+/// = ACTIVE_CHAR
+pub const MATCH: placeholdertype = 13;
+pub const COMMENT: placeholdertype = 14;
+/// = COMMENT
+pub const END_MATCH: placeholdertype = 14;
+/// = COMMENT
+pub const STOP: placeholdertype = 14;
+pub const INVALID_CHAR: placeholdertype = 15;
+/// = INVALID_CHAR
+pub const DELIM_NUM: placeholdertype = 15;
+pub const CHAR_NUM: placeholdertype = 16;
+pub const MATH_CHAR_NUM: placeholdertype = 17;
+pub const MARK: placeholdertype = 18;
+pub const XRAY: placeholdertype = 19;
+pub const MAKE_BOX: placeholdertype = 20;
+pub const HMOVE: placeholdertype = 21;
+pub const VMOVE: placeholdertype = 22;
+pub const UN_HBOX: placeholdertype = 23;
+pub const UN_VBOX: placeholdertype = 24;
+pub const REMOVE_ITEM: placeholdertype = 25;
+pub const HSKIP: placeholdertype = 26;
+pub const VSKIP: placeholdertype = 27;
+pub const MSKIP: placeholdertype = 28;
+pub const KERN: placeholdertype = 29;
+pub const MKERN: placeholdertype = 30;
+pub const LEADER_SHIP: placeholdertype = 31;
+pub const HALIGN: placeholdertype = 32;
+pub const VALIGN: placeholdertype = 33;
+pub const NO_ALIGN: placeholdertype = 34;
+pub const VRULE: placeholdertype = 35;
+pub const HRULE: placeholdertype = 36;
+pub const INSERT: placeholdertype = 37;
+pub const VADJUST: placeholdertype = 38;
+pub const IGNORE_SPACES: placeholdertype = 39;
+pub const AFTER_ASSIGNMENT: placeholdertype = 40;
+pub const AFTER_GROUP: placeholdertype = 41;
+pub const BREAK_PENALTY: placeholdertype = 42;
+pub const START_PAR: placeholdertype = 43;
+pub const ITAL_CORR: placeholdertype = 44;
+pub const ACCENT: placeholdertype = 45;
+pub const MATH_ACCENT: placeholdertype = 46;
+pub const DISCRETIONARY: placeholdertype = 47;
+pub const EQ_NO: placeholdertype = 48;
+pub const LEFT_RIGHT: placeholdertype = 49;
+pub const MATH_COMP: placeholdertype = 50;
+pub const LIMIT_SWITCH: placeholdertype = 51;
+pub const ABOVE: placeholdertype = 52;
+pub const MATH_STYLE: placeholdertype = 53;
+pub const MATH_CHOICE: placeholdertype = 54;
+pub const NON_SCRIPT: placeholdertype = 55;
+pub const VCENTER: placeholdertype = 56;
+pub const CASE_SHIFT: placeholdertype = 57;
+pub const MESSAGE: placeholdertype = 58;
+pub const EXTENSION: placeholdertype = 59;
+pub const IN_STREAM: placeholdertype = 60;
+pub const BEGIN_GROUP: placeholdertype = 61;
+pub const END_GROUP: placeholdertype = 62;
+pub const OMIT: placeholdertype = 63;
+pub const EX_SPACE: placeholdertype = 64;
+pub const NO_BOUNDARY: placeholdertype = 65;
+pub const RADICAL: placeholdertype = 66;
+pub const END_CS_NAME: placeholdertype = 67;
+pub const CHAR_GIVEN: placeholdertype = 68;
+pub const MIN_INTERNAL: placeholdertype = 68;
+pub const MATH_GIVEN: placeholdertype = 69;
+pub const XETEX_MATH_GIVEN: placeholdertype = 70;
+pub const LAST_ITEM: placeholdertype = 71;
+pub const MAX_NON_PREFIXED_COMMAND: placeholdertype = 71;
+pub const TOKS_REGISTER: placeholdertype = 72;
+pub const ASSIGN_TOKS: placeholdertype = 73;
+pub const ASSIGN_INT: placeholdertype = 74;
+pub const ASSIGN_DIMEN: placeholdertype = 75;
+pub const ASSIGN_GLUE: placeholdertype = 76;
+pub const ASSIGN_MU_GLUE: placeholdertype = 77;
+pub const ASSIGN_FONT_DIMEN: placeholdertype = 78;
+pub const ASSIGN_FONT_INT: placeholdertype = 79;
+pub const SET_AUX: placeholdertype = 80;
+pub const SET_PREV_GRAF: placeholdertype = 81;
+pub const SET_PAGE_DIMEN: placeholdertype = 82;
+pub const SET_PAGE_INT: placeholdertype = 83;
+pub const SET_BOX_DIMEN: placeholdertype = 84;
+pub const SET_SHAPE: placeholdertype = 85;
+pub const DEF_CODE: placeholdertype = 86;
+pub const XETEX_DEF_CODE: placeholdertype = 87;
+pub const DEF_FAMILY: placeholdertype = 88;
+pub const SET_FONT: placeholdertype = 89;
+pub const DEF_FONT: placeholdertype = 90;
+pub const MAX_INTERNAL: placeholdertype = 91;
+pub const REGISTER: placeholdertype = 91;
+pub const ADVANCE: placeholdertype = 92;
+pub const MULTIPLY: placeholdertype = 93;
+pub const DIVIDE: placeholdertype = 94;
+pub const PREFIX: placeholdertype = 95;
+pub const LET: placeholdertype = 96;
+pub const SHORTHAND_DEF: placeholdertype = 97;
+pub const READ_TO_CS: placeholdertype = 98;
+pub const DEF: placeholdertype = 99;
+pub const SET_BOX: placeholdertype = 100;
+pub const HYPH_DATA: placeholdertype = 101;
+pub const SET_INTERACTION: placeholdertype = 102;
+pub const EXPAND_AFTER: placeholdertype = 104;
+pub const NO_EXPAND: placeholdertype = 105;
+pub const INPUT: placeholdertype = 106;
+pub const IF_TEST: placeholdertype = 107;
+pub const FI_OR_ELSE: placeholdertype = 108;
+pub const CS_NAME: placeholdertype = 109;
+pub const CONVERT: placeholdertype = 110;
+pub const THE: placeholdertype = 111;
+pub const TOP_BOT_MARK: placeholdertype = 112;
+
+/* args to SET_BOX_DIMEN */
+pub const WIDTH_OFFSET: placeholdertype = 1;
+pub const DEPTH_OFFSET: placeholdertype = 2;
+pub const HEIGHT_OFFSET: placeholdertype = 3;
+
+/* args to LAST_ITEM -- heavily overloaded by (X)eTeX for extensions */
+pub const INT_VAL: placeholdertype = 0;
+pub const DIMEN_VAL: placeholdertype = 1;
+pub const GLUE_VAL: placeholdertype = 2;
+pub const MU_VAL: placeholdertype = 3;
+pub const LAST_NODE_TYPE_CODE: placeholdertype = 3;
+pub const INPUT_LINE_NO_CODE: placeholdertype = 4;
+pub const BADNESS_CODE: placeholdertype = 5;
+pub const ETEX_VERSION_CODE: placeholdertype = 6;
+pub const CURRENT_GROUP_LEVEL_CODE: placeholdertype = 7;
+pub const CURRENT_GROUP_TYPE_CODE: placeholdertype = 8;
+pub const CURRENT_IF_LEVEL_CODE: placeholdertype = 9;
+pub const CURRENT_IF_TYPE_CODE: placeholdertype = 10;
+pub const CURRENT_IF_BRANCH_CODE: placeholdertype = 11;
+pub const GLUE_STRETCH_ORDER_CODE: placeholdertype = 12;
+pub const GLUE_SHRINK_ORDER_CODE: placeholdertype = 13;
+pub const XETEX_VERSION_CODE: placeholdertype = 14;
+pub const XETEX_COUNT_GLYPHS_CODE: placeholdertype = 15;
+pub const XETEX_COUNT_VARIATIONS_CODE: placeholdertype = 16;
+pub const XETEX_VARIATION_CODE: placeholdertype = 17;
+pub const XETEX_FIND_VARIATION_BY_NAME_CODE: placeholdertype = 18;
+pub const XETEX_VARIATION_MIN_CODE: placeholdertype = 19;
+pub const XETEX_VARIATION_MAX_CODE: placeholdertype = 20;
+pub const XETEX_VARIATION_DEFAULT_CODE: placeholdertype = 21;
+pub const XETEX_COUNT_FEATURES_CODE: placeholdertype = 22;
+pub const XETEX_FEATURE_CODE_CODE: placeholdertype = 23;
+pub const XETEX_FIND_FEATURE_BY_NAME_CODE: placeholdertype = 24;
+pub const XETEX_IS_EXCLUSIVE_FEATURE_CODE: placeholdertype = 25;
+pub const XETEX_COUNT_SELECTORS_CODE: placeholdertype = 26;
+pub const XETEX_SELECTOR_CODE_CODE: placeholdertype = 27;
+pub const XETEX_FIND_SELECTOR_BY_NAME_CODE: placeholdertype = 28;
+pub const XETEX_IS_DEFAULT_SELECTOR_CODE: placeholdertype = 29;
+pub const XETEX_OT_COUNT_SCRIPTS_CODE: placeholdertype = 30;
+pub const XETEX_OT_COUNT_LANGUAGES_CODE: placeholdertype = 31;
+pub const XETEX_OT_COUNT_FEATURES_CODE: placeholdertype = 32;
+pub const XETEX_OT_SCRIPT_CODE: placeholdertype = 33;
+pub const XETEX_OT_LANGUAGE_CODE: placeholdertype = 34;
+pub const XETEX_OT_FEATURE_CODE: placeholdertype = 35;
+pub const XETEX_MAP_CHAR_TO_GLYPH_CODE: placeholdertype = 36;
+pub const XETEX_GLYPH_INDEX_CODE: placeholdertype = 37;
+pub const XETEX_FONT_TYPE_CODE: placeholdertype = 38;
+pub const XETEX_FIRST_CHAR_CODE: placeholdertype = 39;
+pub const XETEX_LAST_CHAR_CODE: placeholdertype = 40;
+pub const PDF_LAST_X_POS_CODE: placeholdertype = 41;
+pub const PDF_LAST_Y_POS_CODE: placeholdertype = 42;
+pub const PDF_SHELL_ESCAPE_CODE: placeholdertype = 45;
+pub const XETEX_PDF_PAGE_COUNT_CODE: placeholdertype = 46;
+pub const XETEX_GLYPH_BOUNDS_CODE: placeholdertype = 47;
+pub const FONT_CHAR_WD_CODE: placeholdertype = 48;
+pub const FONT_CHAR_HT_CODE: placeholdertype = 49;
+pub const FONT_CHAR_DP_CODE: placeholdertype = 50;
+pub const FONT_CHAR_IC_CODE: placeholdertype = 51;
+pub const PAR_SHAPE_LENGTH_CODE: placeholdertype = 52;
+pub const PAR_SHAPE_INDENT_CODE: placeholdertype = 53;
+pub const PAR_SHAPE_DIMEN_CODE: placeholdertype = 54;
+pub const GLUE_STRETCH_CODE: placeholdertype = 55;
+pub const GLUE_SHRINK_CODE: placeholdertype = 56;
+pub const MU_TO_GLUE_CODE: placeholdertype = 57;
+pub const GLUE_TO_MU_CODE: placeholdertype = 58;
+pub const ETEX_EXPR: placeholdertype = 59;
+
+/* args to CONVERT -- also heavily overloaded */
+pub const NUMBER_CODE: placeholdertype = 0;
+pub const ROMAN_NUMERAL_CODE: placeholdertype = 1;
+pub const STRING_CODE: placeholdertype = 2;
+pub const MEANING_CODE: placeholdertype = 3;
+pub const FONT_NAME_CODE: placeholdertype = 4;
+pub const ETEX_REVISION_CODE: placeholdertype = 5;
+pub const XETEX_REVISION_CODE: placeholdertype = 6;
+pub const XETEX_VARIATION_NAME_CODE: placeholdertype = 7;
+pub const XETEX_FEATURE_NAME_CODE: placeholdertype = 8;
+pub const XETEX_SELECTOR_NAME_CODE: placeholdertype = 9;
+pub const XETEX_GLYPH_NAME_CODE: placeholdertype = 10;
+pub const LEFT_MARGIN_KERN_CODE: placeholdertype = 11;
+pub const RIGHT_MARGIN_KERN_CODE: placeholdertype = 12;
+pub const XETEX_UCHAR_CODE: placeholdertype = 13;
+pub const XETEX_UCHARCAT_CODE: placeholdertype = 14;
+pub const JOB_NAME_CODE: placeholdertype = 15;
+pub const PDF_STRCMP_CODE: placeholdertype = 43;
+pub const PDF_MDFIVE_SUM_CODE: placeholdertype = 44;
+
+/* args to IF_TEST */
+pub const IF_CHAR_CODE: placeholdertype = 0;
+pub const IF_CODE: placeholdertype = 1;
+pub const IF_CAT_CODE: placeholdertype = 1;
+pub const IF_INT_CODE: placeholdertype = 2;
+pub const IF_DIM_CODE: placeholdertype = 3;
+pub const IF_ODD_CODE: placeholdertype = 4;
+pub const IF_VMODE_CODE: placeholdertype = 5;
+pub const IF_HMODE_CODE: placeholdertype = 6;
+pub const IF_MMODE_CODE: placeholdertype = 7;
+pub const IF_INNER_CODE: placeholdertype = 8;
+pub const IF_VOID_CODE: placeholdertype = 9;
+pub const IF_HBOX_CODE: placeholdertype = 10;
+pub const IF_VBOX_CODE: placeholdertype = 11;
+pub const IFX_CODE: placeholdertype = 12;
+pub const IF_EOF_CODE: placeholdertype = 13;
+pub const IF_TRUE_CODE: placeholdertype = 14;
+pub const IF_FALSE_CODE: placeholdertype = 15;
+pub const IF_CASE_CODE: placeholdertype = 16;
+pub const IF_DEF_CODE: placeholdertype = 17;
+pub const IF_CS_CODE: placeholdertype = 18;
+pub const IF_FONT_CHAR_CODE: placeholdertype = 19;
+pub const IF_IN_CSNAME_CODE: placeholdertype = 20;
+pub const IF_PRIMITIVE_CODE: placeholdertype = 21;
+
+/* args to FI_OR_ELSE */
+pub const FI_CODE: placeholdertype = 2;
+pub const ELSE_CODE: placeholdertype = 3;
+pub const OR_CODE: placeholdertype = 4;
+
+/* special args for TAB_MARK, CAR_RET */
+pub const SPAN_CODE: placeholdertype = (BIGGEST_USV + 2);
+pub const CR_CODE: placeholdertype = (BIGGEST_USV + 3);
+pub const CR_CR_CODE: placeholdertype = (BIGGEST_USV + 4);
+
+/* HSKIP, VSKIP, MSKIP */
+pub const FIL_CODE: placeholdertype = 0;
+pub const FILL_CODE: placeholdertype = 1;
+pub const SS_CODE: placeholdertype = 2;
+pub const FIL_NEG_CODE: placeholdertype = 3;
+pub const SKIP_CODE: placeholdertype = 4;
+pub const MSKIP_CODE: placeholdertype = 5;
+
+/* MAKE_BOX, UN_HBOX, UN_VBOX */
+pub const BOX_CODE: placeholdertype = 0;
+pub const COPY_CODE: placeholdertype = 1;
+pub const LAST_BOX_CODE: placeholdertype = 2;
+pub const VSPLIT_CODE: placeholdertype = 3;
+pub const VTOP_CODE: placeholdertype = 4;
+
+/* LEADER_SHIP */
+pub const A_LEADERS: placeholdertype = 100;
+pub const C_LEADERS: placeholdertype = 101;
+pub const X_LEADERS: placeholdertype = 102;
+
+/* LIMIT_SWITCH */
+/* also NORMAL = 0 */
+pub const LIMITS: placeholdertype = 1;
+pub const NO_LIMITS: placeholdertype = 2;
+
+/* MATH_STYLE */
+pub const DISPLAY_STYLE: placeholdertype = 0;
+pub const TEXT_STYLE: placeholdertype = 2;
+pub const SCRIPT_STYLE: placeholdertype = 4;
+pub const SCRIPT_SCRIPT_STYLE: placeholdertype = 6;
+
+/* ABOVE */
+pub const ABOVE_CODE: placeholdertype = 0;
+pub const OVER_CODE: placeholdertype = 1;
+pub const ATOP_CODE: placeholdertype = 2;
+pub const DELIMITED_CODE: placeholdertype = 3;
+
+/* SHORTHAND_DEF */
+pub const CHAR_DEF_CODE: placeholdertype = 0;
+pub const MATH_CHAR_DEF_CODE: placeholdertype = 1;
+pub const COUNT_DEF_CODE: placeholdertype = 2;
+pub const DIMEN_DEF_CODE: placeholdertype = 3;
+pub const SKIP_DEF_CODE: placeholdertype = 4;
+pub const MU_SKIP_DEF_CODE: placeholdertype = 5;
+pub const TOKS_DEF_CODE: placeholdertype = 6;
+pub const CHAR_SUB_DEF_CODE: placeholdertype = 7;
+pub const XETEX_MATH_CHAR_NUM_DEF_CODE: placeholdertype = 8;
+pub const XETEX_MATH_CHAR_DEF_CODE: placeholdertype = 9;
+
+/* XRAY */
+pub const SHOW_CODE: placeholdertype = 0;
+pub const SHOW_BOX_CODE: placeholdertype = 1;
+pub const SHOW_THE_CODE: placeholdertype = 2;
+pub const SHOW_LISTS: placeholdertype = 3;
+pub const SHOW_GROUPS: placeholdertype = 4;
+pub const SHOW_TOKENS: placeholdertype = 5;
+pub const SHOW_IFS: placeholdertype = 6;
+
+/* EXTENSION */
+pub const OPEN_NODE: placeholdertype = 0;
+pub const WRITE_NODE: placeholdertype = 1;
+pub const CLOSE_NODE: placeholdertype = 2;
+pub const SPECIAL_NODE: placeholdertype = 3;
+pub const LANGUAGE_NODE: placeholdertype = 4;
+pub const IMMEDIATE_CODE: placeholdertype = 4;
+pub const SET_LANGUAGE_CODE: placeholdertype = 5;
+pub const PDFTEX_FIRST_EXTENSION_CODE: placeholdertype = 6;
+pub const PDF_SAVE_POS_NODE: placeholdertype = 6;
+/// not to be confused with PIC_NODE = 43!
+pub const PIC_FILE_CODE: placeholdertype = 41;
+/// not to be confused with PDF_NODE = 44!
+pub const PDF_FILE_CODE: placeholdertype = 42;
+/// not to be confused with GLYPH_NODE = 42!
+pub const GLYPH_CODE: placeholdertype = 43;
+pub const XETEX_INPUT_ENCODING_EXTENSION_CODE: placeholdertype = 44;
+pub const XETEX_DEFAULT_ENCODING_EXTENSION_CODE: placeholdertype = 45;
+pub const XETEX_LINEBREAK_LOCALE_EXTENSION_CODE: placeholdertype = 46;
+
+/* VALIGN overloads */
+pub const BEGIN_L_CODE: placeholdertype = 6;
+pub const END_L_CODE: placeholdertype = 7;
+pub const BEGIN_R_CODE: placeholdertype = 10;
+pub const END_R_CODE: placeholdertype = 11;
+
+/* begin_token_list() types */
+pub const PARAMETER: u16 = 0;
+pub const U_TEMPLATE: u16 = 1;
+pub const V_TEMPLATE: u16 = 2;
+pub const BACKED_UP: u16 = 3;
+pub const BACKED_UP_CHAR: u16 = 4;
+pub const INSERTED: u16 = 5;
+pub const MACRO: u16 = 6;
+pub const OUTPUT_TEXT: u16 = 7;
+pub const EVERY_PAR_TEXT: u16 = 8;
+pub const EVERY_MATH_TEXT: u16 = 9;
+pub const EVERY_DISPLAY_TEXT: u16 = 10;
+pub const EVERY_HBOX_TEXT: u16 = 11;
+pub const EVERY_VBOX_TEXT: u16 = 12;
+pub const EVERY_JOB_TEXT: u16 = 13;
+pub const EVERY_CR_TEXT: u16 = 14;
+pub const MARK_TEXT: u16 = 15;
+pub const EVERY_EOF_TEXT: u16 = 16;
+pub const INTER_CHAR_TEXT: u16 = 17;
+pub const WRITE_TEXT: u16 = 18;
+pub const TECTONIC_CODA_TEXT: u16 = 19;
+
+/* input state */
+pub const MID_LINE: placeholdertype = 1;
+pub const SKIP_BLANKS: placeholdertype = 17;
+pub const NEW_LINE: placeholdertype = 33;
+
+/* DVI format codes */
+pub const XDV_ID_BYTE: placeholdertype = 7;
+pub const SPX_ID_BYTE: placeholdertype = 100;
+
+/* page_contents possibilities (EMPTY is overloaded) */
+pub const EMPTY: placeholdertype = 0;
+pub const INSERTS_ONLY: placeholdertype = 1;
+pub const BOX_THERE: placeholdertype = 2;
+
+pub const SET1: placeholdertype = 128;
+pub const SET_RULE: placeholdertype = 132;
+pub const PUT_RULE: placeholdertype = 137;
+pub const BOP: placeholdertype = 139;
+pub const EOP: placeholdertype = 140;
+pub const PUSH: placeholdertype = 141;
+pub const POP: placeholdertype = 142;
+pub const RIGHT1: placeholdertype = 143;
+pub const DOWN1: placeholdertype = 157;
+pub const FNT1: placeholdertype = 235;
+pub const XXX1: placeholdertype = 239;
+pub const XXX4: placeholdertype = 242;
+pub const FNT_DEF1: placeholdertype = 243;
+pub const PRE: placeholdertype = 247;
+pub const POST: placeholdertype = 248;
+pub const POST_POST: placeholdertype = 249;
+pub const DEFINE_NATIVE_FONT: placeholdertype = 252;
+pub const SET_GLYPHS: placeholdertype = 253;
+pub const SET_TEXT_AND_GLYPHS: placeholdertype = 254;
+
+pub const XETEX_INPUT_MODE_AUTO: placeholdertype = 0;
+pub const XETEX_VERSION: placeholdertype = 0;
+pub const EXACTLY: placeholdertype = 0;
+pub const FONT_BASE: placeholdertype = 0;
+pub const INSERTING: placeholdertype = 0;
+pub const NON_ADDRESS: placeholdertype = 0;
+pub const RESTORE_OLD_VALUE: placeholdertype = 0;
+pub const TOKEN_LIST: placeholdertype = 0;
+pub const UNDEFINED_PRIMITIVE: placeholdertype = 0;
+pub const UNHYPHENATED: placeholdertype = 0;
+pub const ADDITIONAL: placeholdertype = 1;
+pub const EXPLICIT: placeholdertype = 1;
+pub const FIXED_ACC: placeholdertype = 1;
+pub const HYPHENATED: placeholdertype = 1;
+pub const JUST_OPEN: placeholdertype = 1;
+pub const MATH_CHAR: placeholdertype = 1;
+pub const PRIM_BASE: placeholdertype = 1;
+pub const RESTORE_ZERO: placeholdertype = 1;
+pub const REVERSED: placeholdertype = 1;
+pub const SLANT_CODE: placeholdertype = 1;
+pub const SPLIT_UP: placeholdertype = 1;
+pub const STRETCHING: placeholdertype = 1;
+pub const VMODE: placeholdertype = 1;
+pub const ACC_KERN: placeholdertype = 2;
+pub const BOTTOM_ACC: placeholdertype = 2;
+pub const CLOSED: placeholdertype = 2;
+pub const DLIST: placeholdertype = 2;
+pub const ETEX_VERSION: placeholdertype = 2;
+pub const INSERT_TOKEN: placeholdertype = 2;
+pub const SHRINKING: placeholdertype = 2;
+pub const SPACE_CODE: placeholdertype = 2;
+pub const SUB_BOX: placeholdertype = 2;
+pub const DISPLAYOPERATORMINHEIGHT: placeholdertype = 3;
+pub const LEVEL_BOUNDARY: placeholdertype = 3;
+// pub const MATH_SHIFT: placeholdertype = 3;
+pub const SPACE_ADJUSTMENT: placeholdertype = 3;
+pub const SUB_MLIST: placeholdertype = 3;
+pub const IDENT_VAL: placeholdertype = 4;
+pub const MATH_TEXT_CHAR: placeholdertype = 4;
+pub const RESTORE_SA: placeholdertype = 4;
+pub const SPACE_SHRINK_CODE: placeholdertype = 4;
+// pub const OUT_PARAM: placeholdertype = 5;
+pub const TOK_VAL: placeholdertype = 5;
+pub const X_HEIGHT_CODE: placeholdertype = 5;
+pub const ACCENTBASEHEIGHT: placeholdertype = 6;
+pub const INTER_CHAR_VAL: placeholdertype = 6;
+// pub const MAC_PARAM: placeholdertype = 6;
+pub const QUAD_CODE: placeholdertype = 6;
+pub const EXTRA_SPACE_CODE: placeholdertype = 7;
+pub const MARK_VAL: placeholdertype = 7;
+// pub const SUP_MARK: placeholdertype = 7;
+pub const VAR_FAM_CLASS: placeholdertype = 7;
+// pub const IGNORE: placeholdertype = 9;
+pub const SUBSCRIPTTOPMAX: placeholdertype = 9;
+pub const NATIVE_GLYPH_INFO_SIZE: placeholdertype = 10;
+// pub const ACTIVE_CHAR: placeholdertype = 13;
+pub const CARRIAGE_RETURN: placeholdertype = 13;
+pub const SUPERSCRIPTBOTTOMMIN: placeholdertype = 13;
+pub const TOTAL_MATHEX_PARAMS: placeholdertype = 13;
+// pub const COMMENT: placeholdertype = 14;
+pub const HI_MEM_STAT_USAGE: placeholdertype = 15;
+// pub const INVALID_CHAR: placeholdertype = 15;
+pub const MAX_CHAR_CODE: placeholdertype = 15;
+pub const SUBSUPERSCRIPTGAPMIN: placeholdertype = 15;
+pub const SUPERSCRIPTBOTTOMMAXWITHSUBSCRIPT: placeholdertype = 16;
+pub const TOTAL_MATHSY_PARAMS: placeholdertype = 22;
+pub const STACKGAPMIN: placeholdertype = 26;
+pub const STACKDISPLAYSTYLEGAPMIN: placeholdertype = 27;
+pub const UNLESS_CODE: placeholdertype = 32;
+// pub const VRULE: placeholdertype = 35;
+pub const FRACTIONNUMERATORGAPMIN: placeholdertype = 36;
+pub const FRACTIONNUMDISPLAYSTYLEGAPMIN: placeholdertype = 37;
+// pub const XETEX_FIRST_CHAR_CODE: placeholdertype = 39;
+pub const FRACTIONDENOMINATORGAPMIN: placeholdertype = 39;
+pub const FRACTIONDENOMDISPLAYSTYLEGAPMIN: placeholdertype = 40;
+pub const XETEX_DIM: placeholdertype = 47;
+pub const RADICALVERTICALGAP: placeholdertype = 49;
+pub const RADICALDISPLAYSTYLEVERTICALGAP: placeholdertype = 50;
+pub const RADICALRULETHICKNESS: placeholdertype = 51;
+pub const ETEX_GLUE: placeholdertype = 57;
+pub const ETEX_MU: placeholdertype = 58;
+pub const COND_MATH_GLUE: placeholdertype = 98;
+pub const MU_GLUE: placeholdertype = 99;
+pub const MAX_COMMAND: placeholdertype = 102;
+pub const UNDEFINED_CS: placeholdertype = 103;
+pub const HMODE: placeholdertype = 104;
+pub const CALL: placeholdertype = 113;
+pub const LONG_CALL: placeholdertype = 114;
+pub const OUTER_CALL: placeholdertype = 115;
+pub const LONG_OUTER_CALL: placeholdertype = 116;
+pub const END_TEMPLATE: placeholdertype = 117;
+pub const DONT_EXPAND: placeholdertype = 118;
+pub const GLUE_REF: placeholdertype = 119;
+pub const SHAPE_REF: placeholdertype = 120;
+pub const BOX_REF: placeholdertype = 121;
+pub const DATA: placeholdertype = 122;
+pub const DIMEN_VAL_LIMIT: placeholdertype = 128;
+pub const MMODE: placeholdertype = 207;
+pub const BIGGEST_LANG: placeholdertype = 255;
+pub const MU_VAL_LIMIT: placeholdertype = 256;
+pub const TOO_BIG_LANG: placeholdertype = 256;
+pub const BOX_VAL_LIMIT: placeholdertype = 320;
+pub const TOK_VAL_LIMIT: placeholdertype = 384;
+pub const PRIM_PRIME: placeholdertype = 431;
+pub const PRIM_SIZE: placeholdertype = 500;
+pub const MAX_HLIST_STACK: placeholdertype = 512;
+pub const HYPH_PRIME: placeholdertype = 607;
+pub const HYPHENATABLE_LENGTH_LIMIT: placeholdertype = 4095;
+pub const CHAR_CLASS_LIMIT: placeholdertype = 4096;
+pub const EJECT_PENALTY: placeholdertype = -10000;
+pub const INF_BAD: placeholdertype = 10000;
+pub const INF_PENALTY: placeholdertype = 10000;
+pub const DEFAULT_RULE: placeholdertype = 26214;
+pub const TOO_BIG_CHAR: placeholdertype = 65536;
+pub const NO_EXPAND_FLAG: placeholdertype = (BIGGEST_USV + 2);
+
+pub const ACTIVE_MATH_CHAR: placeholdertype = 0x1FFFFF;
+
+/* Token codes */
+
+/// 1 << 21
+pub const MAX_CHAR_VAL: placeholdertype = 0x200000;
+pub const CS_TOKEN_FLAG: placeholdertype = 0x1FFFFFF;
+/// LEFT_BRACE << 21
+pub const LEFT_BRACE_TOKEN: placeholdertype = 0x200000;
+/// (LEFT_BRACE + 1) << 21
+pub const LEFT_BRACE_LIMIT: placeholdertype = 0x400000;
+/// RIGHT_BRACE << 21
+pub const RIGHT_BRACE_TOKEN: placeholdertype = 0x400000;
+/// (RIGHT_BRACE + 1) << 21
+pub const RIGHT_BRACE_LIMIT: placeholdertype = 0x600000;
+/// MATH_SHIFT << 21
+pub const MATH_SHIFT_TOKEN: placeholdertype = 0x600000;
+/// TAB_MARK << 21
+pub const TAB_TOKEN: placeholdertype = 0x800000;
+/// OUT_PARAM << 21
+pub const OUT_PARAM_TOKEN: placeholdertype = 0xA00000;
+/// SPACER << 21 + ord(' ')
+pub const SPACE_TOKEN: placeholdertype = 0x1400020;
+/// LETTER << 21
+pub const LETTER_TOKEN: placeholdertype = 0x1600000;
+/// OTHER_CHAR << 21
+pub const OTHER_TOKEN: placeholdertype = 0x1800000;
+/// MATCH << 21
+pub const MATCH_TOKEN: placeholdertype = 0x1A00000;
+/// END_MATCH << 21
+pub const END_MATCH_TOKEN: placeholdertype = 0x1C00000;
+pub const PROTECTED_TOKEN: placeholdertype = (END_MATCH_TOKEN + 1);
+
+pub const A_TOKEN: placeholdertype = (LETTER_TOKEN + 'A' as placeholdertype);
+pub const OTHER_A_TOKEN: placeholdertype = (OTHER_TOKEN + 'A' as placeholdertype);
+pub const HEX_TOKEN: placeholdertype = (OTHER_TOKEN + '"' as placeholdertype);
+pub const OCTAL_TOKEN: placeholdertype = (OTHER_TOKEN + '\'' as placeholdertype);
+pub const CONTINENTAL_POINT_TOKEN: placeholdertype = (OTHER_TOKEN + ',' as placeholdertype);
+pub const POINT_TOKEN: placeholdertype = (OTHER_TOKEN + '.' as placeholdertype);
+pub const ZERO_TOKEN: placeholdertype = (OTHER_TOKEN + '0' as placeholdertype);
+pub const ALPHA_TOKEN: placeholdertype = (OTHER_TOKEN + '`' as placeholdertype);
+
+pub const BOX_FLAG: placeholdertype = 0x40000000;
+pub const GLOBAL_BOX_FLAG: placeholdertype = 0x40008000;
+pub const SHIP_OUT_FLAG: placeholdertype = 0x40010000;
+pub const LEADER_FLAG: placeholdertype = 0x40010001;
+
+pub const LP_CODE_BASE: placeholdertype = 2;
+pub const RP_CODE_BASE: placeholdertype = 3;
+
+pub const LEFT_SIDE: placeholdertype = 0;
+pub const RIGHT_SIDE: placeholdertype = 1;
+
+/* modes to do_marks() */
+pub const VSPLIT_INIT: placeholdertype = 0;
+pub const FIRE_UP_INIT: placeholdertype = 1;
+pub const FIRE_UP_DONE: placeholdertype = 2;
+pub const DESTROY_MARKS: placeholdertype = 3;
+
+pub const MARKS_CODE: placeholdertype = 5;
+
+pub const IGNORE_DEPTH: placeholdertype = -65536000;
+
+pub const MIDDLE_NOAD: placeholdertype = 1;
+
+/* movement() */
+pub const MOV_NONE_SEEN: placeholdertype = 0;
+pub const MOV_Y_HERE: placeholdertype = 1;
+pub const MOV_Z_HERE: placeholdertype = 2;
+pub const MOV_YZ_OK: placeholdertype = 3;
+pub const MOV_Y_OK: placeholdertype = 4;
+pub const MOV_Z_OK: placeholdertype = 5;
+pub const MOV_Y_SEEN: placeholdertype = 6;
+pub const MOV_D_FIXED: placeholdertype = 6;
+pub const MOV_Z_SEEN: placeholdertype = 12;
+
+/* Increase this whenever the engine internals change such that the contents
+ * of the "format" files must be regenerated -- this includes changes to the
+ * string pool. KEEP SYNCHRONIZED WITH src/lib.rs!!! */
+
+pub const FORMAT_SERIAL: placeholdertype = 28;

--- a/engine/src/xetex_ini.rs
+++ b/engine/src/xetex_ini.rs
@@ -13,6 +13,7 @@ use std::io::Write;
 
 use super::xetex_texmfmp::get_date_and_time;
 use crate::core_memory::{mfree, xcalloc, xmalloc};
+use crate::xetex_consts::*;
 use crate::xetex_errors::{confusion, error, overflow};
 use crate::xetex_ext::release_font_engine;
 use crate::xetex_layout_engine::{destroy_font_manager, set_cp_code};
@@ -1575,98 +1576,12 @@ unsafe extern "C" fn new_patterns() {
     let mut first_child: bool = false;
     let mut c: UTF16_code = 0;
     if trie_not_ready {
-        if (*eqtb.offset(
-            (1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 50i32) as isize,
-        ))
-        .b32
-        .s1 <= 0i32
-        {
+        if INTPAR(INT_PAR__language) <= 0 {
             cur_lang = 0_u8
-        } else if (*eqtb.offset(
-            (1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 50i32) as isize,
-        ))
-        .b32
-        .s1 > 255i32
-        {
+        } else if INTPAR(INT_PAR__language) > BIGGEST_LANG {
             cur_lang = 0_u8
         } else {
-            cur_lang = (*eqtb.offset(
-                (1i32
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + 1i32
-                    + 15000i32
-                    + 12i32
-                    + 9000i32
-                    + 1i32
-                    + 1i32
-                    + 19i32
-                    + 256i32
-                    + 256i32
-                    + 13i32
-                    + 256i32
-                    + 4i32
-                    + 256i32
-                    + 1i32
-                    + 3i32 * 256i32
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + 50i32) as isize,
-            ))
-            .b32
-            .s1 as u8
+            cur_lang = INTPAR(INT_PAR__language) as _;
         }
         scan_left_brace();
         k = 0_i16;
@@ -1680,30 +1595,7 @@ unsafe extern "C" fn new_patterns() {
                         if cur_chr == '.' as i32 {
                             cur_chr = 0i32
                         } else {
-                            cur_chr = (*eqtb.offset(
-                                (1i32
-                                    + (0x10ffffi32 + 1i32)
-                                    + (0x10ffffi32 + 1i32)
-                                    + 1i32
-                                    + 15000i32
-                                    + 12i32
-                                    + 9000i32
-                                    + 1i32
-                                    + 1i32
-                                    + 19i32
-                                    + 256i32
-                                    + 256i32
-                                    + 13i32
-                                    + 256i32
-                                    + 4i32
-                                    + 256i32
-                                    + 1i32
-                                    + 3i32 * 256i32
-                                    + (0x10ffffi32 + 1i32)
-                                    + cur_chr) as isize,
-                            ))
-                            .b32
-                            .s1;
+                            cur_chr = LC_CODE(cur_chr);
                             if cur_chr == 0i32 {
                                 if file_line_error_style_p != 0 {
                                     print_file_line();
@@ -1823,36 +1715,7 @@ unsafe extern "C" fn new_patterns() {
             }
         }
         /*:996*/
-        if (*eqtb.offset(
-            (1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 66i32) as isize,
-        ))
-        .b32
-        .s1 > 0i32
-        {
+        if INTPAR(INT_PAR__saving_hyphs) > 0 {
             /*1643:*/
             c = cur_lang as UTF16_code;
             first_child = false;
@@ -1887,32 +1750,7 @@ unsafe extern "C" fn new_patterns() {
             first_child = true;
             c = 0i32 as UTF16_code;
             while c as i32 <= 255i32 {
-                if (*eqtb.offset(
-                    (1i32
-                        + (0x10ffffi32 + 1i32)
-                        + (0x10ffffi32 + 1i32)
-                        + 1i32
-                        + 15000i32
-                        + 12i32
-                        + 9000i32
-                        + 1i32
-                        + 1i32
-                        + 19i32
-                        + 256i32
-                        + 256i32
-                        + 13i32
-                        + 256i32
-                        + 4i32
-                        + 256i32
-                        + 1i32
-                        + 3i32 * 256i32
-                        + (0x10ffffi32 + 1i32)
-                        + c as i32) as isize,
-                ))
-                .b32
-                .s1 > 0i32
-                    || c as i32 == 255i32 && first_child as i32 != 0
-                {
+                if LC_CODE(c as _) > 0 || c as i32 == 255i32 && first_child as i32 != 0 {
                     if p == 0i32 {
                         /*999:*/
                         if trie_ptr == trie_size {
@@ -1933,30 +1771,7 @@ unsafe extern "C" fn new_patterns() {
                     } else {
                         *trie_c.offset(p as isize) = c
                     }
-                    *trie_o.offset(p as isize) = (*eqtb.offset(
-                        (1i32
-                            + (0x10ffffi32 + 1i32)
-                            + (0x10ffffi32 + 1i32)
-                            + 1i32
-                            + 15000i32
-                            + 12i32
-                            + 9000i32
-                            + 1i32
-                            + 1i32
-                            + 19i32
-                            + 256i32
-                            + 256i32
-                            + 13i32
-                            + 256i32
-                            + 4i32
-                            + 256i32
-                            + 1i32
-                            + 3i32 * 256i32
-                            + (0x10ffffi32 + 1i32)
-                            + c as i32) as isize,
-                    ))
-                    .b32
-                    .s1 as trie_opcode;
+                    *trie_o.offset(p as isize) = LC_CODE(c as _) as _;
                     q = p;
                     p = *trie_r.offset(q as isize);
                     first_child = false
@@ -2170,98 +1985,12 @@ unsafe extern "C" fn new_hyph_exceptions() {
     let mut u: pool_pointer = 0;
     let mut v: pool_pointer = 0;
     scan_left_brace();
-    if (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32
-            + 1i32
-            + 3i32 * 256i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 50i32) as isize,
-    ))
-    .b32
-    .s1 <= 0i32
-    {
+    if INTPAR(INT_PAR__language) <= 0 {
         cur_lang = 0_u8
-    } else if (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32
-            + 1i32
-            + 3i32 * 256i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 50i32) as isize,
-    ))
-    .b32
-    .s1 > 255i32
-    {
+    } else if INTPAR(INT_PAR__language) > BIGGEST_LANG {
         cur_lang = 0_u8
     } else {
-        cur_lang = (*eqtb.offset(
-            (1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 50i32) as isize,
-        ))
-        .b32
-        .s1 as u8
+        cur_lang = INTPAR(INT_PAR__language) as _;
     }
     if trie_not_ready {
         hyph_index = 0i32
@@ -2272,7 +2001,7 @@ unsafe extern "C" fn new_hyph_exceptions() {
     }
     /*970:*/
     n = 0_i16;
-    p = -0xfffffffi32;
+    p = TEX_NULL;
     's_91: loop {
         get_x_token();
         loop {
@@ -2288,30 +2017,7 @@ unsafe extern "C" fn new_hyph_exceptions() {
                         }
                     } else {
                         if hyph_index == 0i32 || cur_chr > 255i32 {
-                            hc[0] = (*eqtb.offset(
-                                (1i32
-                                    + (0x10ffffi32 + 1i32)
-                                    + (0x10ffffi32 + 1i32)
-                                    + 1i32
-                                    + 15000i32
-                                    + 12i32
-                                    + 9000i32
-                                    + 1i32
-                                    + 1i32
-                                    + 19i32
-                                    + 256i32
-                                    + 256i32
-                                    + 13i32
-                                    + 256i32
-                                    + 4i32
-                                    + 256i32
-                                    + 1i32
-                                    + 3i32 * 256i32
-                                    + (0x10ffffi32 + 1i32)
-                                    + cur_chr) as isize,
-                            ))
-                            .b32
-                            .s1
+                            hc[0] = LC_CODE(cur_chr) as _;
                         } else if *trie_trc.offset((hyph_index + cur_chr) as isize) as i32
                             != cur_chr
                         {
@@ -2466,7 +2172,7 @@ unsafe extern "C" fn new_hyph_exceptions() {
             return;
         }
         n = 0_i16;
-        p = -0xfffffffi32
+        p = TEX_NULL
     }
 }
 #[no_mangle]
@@ -2508,41 +2214,12 @@ pub unsafe extern "C" fn prefixed_command() {
             back_error();
             return;
         }
-        if (*eqtb.offset(
-            (1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 36i32) as isize,
-        ))
-        .b32
-        .s1 > 2i32
-        {
+        if INTPAR(INT_PAR__tracing_commands) > 2 {
             show_cur_cmd_chr();
         }
     }
     if a as i32 >= 8i32 {
-        j = 0x1c00000i32 + 1i32;
+        j = PROTECTED_TOKEN;
         a = (a as i32 - 8i32) as small_number
     } else {
         j = 0i32
@@ -2567,66 +2244,8 @@ pub unsafe extern "C" fn prefixed_command() {
         print_char('\'' as i32);
         error();
     }
-    if (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32
-            + 1i32
-            + 3i32 * 256i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 43i32) as isize,
-    ))
-    .b32
-    .s1 != 0i32
-    {
-        if (*eqtb.offset(
-            (1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 43i32) as isize,
-        ))
-        .b32
-        .s1 < 0i32
-        {
+    if INTPAR(INT_PAR__global_defs) != 0 {
+        if INTPAR(INT_PAR__global_defs) < 0 {
             if a as i32 >= 4i32 {
                 a = (a as i32 - 4i32) as small_number
             }
@@ -2634,35 +2253,17 @@ pub unsafe extern "C" fn prefixed_command() {
             a = (a as i32 + 4i32) as small_number
         }
     }
-    match cur_cmd as i32 {
-        89 => {
+    match cur_cmd as _ {
+        SET_FONT => {
             /*1252:*/
             if a as i32 >= 4i32 {
-                geq_define(1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32)
-                               + 1i32 + 15000i32 + 12i32 + 9000i32 + 1i32 +
-                               1i32 + 19i32 + 256i32 + 256i32 + 13i32 + 256i32
-                               + 4i32 + 256i32, 122_u16, cur_chr);
+                geq_define(CUR_FONT_LOC, DATA as _, cur_chr);
             } else {
-                eq_define(1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                              1i32 + 15000i32 + 12i32 + 9000i32 + 1i32 + 1i32
-                              + 19i32 + 256i32 + 256i32 + 13i32 + 256i32 +
-                              4i32 + 256i32, 122_u16, cur_chr);
+                eq_define(CUR_FONT_LOC, DATA as _, cur_chr);
             }
         }
-        99 => {
-            if cur_chr & 1i32 != 0 && (a as i32) < 4i32 &&
-                   (*eqtb.offset((1i32 + (0x10ffffi32 + 1i32) +
-                                      (0x10ffffi32 + 1i32) + 1i32 + 15000i32 +
-                                      12i32 + 9000i32 + 1i32 + 1i32 + 19i32 +
-                                      256i32 + 256i32 + 13i32 + 256i32 + 4i32
-                                      + 256i32 + 1i32 + 3i32 * 256i32 +
-                                      (0x10ffffi32 + 1i32) +
-                                      (0x10ffffi32 + 1i32) +
-                                      (0x10ffffi32 + 1i32) +
-                                      (0x10ffffi32 + 1i32) +
-                                      (0x10ffffi32 + 1i32) +
-                                      (0x10ffffi32 + 1i32) + 43i32) as
-                                     isize)).b32.s1 >= 0i32 {
+        DEF => {
+            if cur_chr & 1i32 != 0 && (a as i32) < 4i32 && INTPAR(INT_PAR__global_defs) >= 0 {
                 a = (a as i32 + 4i32) as small_number
             }
             e = cur_chr >= 2i32;
@@ -2684,7 +2285,7 @@ pub unsafe extern "C" fn prefixed_command() {
                           def_ref);
             }
         }
-        96 => {
+        LET => {
             n = cur_chr;
             get_r_token();
             p = cur_cs;
@@ -2721,45 +2322,19 @@ pub unsafe extern "C" fn prefixed_command() {
                 geq_define(p, cur_cmd as u16, cur_chr);
             } else { eq_define(p, cur_cmd as u16, cur_chr); }
         }
-        97 => {
+        SHORTHAND_DEF => {
             if cur_chr == 7i32 {
                 scan_char_num();
-                p =
-                    1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) + 1i32
-                        + 15000i32 + 12i32 + 9000i32 + 1i32 + 1i32 + 19i32 +
-                        256i32 + 256i32 + 13i32 + 256i32 + 4i32 + 256i32 +
-                        1i32 + 3i32 * 256i32 + (0x10ffffi32 + 1i32) +
-                        (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                        (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) + cur_val;
+                p = CHAR_SUB_CODE_BASE + cur_val;
                 scan_optional_equals();
                 scan_char_num();
                 n = cur_val;
                 scan_char_num();
-                if (*eqtb.offset((1i32 + (0x10ffffi32 + 1i32) +
-                                      (0x10ffffi32 + 1i32) + 1i32 + 15000i32 +
-                                      12i32 + 9000i32 + 1i32 + 1i32 + 19i32 +
-                                      256i32 + 256i32 + 13i32 + 256i32 + 4i32
-                                      + 256i32 + 1i32 + 3i32 * 256i32 +
-                                      (0x10ffffi32 + 1i32) +
-                                      (0x10ffffi32 + 1i32) +
-                                      (0x10ffffi32 + 1i32) +
-                                      (0x10ffffi32 + 1i32) +
-                                      (0x10ffffi32 + 1i32) +
-                                      (0x10ffffi32 + 1i32) + 57i32) as
-                                     isize)).b32.s1 > 0i32 {
+                if INTPAR(INT_PAR__tracing_char_sub_def) > 0 {
                     begin_diagnostic();
                     print_nl_cstr(b"New character substitution: \x00" as
                                       *const u8 as *const i8);
-                    print(p -
-                              (1i32 + (0x10ffffi32 + 1i32) +
-                                   (0x10ffffi32 + 1i32) + 1i32 + 15000i32 +
-                                   12i32 + 9000i32 + 1i32 + 1i32 + 19i32 +
-                                   256i32 + 256i32 + 13i32 + 256i32 + 4i32 +
-                                   256i32 + 1i32 + 3i32 * 256i32 +
-                                   (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32)
-                                   + (0x10ffffi32 + 1i32) +
-                                   (0x10ffffi32 + 1i32) +
-                                   (0x10ffffi32 + 1i32)));
+                    print(p - CHAR_SUB_CODE_BASE);
                     print_cstr(b" = \x00" as *const u8 as
                                    *const i8);
                     print(n);
@@ -2771,154 +2346,18 @@ pub unsafe extern "C" fn prefixed_command() {
                 if a as i32 >= 4i32 {
                     geq_define(p, 122_u16, n);
                 } else { eq_define(p, 122_u16, n); }
-                if p -
-                       (1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                            1i32 + 15000i32 + 12i32 + 9000i32 + 1i32 + 1i32 +
-                            19i32 + 256i32 + 256i32 + 13i32 + 256i32 + 4i32 +
-                            256i32 + 1i32 + 3i32 * 256i32 +
-                            (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                            (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                            (0x10ffffi32 + 1i32)) <
-                       (*eqtb.offset((1i32 + (0x10ffffi32 + 1i32) +
-                                          (0x10ffffi32 + 1i32) + 1i32 +
-                                          15000i32 + 12i32 + 9000i32 + 1i32 +
-                                          1i32 + 19i32 + 256i32 + 256i32 +
-                                          13i32 + 256i32 + 4i32 + 256i32 +
-                                          1i32 + 3i32 * 256i32 +
-                                          (0x10ffffi32 + 1i32) +
-                                          (0x10ffffi32 + 1i32) +
-                                          (0x10ffffi32 + 1i32) +
-                                          (0x10ffffi32 + 1i32) +
-                                          (0x10ffffi32 + 1i32) +
-                                          (0x10ffffi32 + 1i32) + 55i32) as
-                                         isize)).b32.s1 {
+                if p - CHAR_SUB_CODE_BASE < INTPAR(INT_PAR__char_sub_def_min) {
                     if a as i32 >= 4i32 {
-                        geq_word_define(1i32 + (0x10ffffi32 + 1i32) +
-                                            (0x10ffffi32 + 1i32) + 1i32 +
-                                            15000i32 + 12i32 + 9000i32 + 1i32
-                                            + 1i32 + 19i32 + 256i32 + 256i32 +
-                                            13i32 + 256i32 + 4i32 + 256i32 +
-                                            1i32 + 3i32 * 256i32 +
-                                            (0x10ffffi32 + 1i32) +
-                                            (0x10ffffi32 + 1i32) +
-                                            (0x10ffffi32 + 1i32) +
-                                            (0x10ffffi32 + 1i32) +
-                                            (0x10ffffi32 + 1i32) +
-                                            (0x10ffffi32 + 1i32) + 55i32,
-                                        p -
-                                            (1i32 + (0x10ffffi32 + 1i32) +
-                                                 (0x10ffffi32 + 1i32) + 1i32 +
-                                                 15000i32 + 12i32 + 9000i32 +
-                                                 1i32 + 1i32 + 19i32 + 256i32
-                                                 + 256i32 + 13i32 + 256i32 +
-                                                 4i32 + 256i32 + 1i32 +
-                                                 3i32 * 256i32 +
-                                                 (0x10ffffi32 + 1i32) +
-                                                 (0x10ffffi32 + 1i32) +
-                                                 (0x10ffffi32 + 1i32) +
-                                                 (0x10ffffi32 + 1i32) +
-                                                 (0x10ffffi32 + 1i32)));
+                        geq_word_define(INT_BASE + INT_PAR__char_sub_def_min, p - CHAR_SUB_CODE_BASE);
                     } else {
-                        eq_word_define(1i32 + (0x10ffffi32 + 1i32) +
-                                           (0x10ffffi32 + 1i32) + 1i32 +
-                                           15000i32 + 12i32 + 9000i32 + 1i32 +
-                                           1i32 + 19i32 + 256i32 + 256i32 +
-                                           13i32 + 256i32 + 4i32 + 256i32 +
-                                           1i32 + 3i32 * 256i32 +
-                                           (0x10ffffi32 + 1i32) +
-                                           (0x10ffffi32 + 1i32) +
-                                           (0x10ffffi32 + 1i32) +
-                                           (0x10ffffi32 + 1i32) +
-                                           (0x10ffffi32 + 1i32) +
-                                           (0x10ffffi32 + 1i32) + 55i32,
-                                       p -
-                                           (1i32 + (0x10ffffi32 + 1i32) +
-                                                (0x10ffffi32 + 1i32) + 1i32 +
-                                                15000i32 + 12i32 + 9000i32 +
-                                                1i32 + 1i32 + 19i32 + 256i32 +
-                                                256i32 + 13i32 + 256i32 + 4i32
-                                                + 256i32 + 1i32 +
-                                                3i32 * 256i32 +
-                                                (0x10ffffi32 + 1i32) +
-                                                (0x10ffffi32 + 1i32) +
-                                                (0x10ffffi32 + 1i32) +
-                                                (0x10ffffi32 + 1i32) +
-                                                (0x10ffffi32 + 1i32)));
+                        eq_word_define(INT_BASE + INT_PAR__char_sub_def_min, p - CHAR_SUB_CODE_BASE);
                     }
                 }
-                if p -
-                       (1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                            1i32 + 15000i32 + 12i32 + 9000i32 + 1i32 + 1i32 +
-                            19i32 + 256i32 + 256i32 + 13i32 + 256i32 + 4i32 +
-                            256i32 + 1i32 + 3i32 * 256i32 +
-                            (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                            (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                            (0x10ffffi32 + 1i32)) >
-                       (*eqtb.offset((1i32 + (0x10ffffi32 + 1i32) +
-                                          (0x10ffffi32 + 1i32) + 1i32 +
-                                          15000i32 + 12i32 + 9000i32 + 1i32 +
-                                          1i32 + 19i32 + 256i32 + 256i32 +
-                                          13i32 + 256i32 + 4i32 + 256i32 +
-                                          1i32 + 3i32 * 256i32 +
-                                          (0x10ffffi32 + 1i32) +
-                                          (0x10ffffi32 + 1i32) +
-                                          (0x10ffffi32 + 1i32) +
-                                          (0x10ffffi32 + 1i32) +
-                                          (0x10ffffi32 + 1i32) +
-                                          (0x10ffffi32 + 1i32) + 56i32) as
-                                         isize)).b32.s1 {
+                if p - CHAR_SUB_CODE_BASE < INTPAR(INT_PAR__char_sub_def_max) {
                     if a as i32 >= 4i32 {
-                        geq_word_define(1i32 + (0x10ffffi32 + 1i32) +
-                                            (0x10ffffi32 + 1i32) + 1i32 +
-                                            15000i32 + 12i32 + 9000i32 + 1i32
-                                            + 1i32 + 19i32 + 256i32 + 256i32 +
-                                            13i32 + 256i32 + 4i32 + 256i32 +
-                                            1i32 + 3i32 * 256i32 +
-                                            (0x10ffffi32 + 1i32) +
-                                            (0x10ffffi32 + 1i32) +
-                                            (0x10ffffi32 + 1i32) +
-                                            (0x10ffffi32 + 1i32) +
-                                            (0x10ffffi32 + 1i32) +
-                                            (0x10ffffi32 + 1i32) + 56i32,
-                                        p -
-                                            (1i32 + (0x10ffffi32 + 1i32) +
-                                                 (0x10ffffi32 + 1i32) + 1i32 +
-                                                 15000i32 + 12i32 + 9000i32 +
-                                                 1i32 + 1i32 + 19i32 + 256i32
-                                                 + 256i32 + 13i32 + 256i32 +
-                                                 4i32 + 256i32 + 1i32 +
-                                                 3i32 * 256i32 +
-                                                 (0x10ffffi32 + 1i32) +
-                                                 (0x10ffffi32 + 1i32) +
-                                                 (0x10ffffi32 + 1i32) +
-                                                 (0x10ffffi32 + 1i32) +
-                                                 (0x10ffffi32 + 1i32)));
+                        geq_word_define(INT_BASE + INT_PAR__char_sub_def_max, p - CHAR_SUB_CODE_BASE);
                     } else {
-                        eq_word_define(1i32 + (0x10ffffi32 + 1i32) +
-                                           (0x10ffffi32 + 1i32) + 1i32 +
-                                           15000i32 + 12i32 + 9000i32 + 1i32 +
-                                           1i32 + 19i32 + 256i32 + 256i32 +
-                                           13i32 + 256i32 + 4i32 + 256i32 +
-                                           1i32 + 3i32 * 256i32 +
-                                           (0x10ffffi32 + 1i32) +
-                                           (0x10ffffi32 + 1i32) +
-                                           (0x10ffffi32 + 1i32) +
-                                           (0x10ffffi32 + 1i32) +
-                                           (0x10ffffi32 + 1i32) +
-                                           (0x10ffffi32 + 1i32) + 56i32,
-                                       p -
-                                           (1i32 + (0x10ffffi32 + 1i32) +
-                                                (0x10ffffi32 + 1i32) + 1i32 +
-                                                15000i32 + 12i32 + 9000i32 +
-                                                1i32 + 1i32 + 19i32 + 256i32 +
-                                                256i32 + 13i32 + 256i32 + 4i32
-                                                + 256i32 + 1i32 +
-                                                3i32 * 256i32 +
-                                                (0x10ffffi32 + 1i32) +
-                                                (0x10ffffi32 + 1i32) +
-                                                (0x10ffffi32 + 1i32) +
-                                                (0x10ffffi32 + 1i32) +
-                                                (0x10ffffi32 + 1i32)));
+                        eq_word_define(INT_BASE + INT_PAR__char_sub_def_max, p - CHAR_SUB_CODE_BASE);
                     }
                 }
             } else {
@@ -2926,29 +2365,31 @@ pub unsafe extern "C" fn prefixed_command() {
                 get_r_token();
                 p = cur_cs;
                 if a as i32 >= 4i32 {
-                    geq_define(p, 0_u16, 0x10ffffi32 + 1i32);
-                } else { eq_define(p, 0_u16, 0x10ffffi32 + 1i32); }
+                    geq_define(p, RELAX as _, TOO_BIG_USV);
+                } else {
+                    eq_define(p, RELAX as _, TOO_BIG_USV);
+                }
                 scan_optional_equals();
                 match n {
-                    0 => {
+                    CHAR_DEF_CODE => {
                         scan_usv_num();
                         if a as i32 >= 4i32 {
                             geq_define(p, 68_u16, cur_val);
                         } else { eq_define(p, 68_u16, cur_val); }
                     }
-                    1 => {
+                    MATH_CHAR_DEF_CODE => {
                         scan_fifteen_bit_int();
                         if a as i32 >= 4i32 {
                             geq_define(p, 69_u16, cur_val);
                         } else { eq_define(p, 69_u16, cur_val); }
                     }
-                    8 => {
+                    XETEX_MATH_CHAR_NUM_DEF_CODE => {
                         scan_xetex_math_char_int();
                         if a as i32 >= 4i32 {
                             geq_define(p, 70_u16, cur_val);
                         } else { eq_define(p, 70_u16, cur_val); }
                     }
-                    9 => {
+                    XETEX_MATH_CHAR_DEF_CODE => {
                         scan_math_class_int();
                         n =
                             ((cur_val as u32 &
@@ -2972,9 +2413,9 @@ pub unsafe extern "C" fn prefixed_command() {
                     }
                     _ => {
                         scan_register_num();
-                        if cur_val > 255i32 {
-                            j = n - 2i32;
-                            if j > 3i32 { j = 5i32 }
+                        if cur_val > 255 {
+                            j = n - 2;
+                            if j > MU_VAL { j = TOK_VAL }
                             find_sa_element(j as small_number, cur_val,
                                             true);
                             let ref mut fresh14 =
@@ -2987,140 +2428,39 @@ pub unsafe extern "C" fn prefixed_command() {
                             } else { eq_define(p, j as u16, cur_ptr); }
                         } else {
                             match n {
-                                2 => {
+                                COUNT_DEF_CODE => {
                                     if a as i32 >= 4i32 {
-                                        geq_define(p, 74_u16,
-                                                   1i32 + (0x10ffffi32 + 1i32)
-                                                       + (0x10ffffi32 + 1i32)
-                                                       + 1i32 + 15000i32 +
-                                                       12i32 + 9000i32 + 1i32
-                                                       + 1i32 + 19i32 + 256i32
-                                                       + 256i32 + 13i32 +
-                                                       256i32 + 4i32 + 256i32
-                                                       + 1i32 + 3i32 * 256i32
-                                                       + (0x10ffffi32 + 1i32)
-                                                       + (0x10ffffi32 + 1i32)
-                                                       + (0x10ffffi32 + 1i32)
-                                                       + (0x10ffffi32 + 1i32)
-                                                       + (0x10ffffi32 + 1i32)
-                                                       + (0x10ffffi32 + 1i32)
-                                                       + 85i32 + cur_val);
+                                        geq_define(p, ASSIGN_INT, COUNT_BASE + cur_val);
                                     } else {
-                                        eq_define(p, 74_u16,
-                                                  1i32 + (0x10ffffi32 + 1i32)
-                                                      + (0x10ffffi32 + 1i32) +
-                                                      1i32 + 15000i32 + 12i32
-                                                      + 9000i32 + 1i32 + 1i32
-                                                      + 19i32 + 256i32 +
-                                                      256i32 + 13i32 + 256i32
-                                                      + 4i32 + 256i32 + 1i32 +
-                                                      3i32 * 256i32 +
-                                                      (0x10ffffi32 + 1i32) +
-                                                      (0x10ffffi32 + 1i32) +
-                                                      (0x10ffffi32 + 1i32) +
-                                                      (0x10ffffi32 + 1i32) +
-                                                      (0x10ffffi32 + 1i32) +
-                                                      (0x10ffffi32 + 1i32) +
-                                                      85i32 + cur_val);
+                                        eq_define(p, ASSIGN_INT, COUNT_BASE + cur_val);
                                     }
                                 }
-                                3 => {
+                                DIMEN_DEF_CODE => {
                                     if a as i32 >= 4i32 {
-                                        geq_define(p, 75_u16,
-                                                   1i32 + (0x10ffffi32 + 1i32)
-                                                       + (0x10ffffi32 + 1i32)
-                                                       + 1i32 + 15000i32 +
-                                                       12i32 + 9000i32 + 1i32
-                                                       + 1i32 + 19i32 + 256i32
-                                                       + 256i32 + 13i32 +
-                                                       256i32 + 4i32 + 256i32
-                                                       + 1i32 + 3i32 * 256i32
-                                                       + (0x10ffffi32 + 1i32)
-                                                       + (0x10ffffi32 + 1i32)
-                                                       + (0x10ffffi32 + 1i32)
-                                                       + (0x10ffffi32 + 1i32)
-                                                       + (0x10ffffi32 + 1i32)
-                                                       + (0x10ffffi32 + 1i32)
-                                                       + 85i32 + 256i32 +
-                                                       (0x10ffffi32 + 1i32) +
-                                                       23i32 + cur_val);
+                                        geq_define(p, ASSIGN_DIMEN, SCALED_BASE + cur_val);
                                     } else {
-                                        eq_define(p, 75_u16,
-                                                  1i32 + (0x10ffffi32 + 1i32)
-                                                      + (0x10ffffi32 + 1i32) +
-                                                      1i32 + 15000i32 + 12i32
-                                                      + 9000i32 + 1i32 + 1i32
-                                                      + 19i32 + 256i32 +
-                                                      256i32 + 13i32 + 256i32
-                                                      + 4i32 + 256i32 + 1i32 +
-                                                      3i32 * 256i32 +
-                                                      (0x10ffffi32 + 1i32) +
-                                                      (0x10ffffi32 + 1i32) +
-                                                      (0x10ffffi32 + 1i32) +
-                                                      (0x10ffffi32 + 1i32) +
-                                                      (0x10ffffi32 + 1i32) +
-                                                      (0x10ffffi32 + 1i32) +
-                                                      85i32 + 256i32 +
-                                                      (0x10ffffi32 + 1i32) +
-                                                      23i32 + cur_val);
+                                        eq_define(p, ASSIGN_DIMEN, SCALED_BASE + cur_val);
                                     }
                                 }
-                                4 => {
+                                SKIP_DEF_CODE => {
                                     if a as i32 >= 4i32 {
-                                        geq_define(p, 76_u16,
-                                                   1i32 + (0x10ffffi32 + 1i32)
-                                                       + (0x10ffffi32 + 1i32)
-                                                       + 1i32 + 15000i32 +
-                                                       12i32 + 9000i32 + 1i32
-                                                       + 1i32 + 19i32 +
-                                                       cur_val);
+                                        geq_define(p, ASSIGN_GLUE, SKIP_BASE + cur_val);
                                     } else {
-                                        eq_define(p, 76_u16,
-                                                  1i32 + (0x10ffffi32 + 1i32)
-                                                      + (0x10ffffi32 + 1i32) +
-                                                      1i32 + 15000i32 + 12i32
-                                                      + 9000i32 + 1i32 + 1i32
-                                                      + 19i32 + cur_val);
+                                        eq_define(p, ASSIGN_GLUE, SKIP_BASE + cur_val);
                                     }
                                 }
-                                5 => {
+                                MU_SKIP_DEF_CODE => {
                                     if a as i32 >= 4i32 {
-                                        geq_define(p, 77_u16,
-                                                   1i32 + (0x10ffffi32 + 1i32)
-                                                       + (0x10ffffi32 + 1i32)
-                                                       + 1i32 + 15000i32 +
-                                                       12i32 + 9000i32 + 1i32
-                                                       + 1i32 + 19i32 + 256i32
-                                                       + cur_val);
+                                        geq_define(p, ASSIGN_MU_GLUE, MU_SKIP_BASE + cur_val);
                                     } else {
-                                        eq_define(p, 77_u16,
-                                                  1i32 + (0x10ffffi32 + 1i32)
-                                                      + (0x10ffffi32 + 1i32) +
-                                                      1i32 + 15000i32 + 12i32
-                                                      + 9000i32 + 1i32 + 1i32
-                                                      + 19i32 + 256i32 +
-                                                      cur_val);
+                                        eq_define(p, ASSIGN_MU_GLUE, MU_SKIP_BASE + cur_val);
                                     }
                                 }
-                                6 => {
+                                TOKS_DEF_CODE => {
                                     if a as i32 >= 4i32 {
-                                        geq_define(p, 73_u16,
-                                                   1i32 + (0x10ffffi32 + 1i32)
-                                                       + (0x10ffffi32 + 1i32)
-                                                       + 1i32 + 15000i32 +
-                                                       12i32 + 9000i32 + 1i32
-                                                       + 1i32 + 19i32 + 256i32
-                                                       + 256i32 + 13i32 +
-                                                       cur_val);
+                                        geq_define(p, ASSIGN_TOKS, TOKS_BASE + cur_val);
                                     } else {
-                                        eq_define(p, 73_u16,
-                                                  1i32 + (0x10ffffi32 + 1i32)
-                                                      + (0x10ffffi32 + 1i32) +
-                                                      1i32 + 15000i32 + 12i32
-                                                      + 9000i32 + 1i32 + 1i32
-                                                      + 19i32 + 256i32 +
-                                                      256i32 + 13i32 +
-                                                      cur_val);
+                                        eq_define(p, ASSIGN_TOKS, TOKS_BASE + cur_val);
                                     }
                                 }
                                 _ => { }
@@ -3130,7 +2470,7 @@ pub unsafe extern "C" fn prefixed_command() {
                 }
             }
         }
-        98 => {
+        READ_TO_CS => {
             j = cur_chr;
             scan_int();
             n = cur_val;
@@ -3159,7 +2499,7 @@ pub unsafe extern "C" fn prefixed_command() {
                 geq_define(p, 113_u16, cur_val);
             } else { eq_define(p, 113_u16, cur_val); }
         }
-        72 | 73 => {
+        TOKS_REGISTER | ASSIGN_TOKS => {
             q = cur_cs;
             e = false;
             if cur_cmd as i32 == 72i32 {
@@ -3171,17 +2511,10 @@ pub unsafe extern "C" fn prefixed_command() {
                         cur_chr = cur_ptr;
                         e = true
                     } else {
-                        cur_chr =
-                            1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32)
-                                + 1i32 + 15000i32 + 12i32 + 9000i32 + 1i32 +
-                                1i32 + 19i32 + 256i32 + 256i32 + 13i32 +
-                                cur_val
+                        cur_chr = TOKS_BASE + cur_val;
                     }
                 } else { e = true }
-            } else if cur_chr ==
-                          1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                              1i32 + 15000i32 + 12i32 + 9000i32 + 1i32 + 1i32
-                              + 19i32 + 256i32 + 256i32 + 11i32 {
+            } else if cur_chr == LOCAL_BASE + LOCAL__xetex_inter_char {
                 scan_char_class_not_ignored();
                 cur_ptr = cur_val;
                 scan_char_class_not_ignored();
@@ -3207,21 +2540,13 @@ pub unsafe extern "C" fn prefixed_command() {
                         if cur_chr == 0i32 {
                             scan_register_num(); /* "extended delimiter code flag" */
                             if cur_val < 256i32 {
-                                q =
-                                    (*eqtb.offset((1i32 + (0x10ffffi32 + 1i32)
-                                                       + (0x10ffffi32 + 1i32)
-                                                       + 1i32 + 15000i32 +
-                                                       12i32 + 9000i32 + 1i32
-                                                       + 1i32 + 19i32 + 256i32
-                                                       + 256i32 + 13i32 +
-                                                       cur_val) as
-                                                      isize)).b32.s1
+                                q = TOKS_REG(cur_val);
                             } else {
                                 find_sa_element(5i32 as small_number, cur_val,
                                                 0i32 !=
                                                     0); /* "extended delimiter code family */
-                                if cur_ptr == -0xfffffffi32 {
-                                    q = -0xfffffffi32
+                                if cur_ptr == TEX_NULL {
+                                    q = TEX_NULL
                                 } else {
                                     q =
                                         (*mem.offset((cur_ptr + 1i32) as
@@ -3233,34 +2558,30 @@ pub unsafe extern "C" fn prefixed_command() {
                                 (*mem.offset((cur_chr + 1i32) as
                                                  isize)).b32.s1
                         }
-                    } else if cur_chr ==
-                                  1i32 + (0x10ffffi32 + 1i32) +
-                                      (0x10ffffi32 + 1i32) + 1i32 + 15000i32 +
-                                      12i32 + 9000i32 + 1i32 + 1i32 + 19i32 +
-                                      256i32 + 256i32 + 11i32 {
+                    } else if cur_chr == LOCAL_BASE + LOCAL__xetex_inter_char {
                         scan_char_class_not_ignored(); /*:1268 */
                         cur_ptr = cur_val;
                         scan_char_class_not_ignored();
                         find_sa_element(6i32 as small_number,
                                         cur_ptr * 4096i32 + cur_val,
                                         false);
-                        if cur_ptr == -0xfffffffi32 {
-                            q = -0xfffffffi32
+                        if cur_ptr == TEX_NULL {
+                            q = TEX_NULL
                         } else {
                             q =
                                 (*mem.offset((cur_ptr + 1i32) as
                                                  isize)).b32.s1
                         }
                     } else { q = (*eqtb.offset(cur_chr as isize)).b32.s1 }
-                    if q == -0xfffffffi32 {
+                    if q == TEX_NULL {
                         if e {
                             if a as i32 >= 4i32 {
-                                gsa_def(p, -0xfffffffi32);
-                            } else { sa_def(p, -0xfffffffi32); }
+                                gsa_def(p, TEX_NULL);
+                            } else { sa_def(p, TEX_NULL); }
                         } else if a as i32 >= 4i32 {
-                            geq_define(p, 103_u16, -0xfffffffi32);
+                            geq_define(p, 103_u16, TEX_NULL);
                         } else {
-                            eq_define(p, 103_u16, -0xfffffffi32);
+                            eq_define(p, 103_u16, TEX_NULL);
                         }
                     } else {
                         let ref mut fresh15 =
@@ -3283,25 +2604,20 @@ pub unsafe extern "C" fn prefixed_command() {
                     back_input();
                     cur_cs = q;
                     q = scan_toks(false, false);
-                    if (*mem.offset(def_ref as isize)).b32.s1 == -0xfffffffi32
-                       {
+                    if (*mem.offset(def_ref as isize)).b32.s1 == TEX_NULL {
                         if e {
                             if a as i32 >= 4i32 {
-                                gsa_def(p, -0xfffffffi32);
-                            } else { sa_def(p, -0xfffffffi32); }
+                                gsa_def(p, TEX_NULL);
+                            } else { sa_def(p, TEX_NULL); }
                         } else if a as i32 >= 4i32 {
-                            geq_define(p, 103_u16, -0xfffffffi32);
+                            geq_define(p, 103_u16, TEX_NULL);
                         } else {
-                            eq_define(p, 103_u16, -0xfffffffi32);
+                            eq_define(p, 103_u16, TEX_NULL);
                         }
                         (*mem.offset(def_ref as isize)).b32.s1 = avail;
                         avail = def_ref
                     } else {
-                        if p ==
-                               1i32 + (0x10ffffi32 + 1i32) +
-                                   (0x10ffffi32 + 1i32) + 1i32 + 15000i32 +
-                                   12i32 + 9000i32 + 1i32 + 1i32 + 19i32 +
-                                   256i32 + 256i32 + 1i32 && !e {
+                        if p == LOCAL_BASE + LOCAL__output_routine && !e {
                             (*mem.offset(q as isize)).b32.s1 = get_avail();
                             q = (*mem.offset(q as isize)).b32.s1;
                             (*mem.offset(q as isize)).b32.s0 =
@@ -3324,7 +2640,7 @@ pub unsafe extern "C" fn prefixed_command() {
                 }
             }
         }
-        74 => {
+        ASSIGN_INT => {
             p = cur_chr;
             scan_optional_equals();
             scan_int();
@@ -3332,7 +2648,7 @@ pub unsafe extern "C" fn prefixed_command() {
                 geq_word_define(p, cur_val);
             } else { eq_word_define(p, cur_val); }
         }
-        75 => {
+        ASSIGN_DIMEN => {
             p = cur_chr;
             scan_optional_equals();
             scan_dimen(false, false, false);
@@ -3340,7 +2656,7 @@ pub unsafe extern "C" fn prefixed_command() {
                 geq_word_define(p, cur_val);
             } else { eq_word_define(p, cur_val); }
         }
-        76 | 77 => {
+        ASSIGN_GLUE | ASSIGN_MU_GLUE => {
             p = cur_chr;
             n = cur_cmd as i32;
             scan_optional_equals();
@@ -3352,27 +2668,12 @@ pub unsafe extern "C" fn prefixed_command() {
                 geq_define(p, 119_u16, cur_val);
             } else { eq_define(p, 119_u16, cur_val); }
         }
-        87 => {
-            if cur_chr ==
-                   1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) + 1i32 +
-                       15000i32 + 12i32 + 9000i32 + 1i32 + 1i32 + 19i32 +
-                       256i32 + 256i32 + 13i32 + 256i32 + 4i32 + 256i32 + 1i32
-                       + 3i32 * 256i32 + (0x10ffffi32 + 1i32) +
-                       (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) {
+        XETEX_DEF_CODE => {
+            if cur_chr == SF_CODE_BASE {
                 p = cur_chr;
                 scan_usv_num();
                 p = p + cur_val;
-                n =
-                    ((*eqtb.offset((1i32 + (0x10ffffi32 + 1i32) +
-                                        (0x10ffffi32 + 1i32) + 1i32 + 15000i32
-                                        + 12i32 + 9000i32 + 1i32 + 1i32 +
-                                        19i32 + 256i32 + 256i32 + 13i32 +
-                                        256i32 + 4i32 + 256i32 + 1i32 +
-                                        3i32 * 256i32 + (0x10ffffi32 + 1i32) +
-                                        (0x10ffffi32 + 1i32) +
-                                        (0x10ffffi32 + 1i32) + cur_val) as
-                                       isize)).b32.s1 as i64 %
-                         65536) as i32;
+                n = SF_CODE(cur_val) % 65536;
                 scan_optional_equals();
                 scan_char_class();
                 if a as i32 >= 4i32 {
@@ -3384,13 +2685,7 @@ pub unsafe extern "C" fn prefixed_command() {
                               (cur_val as i64 * 65536 +
                                    n as i64) as i32);
                 }
-            } else if cur_chr ==
-                          1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                              1i32 + 15000i32 + 12i32 + 9000i32 + 1i32 + 1i32
-                              + 19i32 + 256i32 + 256i32 + 13i32 + 256i32 +
-                              4i32 + 256i32 + 1i32 + 3i32 * 256i32 +
-                              (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                              (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) {
+            } else if cur_chr == MATH_CODE_BASE {
                 p = cur_chr;
                 scan_usv_num();
                 p = p + cur_val;
@@ -3399,14 +2694,7 @@ pub unsafe extern "C" fn prefixed_command() {
                 if a as i32 >= 4i32 {
                     geq_define(p, 122_u16, cur_val);
                 } else { eq_define(p, 122_u16, cur_val); }
-            } else if cur_chr ==
-                          1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                              1i32 + 15000i32 + 12i32 + 9000i32 + 1i32 + 1i32
-                              + 19i32 + 256i32 + 256i32 + 13i32 + 256i32 +
-                              4i32 + 256i32 + 1i32 + 3i32 * 256i32 +
-                              (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                              (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                              1i32 {
+            } else if cur_chr == MATH_CODE_BASE + 1 {
                 p = cur_chr - 1i32;
                 scan_usv_num();
                 p = p + cur_val;
@@ -3427,15 +2715,7 @@ pub unsafe extern "C" fn prefixed_command() {
                 if a as i32 >= 4i32 {
                     geq_define(p, 122_u16, n);
                 } else { eq_define(p, 122_u16, n); }
-            } else if cur_chr ==
-                          1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                              1i32 + 15000i32 + 12i32 + 9000i32 + 1i32 + 1i32
-                              + 19i32 + 256i32 + 256i32 + 13i32 + 256i32 +
-                              4i32 + 256i32 + 1i32 + 3i32 * 256i32 +
-                              (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                              (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                              (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                              85i32 + 256i32 {
+            } else if cur_chr == DEL_CODE_BASE {
                 p = cur_chr;
                 scan_usv_num();
                 p = p + cur_val;
@@ -3459,55 +2739,22 @@ pub unsafe extern "C" fn prefixed_command() {
                 } else { eq_word_define(p, n); }
             }
         }
-        86 => {
-            if cur_chr ==
-                   1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) + 1i32 +
-                       15000i32 + 12i32 + 9000i32 + 1i32 + 1i32 + 19i32 +
-                       256i32 + 256i32 + 13i32 + 256i32 + 4i32 + 256i32 + 1i32
-                       + 3i32 * 256i32 {
+    DEF_CODE => {
+            if cur_chr == CAT_CODE_BASE {
                 n = 15i32
-            } else if cur_chr ==
-                          1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                              1i32 + 15000i32 + 12i32 + 9000i32 + 1i32 + 1i32
-                              + 19i32 + 256i32 + 256i32 + 13i32 + 256i32 +
-                              4i32 + 256i32 + 1i32 + 3i32 * 256i32 +
-                              (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                              (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) {
+            } else if cur_chr == MATH_CODE_BASE {
                 n = 0x8000i32
-            } else if cur_chr ==
-                          1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                              1i32 + 15000i32 + 12i32 + 9000i32 + 1i32 + 1i32
-                              + 19i32 + 256i32 + 256i32 + 13i32 + 256i32 +
-                              4i32 + 256i32 + 1i32 + 3i32 * 256i32 +
-                              (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                              (0x10ffffi32 + 1i32) {
+            } else if cur_chr == SF_CODE_BASE {
                 n = 0x7fffi32
-            } else if cur_chr ==
-                          1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                              1i32 + 15000i32 + 12i32 + 9000i32 + 1i32 + 1i32
-                              + 19i32 + 256i32 + 256i32 + 13i32 + 256i32 +
-                              4i32 + 256i32 + 1i32 + 3i32 * 256i32 +
-                              (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                              (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                              (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                              85i32 + 256i32 {
+            } else if cur_chr == DEL_CODE_BASE {
                 n = 0xffffffi32
-            } else { n = 0x10ffffi32 }
+            } else { n = BIGGEST_USV }
             p = cur_chr;
             scan_usv_num();
             p = p + cur_val;
             scan_optional_equals();
             scan_int();
-            if cur_val < 0i32 &&
-                   p <
-                       1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                           1i32 + 15000i32 + 12i32 + 9000i32 + 1i32 + 1i32 +
-                           19i32 + 256i32 + 256i32 + 13i32 + 256i32 + 4i32 +
-                           256i32 + 1i32 + 3i32 * 256i32 +
-                           (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                           (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                           (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) + 85i32
-                           + 256i32 || cur_val > n {
+            if (cur_val < 0i32 && p < DEL_CODE_BASE) || cur_val > n {
                 if file_line_error_style_p != 0 {
                     print_file_line();
                 } else {
@@ -3517,15 +2764,7 @@ pub unsafe extern "C" fn prefixed_command() {
                 print_cstr(b"Invalid code (\x00" as *const u8 as
                                *const i8);
                 print_int(cur_val);
-                if p <
-                       1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                           1i32 + 15000i32 + 12i32 + 9000i32 + 1i32 + 1i32 +
-                           19i32 + 256i32 + 256i32 + 13i32 + 256i32 + 4i32 +
-                           256i32 + 1i32 + 3i32 * 256i32 +
-                           (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                           (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                           (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) + 85i32
-                           + 256i32 {
+                if p < MATH_CODE_BASE {
                     print_cstr(b"), should be in the range 0..\x00" as
                                    *const u8 as *const i8);
                 } else {
@@ -3540,20 +2779,8 @@ pub unsafe extern "C" fn prefixed_command() {
                 error();
                 cur_val = 0i32
             }
-            if p <
-                   1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) + 1i32 +
-                       15000i32 + 12i32 + 9000i32 + 1i32 + 1i32 + 19i32 +
-                       256i32 + 256i32 + 13i32 + 256i32 + 4i32 + 256i32 + 1i32
-                       + 3i32 * 256i32 + (0x10ffffi32 + 1i32) +
-                       (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                       (0x10ffffi32 + 1i32) {
-                if p >=
-                       1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                           1i32 + 15000i32 + 12i32 + 9000i32 + 1i32 + 1i32 +
-                           19i32 + 256i32 + 256i32 + 13i32 + 256i32 + 4i32 +
-                           256i32 + 1i32 + 3i32 * 256i32 +
-                           (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                           (0x10ffffi32 + 1i32) {
+            if p < MATH_CODE_BASE {
+                if p >= SF_CODE_BASE {
                     n =
                         ((*eqtb.offset(p as isize)).b32.s1 as i64 /
                              65536) as i32;
@@ -3569,17 +2796,9 @@ pub unsafe extern "C" fn prefixed_command() {
                 } else if a as i32 >= 4i32 {
                     geq_define(p, 122_u16, cur_val);
                 } else { eq_define(p, 122_u16, cur_val); }
-            } else if p <
-                          1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                              1i32 + 15000i32 + 12i32 + 9000i32 + 1i32 + 1i32
-                              + 19i32 + 256i32 + 256i32 + 13i32 + 256i32 +
-                              4i32 + 256i32 + 1i32 + 3i32 * 256i32 +
-                              (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                              (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                              (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                              85i32 + 256i32 {
+            } else if p < DEL_CODE_BASE {
                 if cur_val as i64 == 32768 {
-                    cur_val = 0x1fffffi32
+                    cur_val = ACTIVE_MATH_CHAR
                 } else {
                     cur_val =
                         (((cur_val / 4096i32) as u32 &
@@ -3602,7 +2821,7 @@ pub unsafe extern "C" fn prefixed_command() {
                 geq_word_define(p, cur_val);
             } else { eq_word_define(p, cur_val); }
         }
-        88 => {
+        DEF_FAMILY => {
             p = cur_chr;
             scan_math_fam_int();
             p = p + cur_val;
@@ -3612,12 +2831,12 @@ pub unsafe extern "C" fn prefixed_command() {
                 geq_define(p, 122_u16, cur_val);
             } else { eq_define(p, 122_u16, cur_val); }
         }
-        91 | 92 | 93 | 94 => { do_register_command(a); }
-        100 => {
+        REGISTER | ADVANCE | MULTIPLY | DIVIDE => { do_register_command(a); }
+        SET_BOX => {
             scan_register_num();
             if a as i32 >= 4i32 {
-                n = 0x40008000i32 + cur_val
-            } else { n = 0x40000000i32 + cur_val }
+                n = GLOBAL_BOX_FLAG + cur_val
+            } else { n = BOX_FLAG + cur_val }
             scan_optional_equals();
             if set_box_allowed {
                 scan_box(n);
@@ -3642,22 +2861,19 @@ pub unsafe extern "C" fn prefixed_command() {
                 error();
             }
         }
-        80 => { alter_aux(); }
-        81 => { alter_prev_graf(); }
-        82 => { alter_page_so_far(); }
-        83 => { alter_integer(); }
-        84 => { alter_box_dimen(); }
-        85 => {
+        SET_AUX => { alter_aux(); }
+        SET_PREV_GRAF => { alter_prev_graf(); }
+        SET_PAGE_DIMEN => { alter_page_so_far(); }
+        SET_PAGE_INT => { alter_integer(); }
+        SET_BOX_DIMEN => { alter_box_dimen(); }
+        SET_SHAPE => {
             q = cur_chr;
             scan_optional_equals();
             scan_int();
             n = cur_val;
             if n <= 0i32 {
-                p = -0xfffffffi32
-            } else if q >
-                          1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) +
-                              1i32 + 15000i32 + 12i32 + 9000i32 + 1i32 + 1i32
-                              + 19i32 + 256i32 + 256i32 + 0i32 {
+                p = TEX_NULL
+            } else if q > LOCAL_BASE + LOCAL__par_shape {
                 n = cur_val / 2i32 + 1i32;
                 p = get_node(2i32 * n + 1i32);
                 (*mem.offset(p as isize)).b32.s0 = n;
@@ -3689,7 +2905,7 @@ pub unsafe extern "C" fn prefixed_command() {
                 geq_define(q, 120_u16, p);
             } else { eq_define(q, 120_u16, p); }
         }
-        101 => {
+        HYPH_DATA => {
             if cur_chr == 1i32 {
                 if in_initex_mode {
                     new_patterns();
@@ -3706,20 +2922,20 @@ pub unsafe extern "C" fn prefixed_command() {
                     error();
                     loop  {
                         get_token();
-                        if !(cur_cmd as i32 != 2i32) { break ; }
+                        if !(cur_cmd != RIGHT_BRACE as _) { break ; }
                     }
                     return
                 }
             } else { new_hyph_exceptions(); }
         }
-        78 => {
-            find_font_dimen(1i32 != 0);
+        ASSIGN_FONT_DIMEN => {
+            find_font_dimen(true);
             k = cur_val;
             scan_optional_equals();
             scan_dimen(false, false, false);
             (*font_info.offset(k as isize)).b32.s1 = cur_val
         }
-        79 => {
+        ASSIGN_FONT_INT => {
             n = cur_chr;
             scan_font_ident();
             f = cur_val;
@@ -3740,21 +2956,21 @@ pub unsafe extern "C" fn prefixed_command() {
                 scan_optional_equals();
                 scan_int();
                 match n {
-                    2 => { set_cp_code(f, p as u32, 0i32, cur_val); }
-                    3 => { set_cp_code(f, p as u32, 1i32, cur_val); }
+                    LP_CODE_BASE => { set_cp_code(f, p as u32, 0i32, cur_val); }
+                    RP_CODE_BASE => { set_cp_code(f, p as u32, 1i32, cur_val); }
                     _ => { }
                 }
             }
         }
-        90 => { new_font(a); }
-        102 => { new_interaction(); }
+        DEF_FONT => { new_font(a); }
+        SET_INTERACTION => { new_interaction(); }
         _ => { confusion(b"prefix\x00" as *const u8 as *const i8); }
     }
     /*1304:*/
-    if after_token != 0i32 {
+    if after_token != 0 {
         cur_tok = after_token;
         back_input();
-        after_token = 0i32
+        after_token = 0;
     };
 }
 /*:1328*/
@@ -3791,108 +3007,18 @@ unsafe extern "C" fn store_fmt_file() {
     print_cstr(b" (preloaded format=\x00" as *const u8 as *const i8);
     print(job_name);
     print_char(' ' as i32);
-    print_int(
-        (*eqtb.offset(
-            (1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 23i32) as isize,
-        ))
-        .b32
-        .s1,
-    );
+    print_int(INTPAR(INT_PAR__year));
     print_char('.' as i32);
-    print_int(
-        (*eqtb.offset(
-            (1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 22i32) as isize,
-        ))
-        .b32
-        .s1,
-    );
+    print_int(INTPAR(INT_PAR__month));
     print_char('.' as i32);
-    print_int(
-        (*eqtb.offset(
-            (1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 21i32) as isize,
-        ))
-        .b32
-        .s1,
-    );
+    print_int(INTPAR(INT_PAR__day));
     print_char(')' as i32);
-    if interaction as i32 == 0i32 {
+    if interaction as i32 == BATCH_MODE {
         selector = Selector::LOG_ONLY
     } else {
         selector = Selector::TERM_AND_LOG
     }
-    if pool_ptr + 1i32 > pool_size {
+    if pool_ptr + 1 > pool_size {
         overflow(
             b"pool size\x00" as *const u8 as *const i8,
             pool_size - init_pool_ptr,
@@ -3923,7 +3049,7 @@ unsafe extern "C" fn store_fmt_file() {
         1i32 as size_t,
         fmt_out,
     );
-    let mut x_val_0: i32 = 28i32;
+    let mut x_val_0: i32 = FORMAT_SERIAL;
     do_dump(
         &mut x_val_0 as *mut i32 as *mut i8,
         ::std::mem::size_of::<i32>() as u64,
@@ -3937,60 +3063,31 @@ unsafe extern "C" fn store_fmt_file() {
         1i32 as size_t,
         fmt_out,
     );
-    while pseudo_files != -0xfffffffi32 {
+    while pseudo_files != TEX_NULL {
         pseudo_close();
     }
-    let mut x_val_2: i32 = 4999999i32;
+    let mut x_val_2: i32 = MEM_TOP;
     do_dump(
         &mut x_val_2 as *mut i32 as *mut i8,
         ::std::mem::size_of::<i32>() as u64,
         1i32 as size_t,
         fmt_out,
     );
-    let mut x_val_3: i32 = 1i32
-        + (0x10ffffi32 + 1i32)
-        + (0x10ffffi32 + 1i32)
-        + 1i32
-        + 15000i32
-        + 12i32
-        + 9000i32
-        + 1i32
-        + 1i32
-        + 19i32
-        + 256i32
-        + 256i32
-        + 13i32
-        + 256i32
-        + 4i32
-        + 256i32
-        + 1i32
-        + 3i32 * 256i32
-        + (0x10ffffi32 + 1i32)
-        + (0x10ffffi32 + 1i32)
-        + (0x10ffffi32 + 1i32)
-        + (0x10ffffi32 + 1i32)
-        + (0x10ffffi32 + 1i32)
-        + (0x10ffffi32 + 1i32)
-        + 85i32
-        + 256i32
-        + (0x10ffffi32 + 1i32)
-        + 23i32
-        + 256i32
-        - 1i32;
+    let mut x_val_3: i32 = EQTB_SIZE;
     do_dump(
         &mut x_val_3 as *mut i32 as *mut i8,
         ::std::mem::size_of::<i32>() as u64,
         1i32 as size_t,
         fmt_out,
     );
-    let mut x_val_4: i32 = 8501i32;
+    let mut x_val_4: i32 = HASH_PRIME;
     do_dump(
         &mut x_val_4 as *mut i32 as *mut i8,
         ::std::mem::size_of::<i32>() as u64,
         1i32 as size_t,
         fmt_out,
     );
-    let mut x_val_5: i32 = 607i32;
+    let mut x_val_5: i32 = HYPH_PRIME;
     do_dump(
         &mut x_val_5 as *mut i32 as *mut i8,
         ::std::mem::size_of::<i32>() as u64,
@@ -4105,7 +3202,7 @@ unsafe extern "C" fn store_fmt_file() {
     );
     x = x + mem_end + 1i32 - hi_mem_min;
     p = avail;
-    while p != -0xfffffffi32 {
+    while p != TEX_NULL {
         dyn_used -= 1;
         p = (*mem.offset(p as isize)).b32.s1
     }
@@ -4130,36 +3227,11 @@ unsafe extern "C" fn store_fmt_file() {
     print_char('&' as i32);
     print_int(dyn_used);
     /* equivalents table / primitive */
-    k = 1i32; /*:1350*/
+    k = ACTIVE_BASE; /*:1350*/
     loop {
         j = k;
         loop {
-            if !(j < 1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                - 1i32)
-            {
+            if !(j < INT_BASE - 1) {
                 current_block = 7923086311623215889;
                 break;
             }
@@ -4176,60 +3248,12 @@ unsafe extern "C" fn store_fmt_file() {
         }
         match current_block {
             7923086311623215889 => {
-                l = 1i32
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + 1i32
-                    + 15000i32
-                    + 12i32
-                    + 9000i32
-                    + 1i32
-                    + 1i32
-                    + 19i32
-                    + 256i32
-                    + 256i32
-                    + 13i32
-                    + 256i32
-                    + 4i32
-                    + 256i32
-                    + 1i32
-                    + 3i32 * 256i32
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
+                l = INT_BASE;
             }
             _ => {
                 j += 1;
                 l = j;
-                while j < 1i32
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + 1i32
-                    + 15000i32
-                    + 12i32
-                    + 9000i32
-                    + 1i32
-                    + 1i32
-                    + 19i32
-                    + 256i32
-                    + 256i32
-                    + 13i32
-                    + 256i32
-                    + 4i32
-                    + 256i32
-                    + 1i32
-                    + 3i32 * 256i32
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    - 1i32
-                {
+                while j < INT_BASE - 1 {
                     if (*eqtb.offset(j as isize)).b32.s1
                         != (*eqtb.offset((j + 1i32) as isize)).b32.s1
                         || (*eqtb.offset(j as isize)).b16.s1 as i32
@@ -4264,69 +3288,14 @@ unsafe extern "C" fn store_fmt_file() {
             1i32 as size_t,
             fmt_out,
         );
-        if !(k
-            != 1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32))
-        {
+        if !(k != INT_BASE) {
             break;
         }
     }
     loop {
         j = k;
         loop {
-            if !(j < 1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 85i32
-                + 256i32
-                + (0x10ffffi32 + 1i32)
-                + 23i32
-                + 256i32
-                - 1i32)
-            {
+            if !(j < EQTB_SIZE) {
                 current_block = 10505255564575309249;
                 break;
             }
@@ -4338,72 +3307,12 @@ unsafe extern "C" fn store_fmt_file() {
         }
         match current_block {
             10505255564575309249 => {
-                l = 1i32
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + 1i32
-                    + 15000i32
-                    + 12i32
-                    + 9000i32
-                    + 1i32
-                    + 1i32
-                    + 19i32
-                    + 256i32
-                    + 256i32
-                    + 13i32
-                    + 256i32
-                    + 4i32
-                    + 256i32
-                    + 1i32
-                    + 3i32 * 256i32
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + 85i32
-                    + 256i32
-                    + (0x10ffffi32 + 1i32)
-                    + 23i32
-                    + 256i32
-                    - 1i32
-                    + 1i32
+                l = EQTB_SIZE + 1;
             }
             _ => {
                 j += 1;
                 l = j;
-                while j < 1i32
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + 1i32
-                    + 15000i32
-                    + 12i32
-                    + 9000i32
-                    + 1i32
-                    + 1i32
-                    + 19i32
-                    + 256i32
-                    + 256i32
-                    + 13i32
-                    + 256i32
-                    + 4i32
-                    + 256i32
-                    + 1i32
-                    + 3i32 * 256i32
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + 85i32
-                    + 256i32
-                    + (0x10ffffi32 + 1i32)
-                    + 23i32
-                    + 256i32
-                    - 1i32
-                {
+                while j < EQTB_SIZE {
                     if (*eqtb.offset(j as isize)).b32.s1
                         != (*eqtb.offset((j + 1i32) as isize)).b32.s1
                     {
@@ -4434,76 +3343,13 @@ unsafe extern "C" fn store_fmt_file() {
             1i32 as size_t,
             fmt_out,
         );
-        if !(k
-            <= 1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 85i32
-                + 256i32
-                + (0x10ffffi32 + 1i32)
-                + 23i32
-                + 256i32
-                - 1i32)
-        {
+        if !(k <= EQTB_SIZE) {
             break;
         }
     }
     if hash_high > 0i32 {
         do_dump(
-            &mut *eqtb.offset(
-                (1i32
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + 1i32
-                    + 15000i32
-                    + 12i32
-                    + 9000i32
-                    + 1i32
-                    + 1i32
-                    + 19i32
-                    + 256i32
-                    + 256i32
-                    + 13i32
-                    + 256i32
-                    + 4i32
-                    + 256i32
-                    + 1i32
-                    + 3i32 * 256i32
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + 85i32
-                    + 256i32
-                    + (0x10ffffi32 + 1i32)
-                    + 23i32
-                    + 256i32
-                    - 1i32
-                    + 1i32) as isize,
-            ) as *mut memory_word as *mut i8,
+            &mut *eqtb.offset(EQTB_SIZE as isize + 1) as *mut memory_word as *mut i8,
             ::std::mem::size_of::<memory_word>() as u64,
             hash_high as size_t,
             fmt_out,
@@ -4524,7 +3370,7 @@ unsafe extern "C" fn store_fmt_file() {
         fmt_out,
     );
     p = 0i32;
-    while p <= 500i32 {
+    while p <= PRIM_SIZE {
         do_dump(
             &mut *prim.as_mut_ptr().offset(p as isize) as *mut b32x2 as *mut i8,
             ::std::mem::size_of::<b32x2>() as u64,
@@ -4534,7 +3380,7 @@ unsafe extern "C" fn store_fmt_file() {
         p += 1
     }
     p = 0i32;
-    while p <= 500i32 {
+    while p <= PRIM_SIZE {
         do_dump(
             &mut *prim_eqtb.as_mut_ptr().offset(p as isize) as *mut memory_word as *mut i8,
             ::std::mem::size_of::<memory_word>() as u64,
@@ -4551,10 +3397,8 @@ unsafe extern "C" fn store_fmt_file() {
         1i32 as size_t,
         fmt_out,
     );
-    cs_count =
-        1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) + 1i32 + 15000i32 - 1i32 - hash_used
-            + hash_high;
-    p = 1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) + 1i32;
+    cs_count = (FROZEN_CONTROL_SEQUENCE - 1) - hash_used + hash_high;
+    p = HASH_BASE;
     while p <= hash_used {
         if (*hash.offset(p as isize)).s1 != 0i32 {
             let mut x_val_22: i32 = p;
@@ -4577,53 +3421,12 @@ unsafe extern "C" fn store_fmt_file() {
     do_dump(
         &mut *hash.offset((hash_used + 1i32) as isize) as *mut b32x2 as *mut i8,
         ::std::mem::size_of::<b32x2>() as u64,
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            - 1i32
-            - hash_used) as size_t,
+        ((UNDEFINED_CONTROL_SEQUENCE - 1) - hash_used) as _,
         fmt_out,
     );
     if hash_high > 0i32 {
         do_dump(
-            &mut *hash.offset(
-                (1i32
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + 1i32
-                    + 15000i32
-                    + 12i32
-                    + 9000i32
-                    + 1i32
-                    + 1i32
-                    + 19i32
-                    + 256i32
-                    + 256i32
-                    + 13i32
-                    + 256i32
-                    + 4i32
-                    + 256i32
-                    + 1i32
-                    + 3i32 * 256i32
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + 85i32
-                    + 256i32
-                    + (0x10ffffi32 + 1i32)
-                    + 23i32
-                    + 256i32
-                    - 1i32
-                    + 1i32) as isize,
-            ) as *mut b32x2 as *mut i8,
+            &mut *hash.offset(EQTB_SIZE as isize + 1) as *mut b32x2 as *mut i8,
             ::std::mem::size_of::<b32x2>() as u64,
             hash_high as size_t,
             fmt_out,
@@ -4798,16 +3601,10 @@ unsafe extern "C" fn store_fmt_file() {
         (font_ptr + 1i32) as size_t,
         fmt_out,
     );
-    k = 0i32;
+    k = FONT_BASE;
     while k <= font_ptr {
         print_nl_cstr(b"\\font\x00" as *const u8 as *const i8);
-        print_esc(
-            (*hash.offset(
-                (1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) + 1i32 + 15000i32 + 12i32 + k)
-                    as isize,
-            ))
-            .s1,
-        );
+        print_esc((*hash.offset(FONT_ID_BASE as isize + k as isize)).s1);
         print_char('=' as i32);
         if *font_area.offset(k as isize) as u32 == 0xffffu32
             || *font_area.offset(k as isize) as u32 == 0xfffeu32
@@ -4988,7 +3785,7 @@ unsafe extern "C" fn store_fmt_file() {
     }
     print_cstr(b" out of \x00" as *const u8 as *const i8);
     print_int(35111 as i32);
-    k = 255i32;
+    k = BIGGEST_LANG;
     while k >= 0i32 {
         if trie_used[k as usize] as i32 > 0i32 {
             print_nl_cstr(b"  \x00" as *const u8 as *const i8);
@@ -5020,35 +3817,7 @@ unsafe extern "C" fn store_fmt_file() {
         1i32 as size_t,
         fmt_out,
     );
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32
-            + 1i32
-            + 3i32 * 256i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 31i32) as isize,
-    ))
-    .b32
-    .s1 = 0i32;
+    INTPAR_set(INT_PAR__tracing_stats, 0);
     ttstub_output_close(fmt_out_owner);
 }
 unsafe extern "C" fn pack_buffered_name(mut n: small_number, mut a: i32, mut b: i32) {
@@ -5123,46 +3892,9 @@ unsafe extern "C" fn load_fmt_file() -> bool {
             if hash_extra < hash_high {
                 hash_extra = hash_high
             }
-            eqtb_top = 1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 85i32
-                + 256i32
-                + (0x10ffffi32 + 1i32)
-                + 23i32
-                + 256i32
-                - 1i32
-                + hash_extra;
+            eqtb_top = EQTB_SIZE + hash_extra;
             if hash_extra == 0i32 {
-                hash_top = 1i32
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + 1i32
-                    + 15000i32
-                    + 12i32
-                    + 9000i32
-                    + 1i32
+                hash_top = UNDEFINED_CONTROL_SEQUENCE;
             } else {
                 hash_top = eqtb_top
             }
@@ -5177,92 +3909,19 @@ unsafe extern "C" fn load_fmt_file() -> bool {
                 .s1 = 0i32;
             x = 1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) + 1i32 + 1i32;
             while x <= hash_top {
-                *hash.offset(x as isize) = *hash
-                    .offset((1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) + 1i32) as isize);
+                *hash.offset(x as isize) = *hash.offset(HASH_BASE as isize);
                 x += 1
             }
             eqtb = xmalloc(
                 ((eqtb_top + 1i32 + 1i32) as u64)
                     .wrapping_mul(::std::mem::size_of::<memory_word>() as u64),
             ) as *mut memory_word;
-            (*eqtb.offset(
-                (1i32
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + 1i32
-                    + 15000i32
-                    + 12i32
-                    + 9000i32
-                    + 1i32) as isize,
-            ))
-            .b16
-            .s1 = 103_u16;
-            (*eqtb.offset(
-                (1i32
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + 1i32
-                    + 15000i32
-                    + 12i32
-                    + 9000i32
-                    + 1i32) as isize,
-            ))
-            .b32
-            .s1 = -0xfffffffi32;
-            (*eqtb.offset(
-                (1i32
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + 1i32
-                    + 15000i32
-                    + 12i32
-                    + 9000i32
-                    + 1i32) as isize,
-            ))
-            .b16
-            .s0 = 0_u16;
-            x = 1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 85i32
-                + 256i32
-                + (0x10ffffi32 + 1i32)
-                + 23i32
-                + 256i32
-                - 1i32
-                + 1i32;
+            (*eqtb.offset(UNDEFINED_CONTROL_SEQUENCE as isize)).b16.s1 = UNDEFINED_CS as _;
+            (*eqtb.offset(UNDEFINED_CONTROL_SEQUENCE as isize)).b32.s1 = TEX_NULL as _;
+            (*eqtb.offset(UNDEFINED_CONTROL_SEQUENCE as isize)).b16.s0 = LEVEL_ZERO as _;
+            x = EQTB_SIZE + 1;
             while x <= eqtb_top {
-                *eqtb.offset(x as isize) = *eqtb.offset(
-                    (1i32
-                        + (0x10ffffi32 + 1i32)
-                        + (0x10ffffi32 + 1i32)
-                        + 1i32
-                        + 15000i32
-                        + 12i32
-                        + 9000i32
-                        + 1i32) as isize,
-                );
+                *eqtb.offset(x as isize) = *eqtb.offset(UNDEFINED_CONTROL_SEQUENCE as isize);
                 x += 1
             }
             max_reg_num = 32767i32;
@@ -5275,10 +3934,10 @@ unsafe extern "C" fn load_fmt_file() -> bool {
                 1i32 as size_t,
                 fmt_in,
             );
-            if !(x != 4999999i32) {
-                cur_list.head = 4999999i32 - 1i32;
-                cur_list.tail = 4999999i32 - 1i32;
-                page_tail = 4999999i32 - 2i32;
+            if !(x != MEM_TOP) {
+                cur_list.head = CONTRIB_HEAD;
+                cur_list.tail = CONTRIB_HEAD;
+                page_tail = PAGE_HEAD;
                 mem = xmalloc(
                     ((4999999i32 + 1i32 + 1i32) as u64)
                         .wrapping_mul(::std::mem::size_of::<memory_word>() as u64),
@@ -5289,38 +3948,7 @@ unsafe extern "C" fn load_fmt_file() -> bool {
                     1i32 as size_t,
                     fmt_in,
                 );
-                if !(x
-                    != 1i32
-                        + (0x10ffffi32 + 1i32)
-                        + (0x10ffffi32 + 1i32)
-                        + 1i32
-                        + 15000i32
-                        + 12i32
-                        + 9000i32
-                        + 1i32
-                        + 1i32
-                        + 19i32
-                        + 256i32
-                        + 256i32
-                        + 13i32
-                        + 256i32
-                        + 4i32
-                        + 256i32
-                        + 1i32
-                        + 3i32 * 256i32
-                        + (0x10ffffi32 + 1i32)
-                        + (0x10ffffi32 + 1i32)
-                        + (0x10ffffi32 + 1i32)
-                        + (0x10ffffi32 + 1i32)
-                        + (0x10ffffi32 + 1i32)
-                        + (0x10ffffi32 + 1i32)
-                        + 85i32
-                        + 256i32
-                        + (0x10ffffi32 + 1i32)
-                        + 23i32
-                        + 256i32
-                        - 1i32)
-                {
+                if !(x != EQTB_SIZE) {
                     do_undump(
                         &mut x as *mut i32 as *mut i8,
                         ::std::mem::size_of::<i32>() as u64,
@@ -5443,7 +4071,7 @@ unsafe extern "C" fn load_fmt_file() -> bool {
                                                     1i32 as size_t,
                                                     fmt_in,
                                                 );
-                                                if x < -0xfffffffi32 || x > lo_mem_max {
+                                                if x < TEX_NULL || x > lo_mem_max {
                                                     current_block = 6442379788293543199;
                                                     break;
                                                 }
@@ -5515,8 +4143,7 @@ unsafe extern "C" fn load_fmt_file() -> bool {
                                                                     1i32 as size_t,
                                                                     fmt_in,
                                                                 );
-                                                                if !(x < -0xfffffffi32
-                                                                    || x > 4999999i32)
+                                                                if !(x < TEX_NULL || x > 4999999i32)
                                                                 {
                                                                     avail = x;
                                                                     mem_end = 4999999i32;
@@ -6690,7 +5317,7 @@ unsafe extern "C" fn load_fmt_file() -> bool {
                                                                                                                                                  as
                                                                                                                                                  isize)
                                                                                                                    <
-                                                                                                                   -0xfffffffi32
+                                                                                                                   TEX_NULL
                                                                                                                    ||
                                                                                                                    *(&mut *font_params.offset(0)
                                                                                                                          as
@@ -6714,7 +5341,7 @@ unsafe extern "C" fn load_fmt_file() -> bool {
                                                                                                                               *mut font_index
                                                                                                                               as
                                                                                                                               uintptr_t,
-                                                                                                                          -0xfffffffi32
+                                                                                                                          TEX_NULL
                                                                                                                               as
                                                                                                                               uintptr_t,
                                                                                                                           0x3fffffffi32
@@ -7051,7 +5678,7 @@ unsafe extern "C" fn load_fmt_file() -> bool {
                                                                                                                                               as
                                                                                                                                               isize)
                                                                                                                    <
-                                                                                                                   -0xfffffffi32
+                                                                                                                   TEX_NULL
                                                                                                                    ||
                                                                                                                    *(&mut *font_glue.offset(0)
                                                                                                                          as
@@ -7075,7 +5702,7 @@ unsafe extern "C" fn load_fmt_file() -> bool {
                                                                                                                               *mut i32
                                                                                                                               as
                                                                                                                               uintptr_t,
-                                                                                                                          -0xfffffffi32
+                                                                                                                          TEX_NULL
                                                                                                                               as
                                                                                                                               uintptr_t,
                                                                                                                           lo_mem_max
@@ -7481,7 +6108,7 @@ unsafe extern "C" fn load_fmt_file() -> bool {
                                                                                                                               fmt_in);
                                                                                                                     if x
                                                                                                                            <
-                                                                                                                           -0xfffffffi32
+                                                                                                                           TEX_NULL
                                                                                                                            ||
                                                                                                                            x
                                                                                                                                >
@@ -8008,7 +6635,7 @@ unsafe extern "C" fn final_cleanup() {
         print_char(')' as i32);
         show_save_groups();
     }
-    while cond_ptr != -0xfffffffi32 {
+    while cond_ptr != TEX_NULL {
         print_nl('(' as i32);
         print_esc_cstr(b"end occurred \x00" as *const u8 as *const i8);
         print_cstr(b"when \x00" as *const u8 as *const i8);
@@ -8043,7 +6670,7 @@ unsafe extern "C" fn final_cleanup() {
             for_end = 4i32;
             if c as i32 <= for_end {
                 loop {
-                    if cur_mark[c as usize] != -0xfffffffi32 {
+                    if cur_mark[c as usize] != TEX_NULL {
                         delete_token_ref(cur_mark[c as usize]);
                     }
                     let fresh17 = c;
@@ -8053,9 +6680,9 @@ unsafe extern "C" fn final_cleanup() {
                     }
                 }
             }
-            if sa_root[7] != -0xfffffffi32 {
+            if sa_root[7] != TEX_NULL {
                 if do_marks(3i32 as small_number, 0i32 as small_number, sa_root[7]) {
-                    sa_root[7] = -0xfffffffi32
+                    sa_root[7] = TEX_NULL
                 }
             }
             let mut for_end_0: i32 = 0;
@@ -8120,76 +6747,22 @@ unsafe extern "C" fn initialize_more_variables() {
     use_err_help = false;
     nest_ptr = 0i32;
     max_nest_stack = 0i32;
-    cur_list.mode = 1_i16;
-    cur_list.head = 4999999i32 - 1i32;
-    cur_list.tail = 4999999i32 - 1i32;
-    cur_list.eTeX_aux = -0xfffffffi32;
-    cur_list.aux.b32.s1 = -65536000i32;
+    cur_list.mode = VMODE as _;
+    cur_list.head = CONTRIB_HEAD;
+    cur_list.tail = CONTRIB_HEAD;
+    cur_list.eTeX_aux = TEX_NULL;
+    cur_list.aux.b32.s1 = IGNORE_DEPTH;
     cur_list.mode_line = 0i32;
     cur_list.prev_graf = 0i32;
     shown_mode = 0_i16;
-    page_contents = 0_u8;
-    page_tail = 4999999i32 - 2i32;
-    last_glue = 0x3fffffffi32;
+    page_contents = EMPTY as _;
+    page_tail = PAGE_HEAD;
+    last_glue = MAX_HALFWORD;
     last_penalty = 0i32;
     last_kern = 0i32;
     page_so_far[7] = 0i32;
-    k = 1i32
-        + (0x10ffffi32 + 1i32)
-        + (0x10ffffi32 + 1i32)
-        + 1i32
-        + 15000i32
-        + 12i32
-        + 9000i32
-        + 1i32
-        + 1i32
-        + 19i32
-        + 256i32
-        + 256i32
-        + 13i32
-        + 256i32
-        + 4i32
-        + 256i32
-        + 1i32
-        + 3i32 * 256i32
-        + (0x10ffffi32 + 1i32)
-        + (0x10ffffi32 + 1i32)
-        + (0x10ffffi32 + 1i32)
-        + (0x10ffffi32 + 1i32)
-        + (0x10ffffi32 + 1i32)
-        + (0x10ffffi32 + 1i32);
-    while k
-        <= 1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32
-            + 1i32
-            + 3i32 * 256i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 85i32
-            + 256i32
-            + (0x10ffffi32 + 1i32)
-            + 23i32
-            + 256i32
-            - 1i32
-    {
+    k = INT_BASE;
+    while k <= EQTB_SIZE {
         _xeq_level_array[(k
             - (1i32
                 + (0x10ffffi32 + 1i32)
@@ -8227,7 +6800,7 @@ unsafe extern "C" fn initialize_more_variables() {
     }
     prim_eqtb[0].b16.s0 = 0_u16;
     prim_eqtb[0].b16.s1 = 103_u16;
-    prim_eqtb[0].b32.s1 = -0xfffffffi32;
+    prim_eqtb[0].b32.s1 = TEX_NULL;
     k = 1i32;
     while k <= 500i32 {
         prim_eqtb[k as usize] = prim_eqtb[0];
@@ -8241,11 +6814,11 @@ unsafe extern "C" fn initialize_more_variables() {
     mag_set = 0i32;
     expand_depth_count = 0i32;
     is_in_csname = false;
-    cur_mark[0] = -0xfffffffi32;
-    cur_mark[1] = -0xfffffffi32;
-    cur_mark[2] = -0xfffffffi32;
-    cur_mark[3] = -0xfffffffi32;
-    cur_mark[4] = -0xfffffffi32;
+    cur_mark[0] = TEX_NULL;
+    cur_mark[1] = TEX_NULL;
+    cur_mark[2] = TEX_NULL;
+    cur_mark[3] = TEX_NULL;
+    cur_mark[4] = TEX_NULL;
     cur_val = 0i32;
     cur_val_level = 0_u8;
     radix = 0i32 as small_number;
@@ -8255,7 +6828,7 @@ unsafe extern "C" fn initialize_more_variables() {
         read_open[k as usize] = 2_u8;
         k += 1
     }
-    cond_ptr = -0xfffffffi32;
+    cond_ptr = TEX_NULL;
     if_limit = 0_u8;
     cur_if = 0i32 as small_number;
     if_line = 0i32;
@@ -8270,26 +6843,26 @@ unsafe extern "C" fn initialize_more_variables() {
     last_bop = -1i32;
     doing_leaders = false;
     dead_cycles = 0i32;
-    adjust_tail = -0xfffffffi32;
+    adjust_tail = TEX_NULL;
     last_badness = 0i32;
-    pre_adjust_tail = -0xfffffffi32;
+    pre_adjust_tail = TEX_NULL;
     pack_begin_line = 0i32;
     empty.s1 = 0i32;
-    empty.s0 = -0xfffffffi32;
-    align_ptr = -0xfffffffi32;
-    cur_align = -0xfffffffi32;
-    cur_span = -0xfffffffi32;
-    cur_loop = -0xfffffffi32;
-    cur_head = -0xfffffffi32;
-    cur_tail = -0xfffffffi32;
-    cur_pre_head = -0xfffffffi32;
-    cur_pre_tail = -0xfffffffi32;
+    empty.s0 = TEX_NULL;
+    align_ptr = TEX_NULL;
+    cur_align = TEX_NULL;
+    cur_span = TEX_NULL;
+    cur_loop = TEX_NULL;
+    cur_head = TEX_NULL;
+    cur_tail = TEX_NULL;
+    cur_pre_head = TEX_NULL;
+    cur_pre_tail = TEX_NULL;
     cur_f = 0i32;
     max_hyph_char = 256i32;
     z = 0i32 as hyph_pointer;
     while z as i32 <= hyph_size {
         *hyph_word.offset(z as isize) = 0i32;
-        *hyph_list.offset(z as isize) = -0xfffffffi32;
+        *hyph_list.offset(z as isize) = TEX_NULL;
         *hyph_link.offset(z as isize) = 0i32 as hyph_pointer;
         z = z.wrapping_add(1)
     }
@@ -8313,17 +6886,17 @@ unsafe extern "C" fn initialize_more_variables() {
         write_open[k as usize] = false;
         k += 1
     }
-    LR_ptr = -0xfffffffi32;
+    LR_ptr = TEX_NULL;
     LR_problems = 0i32;
     cur_dir = 0i32 as small_number;
-    pseudo_files = -0xfffffffi32;
-    sa_root[7] = -0xfffffffi32;
-    sa_null.b32.s0 = -0xfffffffi32;
-    sa_null.b32.s1 = -0xfffffffi32;
-    sa_chain = -0xfffffffi32;
+    pseudo_files = TEX_NULL;
+    sa_root[7] = TEX_NULL;
+    sa_null.b32.s0 = TEX_NULL;
+    sa_null.b32.s1 = TEX_NULL;
+    sa_chain = TEX_NULL;
     sa_level = 0_u16;
-    disc_ptr[2] = -0xfffffffi32;
-    disc_ptr[3] = -0xfffffffi32;
+    disc_ptr[2] = TEX_NULL;
+    disc_ptr[3] = TEX_NULL;
     edit_name_start = 0i32;
     stop_at_space = true;
 }
@@ -8337,7 +6910,7 @@ unsafe extern "C" fn initialize_more_initex_variables() {
     }
     k = 0i32;
     while k <= 19i32 {
-        (*mem.offset(k as isize)).b32.s1 = -0xfffffffi32 + 1i32;
+        (*mem.offset(k as isize)).b32.s1 = TEX_NULL + 1i32;
         (*mem.offset(k as isize)).b16.s1 = 0_u16;
         (*mem.offset(k as isize)).b16.s0 = 0_u16;
         k += 4i32
@@ -8358,1592 +6931,168 @@ unsafe extern "C" fn initialize_more_initex_variables() {
     (*mem.offset((rover + 1i32) as isize)).b32.s0 = rover;
     (*mem.offset((rover + 1i32) as isize)).b32.s1 = rover;
     lo_mem_max = rover + 1000i32;
-    (*mem.offset(lo_mem_max as isize)).b32.s1 = -0xfffffffi32;
-    (*mem.offset(lo_mem_max as isize)).b32.s0 = -0xfffffffi32;
-    k = 4999999i32 - 14i32;
-    while k <= 4999999i32 {
+    (*mem.offset(lo_mem_max as isize)).b32.s1 = TEX_NULL;
+    (*mem.offset(lo_mem_max as isize)).b32.s0 = TEX_NULL;
+    k = PRE_ADJUST_HEAD;
+    while k <= MEM_TOP {
         *mem.offset(k as isize) = *mem.offset(lo_mem_max as isize);
         k += 1
     }
-    (*mem.offset((4999999i32 - 10i32) as isize)).b32.s0 = 0x1ffffffi32
-        + (1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) + 1i32 + 15000i32 + 5i32);
-    (*mem.offset((4999999i32 - 9i32) as isize)).b32.s1 = 65535i32 + 1i32;
-    (*mem.offset((4999999i32 - 9i32) as isize)).b32.s0 = -0xfffffffi32;
-    (*mem.offset((4999999i32 - 7i32) as isize)).b16.s1 = 1_u16;
-    (*mem.offset((4999999i32 - 7i32 + 1i32) as isize)).b32.s0 = 0x3fffffffi32;
-    (*mem.offset((4999999i32 - 7i32) as isize)).b16.s0 = 0_u16;
-    (*mem.offset(4999999)).b16.s0 = 255_u16;
-    (*mem.offset(4999999)).b16.s1 = 1_u16;
-    (*mem.offset(4999999)).b32.s1 = 4999999i32;
+    (*mem.offset((OMIT_TEMPLATE) as isize)).b32.s0 = CS_TOKEN_FLAG + FROZEN_END_TEMPLATE;
+    (*mem.offset(END_SPAN as isize)).b32.s1 = std::u16::MAX as i32 + 1;
+    (*mem.offset(END_SPAN as isize)).b32.s0 = TEX_NULL;
+    (*mem.offset(ACTIVE_LIST as isize)).b16.s1 = HYPHENATED as _;
+    (*mem.offset((ACTIVE_LIST + 1) as isize)).b32.s0 = MAX_HALFWORD;
+    (*mem.offset(ACTIVE_LIST as isize)).b16.s0 = 0_u16;
+    (*mem.offset(PAGE_INS_HEAD as isize)).b16.s0 = 255_u16;
+    (*mem.offset(PAGE_INS_HEAD as isize)).b16.s1 = SPLIT_UP as _;
+    (*mem.offset(PAGE_INS_HEAD as isize)).b32.s1 = PAGE_INS_HEAD;
     (*mem.offset((4999999i32 - 2i32) as isize)).b16.s1 = 10_u16;
     (*mem.offset((4999999i32 - 2i32) as isize)).b16.s0 = 0_u16;
-    avail = -0xfffffffi32;
-    mem_end = 4999999i32;
-    hi_mem_min = 4999999i32 - 14i32;
-    var_used = 20i32;
-    dyn_used = 15i32;
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32) as isize,
-    ))
-    .b16
-    .s1 = 103_u16;
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32) as isize,
-    ))
-    .b32
-    .s1 = -0xfffffffi32;
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32) as isize,
-    ))
-    .b16
-    .s0 = 0_u16;
-    k = 1i32;
+    avail = TEX_NULL;
+    mem_end = MEM_TOP;
+    hi_mem_min = PRE_ADJUST_HEAD;
+    var_used = 20;
+    dyn_used = HI_MEM_STAT_USAGE;
+    (*eqtb.offset(UNDEFINED_CONTROL_SEQUENCE as isize)).b16.s1 = UNDEFINED_CS as _;
+    (*eqtb.offset(UNDEFINED_CONTROL_SEQUENCE as isize)).b32.s1 = TEX_NULL;
+    (*eqtb.offset(UNDEFINED_CONTROL_SEQUENCE as isize)).b16.s0 = LEVEL_ZERO as _;
+    k = ACTIVE_BASE;
     while k <= eqtb_top {
-        *eqtb.offset(k as isize) = *eqtb.offset(
-            (1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32) as isize,
-        );
+        *eqtb.offset(k as isize) = *eqtb.offset(UNDEFINED_CONTROL_SEQUENCE as isize);
         k += 1
     }
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32) as isize,
-    ))
-    .b32
-    .s1 = 0i32;
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32) as isize,
-    ))
-    .b16
-    .s0 = 1_u16;
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32) as isize,
-    ))
-    .b16
-    .s1 = 119_u16;
-    k = 1i32
-        + (0x10ffffi32 + 1i32)
-        + (0x10ffffi32 + 1i32)
-        + 1i32
-        + 15000i32
-        + 12i32
-        + 9000i32
-        + 1i32
-        + 1i32
-        + 1i32;
-    while k
-        <= 1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            - 1i32
-    {
-        *eqtb.offset(k as isize) = *eqtb.offset(
-            (1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32) as isize,
-        );
+    (*eqtb.offset(GLUE_BASE as isize)).b32.s1 = 0;
+    (*eqtb.offset(GLUE_BASE as isize)).b16.s0 = LEVEL_ONE as _;
+    (*eqtb.offset(GLUE_BASE as isize)).b16.s1 = GLUE_REF as _;
+    k = GLUE_BASE;
+    while k <= LOCAL_BASE {
+        *eqtb.offset(k as isize) = *eqtb.offset(GLUE_BASE as isize);
         k += 1
     }
     let ref mut fresh20 = (*mem.offset(0)).b32.s1;
     *fresh20 += 531i32;
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 0i32) as isize,
-    ))
-    .b32
-    .s1 = -0xfffffffi32;
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 0i32) as isize,
-    ))
-    .b16
-    .s1 = 120_u16;
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 0i32) as isize,
-    ))
-    .b16
-    .s0 = 1_u16;
-    k = 1i32
-        + (0x10ffffi32 + 1i32)
-        + (0x10ffffi32 + 1i32)
-        + 1i32
-        + 15000i32
-        + 12i32
-        + 9000i32
-        + 1i32
-        + 1i32
-        + 19i32
-        + 256i32
-        + 256i32
-        + 13i32
-        + 256i32;
-    while k
-        <= 1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            - 1i32
-    {
-        *eqtb.offset(k as isize) = *eqtb.offset(
-            (1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 0i32) as isize,
-        );
+    LOCAL_set(LOCAL__par_shape, TEX_NULL);
+    (*eqtb.offset(LOCAL_BASE as isize + LOCAL__par_shape as isize))
+        .b16
+        .s1 = SHAPE_REF as _;
+    (*eqtb.offset(LOCAL_BASE as isize + LOCAL__par_shape as isize))
+        .b16
+        .s0 = LEVEL_ONE as _;
+    k = ETEX_PEN_BASE;
+    while k <= ETEX_PENS - 1 {
+        *eqtb.offset(k as isize) = *eqtb.offset(LOCAL_BASE as isize + LOCAL__par_shape as isize);
         k += 1
     }
-    k = 1i32
-        + (0x10ffffi32 + 1i32)
-        + (0x10ffffi32 + 1i32)
-        + 1i32
-        + 15000i32
-        + 12i32
-        + 9000i32
-        + 1i32
-        + 1i32
-        + 19i32
-        + 256i32
-        + 256i32
-        + 1i32;
-    while k
-        <= 1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            - 1i32
-    {
-        *eqtb.offset(k as isize) = *eqtb.offset(
-            (1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32) as isize,
-        );
+    k = LOCAL_BASE + LOCAL__output_routine;
+    while k <= TOKS_BASE + NUMBER_REGS - 1 {
+        *eqtb.offset(k as isize) = *eqtb.offset(UNDEFINED_CONTROL_SEQUENCE as isize);
         k += 1
     }
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32) as isize,
-    ))
-    .b32
-    .s1 = -0xfffffffi32;
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32) as isize,
-    ))
-    .b16
-    .s1 = 121_u16;
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32) as isize,
-    ))
-    .b16
-    .s0 = 1_u16;
-    k = 1i32
-        + (0x10ffffi32 + 1i32)
-        + (0x10ffffi32 + 1i32)
-        + 1i32
-        + 15000i32
-        + 12i32
-        + 9000i32
-        + 1i32
-        + 1i32
-        + 19i32
-        + 256i32
-        + 256i32
-        + 13i32
-        + 256i32
-        + 4i32
-        + 1i32;
-    while k
-        <= 1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32
-            - 1i32
-    {
-        *eqtb.offset(k as isize) = *eqtb.offset(
-            (1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32) as isize,
-        );
+    (*eqtb.offset(BOX_BASE as isize)).b32.s1 = TEX_NULL;
+    (*eqtb.offset(BOX_BASE as isize)).b16.s1 = BOX_REF as _;
+    (*eqtb.offset(BOX_BASE as isize)).b16.s0 = LEVEL_ONE as _;
+    k = BOX_BASE + 1;
+    while k <= BOX_BASE + NUMBER_REGS - 1 {
+        *eqtb.offset(k as isize) = *eqtb.offset(BOX_BASE as _);
         k += 1
     }
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32) as isize,
-    ))
-    .b32
-    .s1 = 0i32;
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32) as isize,
-    ))
-    .b16
-    .s1 = 122_u16;
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32) as isize,
-    ))
-    .b16
-    .s0 = 1_u16;
-    k = 1i32
-        + (0x10ffffi32 + 1i32)
-        + (0x10ffffi32 + 1i32)
-        + 1i32
-        + 15000i32
-        + 12i32
-        + 9000i32
-        + 1i32
-        + 1i32
-        + 19i32
-        + 256i32
-        + 256i32
-        + 13i32
-        + 256i32
-        + 4i32
-        + 256i32
-        + 1i32;
-    while k
-        <= 1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32
-            + 1i32
-            + 3i32 * 256i32
-            - 1i32
-    {
-        *eqtb.offset(k as isize) = *eqtb.offset(
-            (1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32) as isize,
-        );
+    (*eqtb.offset(CUR_FONT_LOC as isize)).b32.s1 = FONT_BASE;
+    (*eqtb.offset(CUR_FONT_LOC as isize)).b16.s1 = DATA as _;
+    (*eqtb.offset(CUR_FONT_LOC as isize)).b16.s0 = LEVEL_ONE as _;
+    k = MATH_FONT_BASE;
+    while k <= MATH_FONT_BASE + NUMBER_MATH_FONTS - 1 {
+        *eqtb.offset(k as isize) = *eqtb.offset(CUR_FONT_LOC as isize);
         k += 1
     }
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32
-            + 1i32
-            + 3i32 * 256i32) as isize,
-    ))
-    .b32
-    .s1 = 0i32;
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32
-            + 1i32
-            + 3i32 * 256i32) as isize,
-    ))
-    .b16
-    .s1 = 122_u16;
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32
-            + 1i32
-            + 3i32 * 256i32) as isize,
-    ))
-    .b16
-    .s0 = 1_u16;
-    k = 1i32
-        + (0x10ffffi32 + 1i32)
-        + (0x10ffffi32 + 1i32)
-        + 1i32
-        + 15000i32
-        + 12i32
-        + 9000i32
-        + 1i32
-        + 1i32
-        + 19i32
-        + 256i32
-        + 256i32
-        + 13i32
-        + 256i32
-        + 4i32
-        + 256i32
-        + 1i32
-        + 3i32 * 256i32
-        + 1i32;
-    while k
-        <= 1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32
-            + 1i32
-            + 3i32 * 256i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            - 1i32
-    {
-        *eqtb.offset(k as isize) = *eqtb.offset(
-            (1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32) as isize,
-        );
+    (*eqtb.offset(CAT_CODE_BASE as isize)).b32.s1 = 0;
+    (*eqtb.offset(CAT_CODE_BASE as isize)).b16.s1 = DATA as _;
+    (*eqtb.offset(CAT_CODE_BASE as isize)).b16.s0 = LEVEL_ONE as _;
+    k = CAT_CODE_BASE + 1;
+    while k <= INT_BASE - 1 {
+        *eqtb.offset(k as isize) = *eqtb.offset(CAT_CODE_BASE as isize);
         k += 1
     }
-    k = 0i32;
-    while k <= 0x10ffffi32 + 1i32 - 1i32 {
-        (*eqtb.offset(
-            (1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + k) as isize,
-        ))
-        .b32
-        .s1 = 12i32;
-        (*eqtb.offset(
-            (1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + k) as isize,
-        ))
-        .b32
-        .s1 = k;
-        (*eqtb.offset(
-            (1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + k) as isize,
-        ))
-        .b32
-        .s1 = 1000i32;
+    k = 0;
+    while k <= NUMBER_USVS - 1 {
+        CAT_CODE_set(k, OTHER_CHAR as _);
+        MATH_CODE_set(k, k);
+        SF_CODE_set(k, 1000);
         k += 1
     }
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32
-            + 1i32
-            + 3i32 * 256i32
-            + 13i32) as isize,
-    ))
-    .b32
-    .s1 = 5i32;
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32
-            + 1i32
-            + 3i32 * 256i32
-            + 32i32) as isize,
-    ))
-    .b32
-    .s1 = 10i32;
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32
-            + 1i32
-            + 3i32 * 256i32
-            + 92i32) as isize,
-    ))
-    .b32
-    .s1 = 0i32;
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32
-            + 1i32
-            + 3i32 * 256i32
-            + 37i32) as isize,
-    ))
-    .b32
-    .s1 = 14i32;
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32
-            + 1i32
-            + 3i32 * 256i32
-            + 127i32) as isize,
-    ))
-    .b32
-    .s1 = 15i32;
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32
-            + 1i32
-            + 3i32 * 256i32) as isize,
-    ))
-    .b32
-    .s1 = 9i32;
+    CAT_CODE_set(13, CAR_RET as _);
+    CAT_CODE_set(32, SPACER as _);
+    CAT_CODE_set(92, ESCAPE as _);
+    CAT_CODE_set(37, COMMENT as _);
+    CAT_CODE_set(127, INVALID_CHAR as _);
+    (*eqtb.offset(CAT_CODE_BASE as isize)).b32.s1 = IGNORE as _;
     k = '0' as i32;
     while k <= '9' as i32 {
-        (*eqtb.offset(
-            (1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + k) as isize,
-        ))
-        .b32
-        .s1 = (k as u32).wrapping_add((7_u32 & 0x7_u32) << 21i32) as i32;
+        MATH_CODE_set(
+            k,
+            (k as u32).wrapping_add((7_u32 & 0x7_u32) << 21i32) as i32,
+        );
         k += 1
     }
     k = 'A' as i32;
     while k <= 'Z' as i32 {
-        (*eqtb.offset(
-            (1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + k) as isize,
-        ))
-        .b32
-        .s1 = 11i32;
-        (*eqtb.offset(
-            (1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (k + 32i32)) as isize,
-        ))
-        .b32
-        .s1 = 11i32;
-        (*eqtb.offset(
-            (1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + k) as isize,
-        ))
-        .b32
-        .s1 = (k as u32)
-            .wrapping_add((1_u32 & 0xff_u32) << 24i32)
-            .wrapping_add((7_u32 & 0x7_u32) << 21i32) as i32;
-        (*eqtb.offset(
-            (1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (k + 32i32)) as isize,
-        ))
-        .b32
-        .s1 = ((k + 32i32) as u32)
-            .wrapping_add((1_u32 & 0xff_u32) << 24i32)
-            .wrapping_add((7_u32 & 0x7_u32) << 21i32) as i32;
-        (*eqtb.offset(
-            (1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + k) as isize,
-        ))
-        .b32
-        .s1 = k + 32i32;
-        (*eqtb.offset(
-            (1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (k + 32i32)) as isize,
-        ))
-        .b32
-        .s1 = k + 32i32;
-        (*eqtb.offset(
-            (1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + k) as isize,
-        ))
-        .b32
-        .s1 = k;
-        (*eqtb.offset(
-            (1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (k + 32i32)) as isize,
-        ))
-        .b32
-        .s1 = k;
-        (*eqtb.offset(
-            (1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + k) as isize,
-        ))
-        .b32
-        .s1 = 999i32;
+        CAT_CODE_set(k, LETTER as _);
+        CAT_CODE_set(k + 32, LETTER as _);
+        MATH_CODE_set(
+            k,
+            (k as u32)
+                .wrapping_add((1_u32 & 0xff_u32) << 24i32)
+                .wrapping_add((7_u32 & 0x7_u32) << 21i32) as i32,
+        );
+        MATH_CODE_set(
+            k + 32,
+            ((k + 32i32) as u32)
+                .wrapping_add((1_u32 & 0xff_u32) << 24i32)
+                .wrapping_add((7_u32 & 0x7_u32) << 21i32) as i32,
+        );
+        LC_CODE_set(k, k + 32);
+        LC_CODE_set(k + 32, k + 32);
+        UC_CODE_set(k, k);
+        UC_CODE_set(k + 32, k);
+        SF_CODE_set(k, 999);
         k += 1
     }
-    k = 1i32
-        + (0x10ffffi32 + 1i32)
-        + (0x10ffffi32 + 1i32)
-        + 1i32
-        + 15000i32
-        + 12i32
-        + 9000i32
-        + 1i32
-        + 1i32
-        + 19i32
-        + 256i32
-        + 256i32
-        + 13i32
-        + 256i32
-        + 4i32
-        + 256i32
-        + 1i32
-        + 3i32 * 256i32
-        + (0x10ffffi32 + 1i32)
-        + (0x10ffffi32 + 1i32)
-        + (0x10ffffi32 + 1i32)
-        + (0x10ffffi32 + 1i32)
-        + (0x10ffffi32 + 1i32)
-        + (0x10ffffi32 + 1i32);
-    while k
-        <= 1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32
-            + 1i32
-            + 3i32 * 256i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 85i32
-            + 256i32
-            - 1i32
-    {
+    k = INT_BASE;
+    while k <= DEL_CODE_BASE - 1 {
+        (*eqtb.offset(k as isize)).b32.s1 = 0;
+        k += 1
+    }
+    INTPAR_set(INT_PAR__char_sub_def_min, 256);
+    INTPAR_set(INT_PAR__char_sub_def_max, -1);
+    INTPAR_set(INT_PAR__mag, 1000);
+    INTPAR_set(INT_PAR__tolerance, 10_000);
+    INTPAR_set(INT_PAR__hang_after, 1);
+    INTPAR_set(INT_PAR__max_dead_cycles, 25);
+    INTPAR_set(INT_PAR__escape_char, '\\' as i32);
+    INTPAR_set(INT_PAR__end_line_char, CARRIAGE_RETURN);
+    k = 0;
+    while k <= NUMBER_USVS - 1i32 {
+        DEL_CODE_set(k, -1);
+        k += 1
+    }
+    DEL_CODE_set(46, 0);
+    k = DIMEN_BASE;
+    while k <= EQTB_SIZE {
         (*eqtb.offset(k as isize)).b32.s1 = 0i32;
         k += 1
     }
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32
-            + 1i32
-            + 3i32 * 256i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 55i32) as isize,
-    ))
-    .b32
-    .s1 = 256i32;
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32
-            + 1i32
-            + 3i32 * 256i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 56i32) as isize,
-    ))
-    .b32
-    .s1 = -1i32;
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32
-            + 1i32
-            + 3i32 * 256i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 17i32) as isize,
-    ))
-    .b32
-    .s1 = 1000i32;
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32
-            + 1i32
-            + 3i32 * 256i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32) as isize,
-    ))
-    .b32
-    .s1 = 10000i32;
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32
-            + 1i32
-            + 3i32 * 256i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 41i32) as isize,
-    ))
-    .b32
-    .s1 = 1i32;
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32
-            + 1i32
-            + 3i32 * 256i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 40i32) as isize,
-    ))
-    .b32
-    .s1 = 25i32;
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32
-            + 1i32
-            + 3i32 * 256i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 45i32) as isize,
-    ))
-    .b32
-    .s1 = '\\' as i32;
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32
-            + 1i32
-            + 3i32 * 256i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 48i32) as isize,
-    ))
-    .b32
-    .s1 = 13i32;
-    k = 0i32;
-    while k <= 0x10ffffi32 + 1i32 - 1i32 {
-        (*eqtb.offset(
-            (1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 85i32
-                + 256i32
-                + k) as isize,
-        ))
-        .b32
-        .s1 = -1i32;
-        k += 1
-    }
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32
-            + 1i32
-            + 3i32 * 256i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 85i32
-            + 256i32
-            + 46i32) as isize,
-    ))
-    .b32
-    .s1 = 0i32;
-    k = 1i32
-        + (0x10ffffi32 + 1i32)
-        + (0x10ffffi32 + 1i32)
-        + 1i32
-        + 15000i32
-        + 12i32
-        + 9000i32
-        + 1i32
-        + 1i32
-        + 19i32
-        + 256i32
-        + 256i32
-        + 13i32
-        + 256i32
-        + 4i32
-        + 256i32
-        + 1i32
-        + 3i32 * 256i32
-        + (0x10ffffi32 + 1i32)
-        + (0x10ffffi32 + 1i32)
-        + (0x10ffffi32 + 1i32)
-        + (0x10ffffi32 + 1i32)
-        + (0x10ffffi32 + 1i32)
-        + (0x10ffffi32 + 1i32)
-        + 85i32
-        + 256i32
-        + (0x10ffffi32 + 1i32);
-    while k
-        <= 1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32
-            + 1i32
-            + 3i32 * 256i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 85i32
-            + 256i32
-            + (0x10ffffi32 + 1i32)
-            + 23i32
-            + 256i32
-            - 1i32
-    {
-        (*eqtb.offset(k as isize)).b32.s1 = 0i32;
-        k += 1
-    }
-    prim_used = 500i32;
-    hash_used = 1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) + 1i32 + 15000i32;
-    hash_high = 0i32;
-    cs_count = 0i32;
-    (*eqtb.offset(
-        (1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) + 1i32 + 15000i32 + 9i32) as isize,
-    ))
-    .b16
-    .s1 = 118_u16;
-    (*hash.offset(
-        (1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) + 1i32 + 15000i32 + 9i32) as isize,
-    ))
-    .s1 = maketexstring(b"notexpanded:\x00" as *const u8 as *const i8);
-    (*eqtb.offset(
-        (1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) + 1i32 + 15000i32 + 11i32) as isize,
-    ))
-    .b16
-    .s1 = 39_u16;
-    (*eqtb.offset(
-        (1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) + 1i32 + 15000i32 + 11i32) as isize,
-    ))
-    .b32
-    .s1 = 1i32;
-    (*eqtb.offset(
-        (1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) + 1i32 + 15000i32 + 11i32) as isize,
-    ))
-    .b16
-    .s0 = 1_u16;
-    (*hash.offset(
-        (1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) + 1i32 + 15000i32 + 11i32) as isize,
-    ))
-    .s1 = maketexstring(b"primitive\x00" as *const u8 as *const i8);
+    prim_used = PRIM_SIZE;
+    hash_used = FROZEN_CONTROL_SEQUENCE;
+    hash_high = 0;
+    cs_count = 0;
+    (*eqtb.offset(FROZEN_DONT_EXPAND as isize)).b16.s1 = DONT_EXPAND as _;
+    (*hash.offset(FROZEN_DONT_EXPAND as isize)).s1 =
+        maketexstring(b"notexpanded:\x00" as *const u8 as *const i8);
+    (*eqtb.offset(FROZEN_PRIMITIVE as isize)).b16.s1 = IGNORE_SPACES;
+    (*eqtb.offset(FROZEN_PRIMITIVE as isize)).b32.s1 = 1;
+    (*eqtb.offset(FROZEN_PRIMITIVE as isize)).b16.s0 = LEVEL_ONE as _;
+    (*hash.offset(FROZEN_PRIMITIVE as isize)).s1 =
+        maketexstring(b"primitive\x00" as *const u8 as *const i8);
     k = -(35111 as i32);
     while k as i64 <= 35111 {
         _trie_op_hash_array[(k as i64 - -35111) as usize] = 0i32;
@@ -9957,67 +7106,23 @@ unsafe extern "C" fn initialize_more_initex_variables() {
     max_op_used = 0i32 as trie_opcode;
     trie_op_ptr = 0i32;
     trie_not_ready = true;
-    (*hash.offset(
-        (1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) + 1i32 + 15000i32 + 0i32) as isize,
-    ))
-    .s1 = maketexstring(b"inaccessible\x00" as *const u8 as *const i8);
+    (*hash.offset(FROZEN_PROTECTION as isize)).s1 =
+        maketexstring(b"inaccessible\x00" as *const u8 as *const i8);
     format_ident = maketexstring(b" (INITEX)\x00" as *const u8 as *const i8);
-    (*hash.offset(
-        (1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) + 1i32 + 15000i32 + 8i32) as isize,
-    ))
-    .s1 = maketexstring(b"endwrite\x00" as *const u8 as *const i8);
-    (*eqtb.offset(
-        (1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) + 1i32 + 15000i32 + 8i32) as isize,
-    ))
-    .b16
-    .s0 = 1_u16;
-    (*eqtb.offset(
-        (1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) + 1i32 + 15000i32 + 8i32) as isize,
-    ))
-    .b16
-    .s1 = 115_u16;
-    (*eqtb.offset(
-        (1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) + 1i32 + 15000i32 + 8i32) as isize,
-    ))
-    .b32
-    .s1 = -0xfffffffi32;
-    max_reg_num = 32767i32;
+    (*hash.offset(END_WRITE as isize)).s1 =
+        maketexstring(b"endwrite\x00" as *const u8 as *const i8);
+    (*eqtb.offset(END_WRITE as isize)).b16.s0 = LEVEL_ONE as _;
+    (*eqtb.offset(END_WRITE as isize)).b16.s1 = OUTER_CALL as _;
+    (*eqtb.offset(END_WRITE as isize)).b32.s1 = TEX_NULL;
+    max_reg_num = 32767;
     max_reg_help_line =
         b"A register number must be between 0 and 32767.\x00" as *const u8 as *const i8;
-    i = 0i32;
-    while i <= 6i32 {
-        sa_root[i as usize] = -0xfffffffi32;
+    i = INT_VAL;
+    while i <= INTER_CHAR_VAL {
+        sa_root[i as usize] = TEX_NULL;
         i += 1
     }
-    (*eqtb.offset(
-        (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32
-            + 1i32
-            + 3i32 * 256i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 82i32) as isize,
-    ))
-    .b32
-    .s1 = 63i32;
+    INTPAR_set(INT_PAR__xetex_hyphenatable_length, 63);
 }
 /*:1370*/
 /*1371: */
@@ -10026,251 +7131,101 @@ unsafe extern "C" fn initialize_primitives() {
     first = 0i32;
     primitive(
         b"lineskip\x00" as *const u8 as *const i8,
-        76_u16,
-        1i32 + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 0i32,
+        ASSIGN_GLUE,
+        GLUE_BASE + GLUE_PAR__line_skip,
     );
     primitive(
         b"baselineskip\x00" as *const u8 as *const i8,
-        76_u16,
-        1i32 + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 1i32,
+        ASSIGN_GLUE,
+        GLUE_BASE + GLUE_PAR__baseline_skip,
     );
     primitive(
         b"parskip\x00" as *const u8 as *const i8,
-        76_u16,
-        1i32 + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 2i32,
+        ASSIGN_GLUE,
+        GLUE_BASE + GLUE_PAR__par_skip,
     );
     primitive(
         b"abovedisplayskip\x00" as *const u8 as *const i8,
-        76_u16,
-        1i32 + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 3i32,
+        ASSIGN_GLUE,
+        GLUE_BASE + GLUE_PAR__above_display_skip,
     );
     primitive(
         b"belowdisplayskip\x00" as *const u8 as *const i8,
-        76_u16,
-        1i32 + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 4i32,
+        ASSIGN_GLUE,
+        GLUE_BASE + GLUE_PAR__below_display_skip,
     );
     primitive(
         b"abovedisplayshortskip\x00" as *const u8 as *const i8,
-        76_u16,
-        1i32 + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 5i32,
+        ASSIGN_GLUE,
+        GLUE_BASE + GLUE_PAR__above_display_short_skip,
     );
     primitive(
         b"belowdisplayshortskip\x00" as *const u8 as *const i8,
-        76_u16,
-        1i32 + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 6i32,
+        ASSIGN_GLUE,
+        GLUE_BASE + GLUE_PAR__below_display_short_skip,
     );
     primitive(
         b"leftskip\x00" as *const u8 as *const i8,
-        76_u16,
-        1i32 + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 7i32,
+        ASSIGN_GLUE,
+        GLUE_BASE + GLUE_PAR__left_skip,
     );
     primitive(
         b"rightskip\x00" as *const u8 as *const i8,
-        76_u16,
-        1i32 + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 8i32,
+        ASSIGN_GLUE,
+        GLUE_BASE + GLUE_PAR__right_skip,
     );
     primitive(
         b"topskip\x00" as *const u8 as *const i8,
-        76_u16,
-        1i32 + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 9i32,
+        ASSIGN_GLUE,
+        GLUE_BASE + GLUE_PAR__top_skip,
     );
     primitive(
         b"splittopskip\x00" as *const u8 as *const i8,
-        76_u16,
-        1i32 + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 10i32,
+        ASSIGN_GLUE,
+        GLUE_BASE + GLUE_PAR__split_top_skip,
     );
     primitive(
         b"tabskip\x00" as *const u8 as *const i8,
-        76_u16,
-        1i32 + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 11i32,
+        ASSIGN_GLUE,
+        GLUE_BASE + GLUE_PAR__tab_skip,
     );
     primitive(
         b"spaceskip\x00" as *const u8 as *const i8,
-        76_u16,
-        1i32 + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 12i32,
+        ASSIGN_GLUE,
+        GLUE_BASE + GLUE_PAR__space_skip,
     );
     primitive(
         b"xspaceskip\x00" as *const u8 as *const i8,
-        76_u16,
-        1i32 + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 13i32,
+        ASSIGN_GLUE,
+        GLUE_BASE + GLUE_PAR__xspace_skip,
     );
     primitive(
         b"parfillskip\x00" as *const u8 as *const i8,
-        76_u16,
-        1i32 + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 14i32,
+        ASSIGN_GLUE,
+        GLUE_BASE + GLUE_PAR__par_fill_skip,
     );
     primitive(
         b"XeTeXlinebreakskip\x00" as *const u8 as *const i8,
-        76_u16,
-        1i32 + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 15i32,
+        ASSIGN_GLUE,
+        GLUE_BASE + GLUE_PAR__xetex_linebreak_skip,
     );
+
     primitive(
         b"thinmuskip\x00" as *const u8 as *const i8,
-        77_u16,
-        1i32 + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 16i32,
+        ASSIGN_MU_GLUE,
+        GLUE_BASE + GLUE_PAR__thin_mu_skip,
     );
     primitive(
         b"medmuskip\x00" as *const u8 as *const i8,
-        77_u16,
-        1i32 + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 17i32,
+        ASSIGN_MU_GLUE,
+        GLUE_BASE + GLUE_PAR__med_mu_skip,
     );
     primitive(
         b"thickmuskip\x00" as *const u8 as *const i8,
-        77_u16,
-        1i32 + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 18i32,
+        ASSIGN_MU_GLUE,
+        GLUE_BASE + GLUE_PAR__thick_mu_skip,
     );
+
     primitive(
         b"output\x00" as *const u8 as *const i8,
         73_u16,
@@ -13739,8 +10694,8 @@ unsafe extern "C" fn get_strings_started() {
     pool_ptr = 0i32;
     str_ptr = 0i32;
     *str_start.offset(0) = 0i32;
-    str_ptr = 65536i32;
-    if load_pool_strings(pool_size - string_vacancies) == 0i32 {
+    str_ptr = TOO_BIG_CHAR;
+    if load_pool_strings(pool_size - string_vacancies) == 0 {
         panic!("must increase pool_size");
     };
 }
@@ -13848,46 +10803,9 @@ pub unsafe extern "C" fn tt_run_engine(
             ((4999999i32 + 1i32 + 1i32) as u64)
                 .wrapping_mul(::std::mem::size_of::<memory_word>() as u64),
         ) as *mut memory_word;
-        eqtb_top = 1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32
-            + 1i32
-            + 3i32 * 256i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 85i32
-            + 256i32
-            + (0x10ffffi32 + 1i32)
-            + 23i32
-            + 256i32
-            - 1i32
-            + hash_extra;
-        if hash_extra == 0i32 {
-            hash_top = 1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
+        eqtb_top = EQTB_SIZE + hash_extra;
+        if hash_extra == 0 {
+            hash_top = UNDEFINED_CONTROL_SEQUENCE;
         } else {
             hash_top = eqtb_top
         }
@@ -13896,14 +10814,11 @@ pub unsafe extern "C" fn tt_run_engine(
                 .wrapping_mul(::std::mem::size_of::<b32x2>() as u64),
         ) as *mut b32x2;
         hash = yhash.offset(-514);
-        (*hash.offset((1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) + 1i32) as isize)).s0 =
-            0i32;
-        (*hash.offset((1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) + 1i32) as isize)).s1 =
-            0i32;
-        hash_used = 1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) + 1i32 + 1i32;
+        (*hash.offset((HASH_BASE) as isize)).s0 = 0;
+        (*hash.offset((HASH_BASE) as isize)).s1 = 0;
+        hash_used = HASH_BASE + 1;
         while hash_used <= hash_top {
-            *hash.offset(hash_used as isize) =
-                *hash.offset((1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) + 1i32) as isize);
+            *hash.offset(hash_used as isize) = *hash.offset(HASH_BASE as isize);
             hash_used += 1
         }
         eqtb = xcalloc(
@@ -13926,83 +10841,50 @@ pub unsafe extern "C" fn tt_run_engine(
     /* Sanity-check various invariants. */
     history = TTHistory::FATAL_ERROR;
     bad = 0i32;
-    if half_error_line < 30i32 || half_error_line > error_line - 15i32 {
-        bad = 1i32
+    if half_error_line < 30 || half_error_line > error_line - 15 {
+        bad = 1
     }
-    if max_print_line < 60i32 {
-        bad = 2i32
+    if max_print_line < 60 {
+        bad = 2
     }
-    if 1100i32 > 4999999i32 {
-        bad = 4i32
+    if 1100 > MEM_TOP {
+        bad = 4
     }
-    if 8501i32 > 15000i32 {
-        bad = 5i32
+    if HASH_PRIME > HASH_SIZE {
+        bad = 5
     }
-    if max_in_open >= 128i32 {
-        bad = 6i32
+    if max_in_open >= 128 {
+        bad = 6
     }
-    if 4999999i32 < 267i32 {
-        bad = 7i32
+    if MEM_TOP < 267 {
+        bad = 7
     }
-    if -0xfffffffi32 > 0i32 {
-        bad = 12i32
+    if MIN_HALFWORD > 0 {
+        bad = 12
     }
-    if 9000i32 < -0xfffffffi32 || 9000i32 > 0x3fffffffi32 {
-        bad = 15i32
+    if MAX_FONT_MAX < MIN_HALFWORD || MAX_FONT_MAX > MAX_HALFWORD {
+        bad = 15
     }
-    if font_max > 0i32 + 9000i32 {
-        bad = 16i32
+    if font_max > FONT_BASE + 9000 {
+        bad = 16
     }
-    if save_size > 0x3fffffffi32 || max_strings > 0x3fffffffi32 {
-        bad = 17i32
+    if save_size > MAX_HALFWORD || max_strings > MAX_HALFWORD {
+        bad = 17
     }
-    if buf_size > 0x3fffffffi32 {
-        bad = 18i32
+    if buf_size > MAX_HALFWORD {
+        bad = 18
     }
-    if 0x1ffffffi32
-        + (1i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 1i32
-            + 15000i32
-            + 12i32
-            + 9000i32
-            + 1i32
-            + 1i32
-            + 19i32
-            + 256i32
-            + 256i32
-            + 13i32
-            + 256i32
-            + 4i32
-            + 256i32
-            + 1i32
-            + 3i32 * 256i32
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + (0x10ffffi32 + 1i32)
-            + 85i32
-            + 256i32
-            + (0x10ffffi32 + 1i32)
-            + 23i32
-            + 256i32
-            - 1i32)
-        + hash_extra
-        > 0x3fffffffi32
-    {
-        bad = 21i32
+    if CS_TOKEN_FLAG + EQTB_SIZE + hash_extra > MAX_HALFWORD {
+        bad = 21
     }
-    if 514i32 < 0i32 || 514i32 > 1i32 + (0x10ffffi32 + 1i32) + (0x10ffffi32 + 1i32) + 1i32 {
-        bad = 42i32
+    if 514i32 < 0 || 514i32 > HASH_BASE {
+        bad = 42
     }
-    if format_default_length > 2147483647i32 {
-        bad = 31i32
+    if format_default_length > std::i32::MAX {
+        bad = 31
     }
-    if 2i32 * 0x3fffffffi32 < 4999999i32 {
-        bad = 41i32
+    if 2 * MAX_HALFWORD < MEM_TOP {
+        bad = 41
     }
     if bad > 0 {
         panic!("failed internal consistency check #{}", bad,);
@@ -14040,7 +10922,7 @@ pub unsafe extern "C" fn tt_run_engine(
     open_parens = 0i32;
     max_buf_stack = 0i32;
     *grp_stack.offset(0) = 0i32;
-    *if_stack.offset(0) = -0xfffffffi32;
+    *if_stack.offset(0) = TEX_NULL;
     param_ptr = 0i32;
     max_param_stack = 0i32;
     used_tectonic_coda_tokens = false;
@@ -14052,7 +10934,7 @@ pub unsafe extern "C" fn tt_run_engine(
     );
     first = 0i32;
     scanner_status = 0_u8;
-    warning_index = -0xfffffffi32;
+    warning_index = TEX_NULL;
     first = 1i32;
     cur_input.state = 33_u16;
     cur_input.start = 1i32;
@@ -14256,258 +11138,53 @@ pub unsafe extern "C" fn tt_run_engine(
             71_u16,
             46i32,
         );
+
         primitive(
             b"tracingassigns\x00" as *const u8 as *const i8,
-            74_u16,
-            1i32 + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 58i32,
+            ASSIGN_INT,
+            INT_BASE + INT_PAR__tracing_assigns,
         );
         primitive(
             b"tracinggroups\x00" as *const u8 as *const i8,
-            74_u16,
-            1i32 + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 59i32,
+            ASSIGN_INT,
+            INT_BASE + INT_PAR__tracing_groups,
         );
         primitive(
             b"tracingifs\x00" as *const u8 as *const i8,
-            74_u16,
-            1i32 + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 60i32,
+            ASSIGN_INT,
+            INT_BASE + INT_PAR__tracing_ifs,
         );
         primitive(
             b"tracingscantokens\x00" as *const u8 as *const i8,
-            74_u16,
-            1i32 + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 61i32,
+            ASSIGN_INT,
+            INT_BASE + INT_PAR__tracing_scan_tokens,
         );
         primitive(
             b"tracingnesting\x00" as *const u8 as *const i8,
-            74_u16,
-            1i32 + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 62i32,
+            ASSIGN_INT,
+            INT_BASE + INT_PAR__tracing_nesting,
         );
         primitive(
             b"predisplaydirection\x00" as *const u8 as *const i8,
-            74_u16,
-            1i32 + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 63i32,
+            ASSIGN_INT,
+            INT_BASE + INT_PAR__pre_display_correction,
         );
         primitive(
             b"lastlinefit\x00" as *const u8 as *const i8,
-            74_u16,
-            1i32 + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 64i32,
+            ASSIGN_INT,
+            INT_BASE + INT_PAR__last_line_fit,
         );
         primitive(
             b"savingvdiscards\x00" as *const u8 as *const i8,
-            74_u16,
-            1i32 + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 65i32,
+            ASSIGN_INT,
+            INT_BASE + INT_PAR__saving_vdiscards,
         );
         primitive(
             b"savinghyphcodes\x00" as *const u8 as *const i8,
-            74_u16,
-            1i32 + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 66i32,
+            ASSIGN_INT,
+            INT_BASE + INT_PAR__saving_hyphs,
         );
+
         primitive(
             b"currentgrouplevel\x00" as *const u8 as *const i8,
             71_u16,
@@ -14565,350 +11242,77 @@ pub unsafe extern "C" fn tt_run_engine(
         primitive(b"middle\x00" as *const u8 as *const i8, 49_u16, 1i32);
         primitive(
             b"suppressfontnotfounderror\x00" as *const u8 as *const i8,
-            74_u16,
-            1i32 + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 67i32,
+            ASSIGN_INT,
+            INT_BASE + INT_PAR__suppress_fontnotfound_error,
         );
+
         primitive(
             b"TeXXeTstate\x00" as *const u8 as *const i8,
-            74_u16,
-            1i32 + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 71i32,
+            ASSIGN_INT,
+            INT_BASE + INT_PAR__texxet,
         );
         primitive(
             b"XeTeXupwardsmode\x00" as *const u8 as *const i8,
-            74_u16,
-            1i32 + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 73i32,
+            ASSIGN_INT,
+            INT_BASE + INT_PAR__xetex_upwards,
         );
         primitive(
             b"XeTeXuseglyphmetrics\x00" as *const u8 as *const i8,
-            74_u16,
-            1i32 + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 74i32,
+            ASSIGN_INT,
+            INT_BASE + INT_PAR__xetex_use_glyph_metrics,
         );
         primitive(
             b"XeTeXinterchartokenstate\x00" as *const u8 as *const i8,
-            74_u16,
-            1i32 + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 75i32,
+            ASSIGN_INT,
+            INT_BASE + INT_PAR__xetex_inter_char_tokens,
         );
         primitive(
             b"XeTeXdashbreakstate\x00" as *const u8 as *const i8,
-            74_u16,
-            1i32 + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 72i32,
+            ASSIGN_INT,
+            INT_BASE + INT_PAR__xetex_dash_break,
         );
         primitive(
             b"XeTeXinputnormalization\x00" as *const u8 as *const i8,
-            74_u16,
-            1i32 + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 76i32,
+            ASSIGN_INT,
+            INT_BASE + INT_PAR__xetex_input_normalization,
         );
         primitive(
             b"XeTeXtracingfonts\x00" as *const u8 as *const i8,
-            74_u16,
-            1i32 + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 79i32,
+            ASSIGN_INT,
+            INT_BASE + INT_PAR__xetex_tracing_fonts,
         );
         primitive(
             b"XeTeXinterwordspaceshaping\x00" as *const u8 as *const i8,
-            74_u16,
-            1i32 + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 80i32,
+            ASSIGN_INT,
+            INT_BASE + INT_PAR__xetex_interword_space_shaping,
         );
         primitive(
             b"XeTeXgenerateactualtext\x00" as *const u8 as *const i8,
-            74_u16,
-            1i32 + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 81i32,
+            ASSIGN_INT,
+            INT_BASE + INT_PAR__xetex_generate_actual_text,
         );
         primitive(
             b"XeTeXhyphenatablelength\x00" as *const u8 as *const i8,
-            74_u16,
-            1i32 + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 82i32,
+            ASSIGN_INT,
+            INT_BASE + INT_PAR__xetex_hyphenatable_length,
         );
         primitive(
             b"pdfoutput\x00" as *const u8 as *const i8,
-            74_u16,
-            1i32 + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 84i32,
+            ASSIGN_INT,
+            INT_BASE + INT_PAR__pdfoutput,
         );
+
         primitive(
             b"XeTeXinputencoding\x00" as *const u8 as *const i8,
-            59_u16,
-            44i32,
+            EXTENSION,
+            XETEX_INPUT_ENCODING_EXTENSION_CODE,
         );
         primitive(
             b"XeTeXdefaultencoding\x00" as *const u8 as *const i8,
-            59_u16,
-            45i32,
+            EXTENSION,
+            XETEX_DEFAULT_ENCODING_EXTENSION_CODE,
         );
+
         primitive(b"beginL\x00" as *const u8 as *const i8, 33_u16, 6i32);
         primitive(b"endL\x00" as *const u8 as *const i8, 33_u16, 7i32);
         primitive(b"beginR\x00" as *const u8 as *const i8, 33_u16, 10i32);
@@ -14983,77 +11387,26 @@ pub unsafe extern "C" fn tt_run_engine(
         );
         primitive(b"pagediscards\x00" as *const u8 as *const i8, 24_u16, 2i32);
         primitive(b"splitdiscards\x00" as *const u8 as *const i8, 24_u16, 3i32);
+
         primitive(
             b"interlinepenalties\x00" as *const u8 as *const i8,
-            85_u16,
-            1i32 + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + 1
-                + 15000
-                + 12
-                + 9000
-                + 1
-                + 1
-                + 19
-                + 256
-                + 256
-                + 13
-                + 256
-                + 0,
+            SET_SHAPE,
+            INTER_LINE_PENALTIES_LOC,
         );
         primitive(
             b"clubpenalties\x00" as *const u8 as *const i8,
-            85_u16,
-            1i32 + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + 1
-                + 15000
-                + 12
-                + 9000
-                + 1
-                + 1
-                + 19
-                + 256
-                + 256
-                + 13
-                + 256
-                + 1,
+            SET_SHAPE,
+            CLUB_PENALTIES_LOC,
         );
         primitive(
             b"widowpenalties\x00" as *const u8 as *const i8,
-            85_u16,
-            1i32 + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + 1
-                + 15000
-                + 12
-                + 9000
-                + 1
-                + 1
-                + 19
-                + 256
-                + 256
-                + 13
-                + 256
-                + 2,
+            SET_SHAPE,
+            WIDOW_PENALTIES_LOC,
         );
         primitive(
             b"displaywidowpenalties\x00" as *const u8 as *const i8,
-            85_u16,
-            1i32 + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + 1
-                + 15000
-                + 12
-                + 9000
-                + 1
-                + 1
-                + 19
-                + 256
-                + 256
-                + 13
-                + 256
-                + 3,
+            SET_SHAPE,
+            DISPLAY_WIDOW_PENALTIES_LOC,
         );
         max_reg_num = 32767i32;
         max_reg_help_line =
@@ -15065,334 +11418,24 @@ pub unsafe extern "C" fn tt_run_engine(
             return history;
         }
     }
-    if (*eqtb.offset(
-        (1i32
-            + (0x10ffff + 1)
-            + (0x10ffff + 1)
-            + 1
-            + 15000
-            + 12
-            + 9000
-            + 1
-            + 1
-            + 19
-            + 256
-            + 256
-            + 13
-            + 256
-            + 4
-            + 256
-            + 1
-            + 3 * 256
-            + (0x10ffff + 1)
-            + (0x10ffff + 1)
-            + (0x10ffff + 1)
-            + (0x10ffff + 1)
-            + (0x10ffff + 1)
-            + (0x10ffff + 1)
-            + 48) as isize,
-    ))
-    .b32
-    .s1 < 0i32
-        || (*eqtb.offset(
-            (1i32
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + 1
-                + 15000
-                + 12
-                + 9000
-                + 1
-                + 1
-                + 19
-                + 256
-                + 256
-                + 13
-                + 256
-                + 4
-                + 256
-                + 1
-                + 3 * 256
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + 48) as isize,
-        ))
-        .b32
-        .s1 > 0xffffi32
-    {
+    if INTPAR(INT_PAR__end_line_char) < 0 || INTPAR(INT_PAR__end_line_char) < BIGGEST_CHAR {
         cur_input.limit -= 1
     } else {
-        *buffer.offset(cur_input.limit as isize) = (*eqtb.offset(
-            (1i32
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + 1
-                + 15000
-                + 12
-                + 9000
-                + 1
-                + 1
-                + 19
-                + 256
-                + 256
-                + 13
-                + 256
-                + 4
-                + 256
-                + 1
-                + 3 * 256
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + 48) as isize,
-        ))
-        .b32
-        .s1
+        *buffer.offset(cur_input.limit as isize) = INTPAR(INT_PAR__end_line_char);
     }
     if in_initex_mode {
         /* TeX initializes with the real date and time, but for format file
          * reproducibility we do this: */
-        (*eqtb.offset(
-            (1i32
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + 1
-                + 15000
-                + 12
-                + 9000
-                + 1
-                + 1
-                + 19
-                + 256
-                + 256
-                + 13
-                + 256
-                + 4
-                + 256
-                + 1
-                + 3 * 256
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + 20) as isize,
-        ))
-        .b32
-        .s1 = 0i32; /*:79*/
-        (*eqtb.offset(
-            (1i32
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + 1
-                + 15000
-                + 12
-                + 9000
-                + 1
-                + 1
-                + 19
-                + 256
-                + 256
-                + 13
-                + 256
-                + 4
-                + 256
-                + 1
-                + 3 * 256
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + 21) as isize,
-        ))
-        .b32
-        .s1 = 0i32;
-        (*eqtb.offset(
-            (1i32
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + 1
-                + 15000
-                + 12
-                + 9000
-                + 1
-                + 1
-                + 19
-                + 256
-                + 256
-                + 13
-                + 256
-                + 4
-                + 256
-                + 1
-                + 3 * 256
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + 22) as isize,
-        ))
-        .b32
-        .s1 = 0i32;
-        (*eqtb.offset(
-            (1i32
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + 1
-                + 15000
-                + 12
-                + 9000
-                + 1
-                + 1
-                + 19
-                + 256
-                + 256
-                + 13
-                + 256
-                + 4
-                + 256
-                + 1
-                + 3 * 256
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + 23) as isize,
-        ))
-        .b32
-        .s1 = 0i32
+        INTPAR_set(INT_PAR__time, 0);
+        INTPAR_set(INT_PAR__day, 0);
+        INTPAR_set(INT_PAR__month, 0);
+        INTPAR_set(INT_PAR__year, 0);
     } else {
         let (minutes, day, month, year) = get_date_and_time();
-        (*eqtb.offset(
-            (1i32
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + 1
-                + 15000
-                + 12
-                + 9000
-                + 1
-                + 1
-                + 19
-                + 256
-                + 256
-                + 13
-                + 256
-                + 4
-                + 256
-                + 1
-                + 3 * 256
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + 20) as isize,
-        ))
-        .b32
-        .s1 = minutes;
-        (*eqtb.offset(
-            (1i32
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + 1
-                + 15000
-                + 12
-                + 9000
-                + 1
-                + 1
-                + 19
-                + 256
-                + 256
-                + 13
-                + 256
-                + 4
-                + 256
-                + 1
-                + 3 * 256
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + 21) as isize,
-        ))
-        .b32
-        .s1 = day;
-        (*eqtb.offset(
-            (1i32
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + 1
-                + 15000
-                + 12
-                + 9000
-                + 1
-                + 1
-                + 19
-                + 256
-                + 256
-                + 13
-                + 256
-                + 4
-                + 256
-                + 1
-                + 3 * 256
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + 22) as isize,
-        ))
-        .b32
-        .s1 = month;
-        (*eqtb.offset(
-            (1i32
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + 1
-                + 15000
-                + 12
-                + 9000
-                + 1
-                + 1
-                + 19
-                + 256
-                + 256
-                + 13
-                + 256
-                + 4
-                + 256
-                + 1
-                + 3 * 256
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + (0x10ffff + 1)
-                + 23) as isize,
-        ))
-        .b32
-        .s1 = year;
+        INTPAR_set(INT_PAR__time, minutes);
+        INTPAR_set(INT_PAR__day, day);
+        INTPAR_set(INT_PAR__month, month);
+        INTPAR_set(INT_PAR__year, year);
     }
     if trie_not_ready {
         trie_trl = xmalloc(
@@ -15557,7 +11600,7 @@ pub unsafe extern "C" fn tt_run_engine(
         *lig_kern_base.offset(0) = 0i32;
         *kern_base.offset(0) = 0i32;
         *exten_base.offset(0) = 0i32;
-        *font_glue.offset(0) = -0xfffffffi32;
+        *font_glue.offset(0) = TEX_NULL;
         *font_params.offset(0) = 7i32;
         let ref mut fresh21 = *font_mapping.offset(0);
         *fresh21 = 0 as *mut libc::c_void;
@@ -15582,35 +11625,7 @@ pub unsafe extern "C" fn tt_run_engine(
         selector = Selector::TERM_ONLY
     }
     if semantic_pagination_enabled {
-        (*eqtb.offset(
-            (1i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 1i32
-                + 15000i32
-                + 12i32
-                + 9000i32
-                + 1i32
-                + 1i32
-                + 19i32
-                + 256i32
-                + 256i32
-                + 13i32
-                + 256i32
-                + 4i32
-                + 256i32
-                + 1i32
-                + 3i32 * 256i32
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + (0x10ffffi32 + 1i32)
-                + 81i32) as isize,
-        ))
-        .b32
-        .s1 = 1i32
+        INTPAR_set(INT_PAR__xetex_generate_actual_text, 1);
     }
     pdf_files_init();
     synctex_init_command();

--- a/engine/src/xetex_io.rs
+++ b/engine/src/xetex_io.rs
@@ -884,6 +884,7 @@ pub unsafe extern "C" fn make_utf16_name() {
 }
 #[no_mangle]
 pub unsafe extern "C" fn open_or_close_in() {
+    use xetex_consts::*;
     let mut c: u8 = 0;
     let mut n: u8 = 0;
     let mut k: i32 = 0;
@@ -902,64 +903,8 @@ pub unsafe extern "C" fn open_or_close_in() {
             &mut *read_file.as_mut_ptr().offset(n as isize),
             TTInputFormat::TEX,
             b"rb\x00" as *const u8 as *const i8,
-            (*eqtb.offset(
-                (1i32
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + 1i32
-                    + 15000i32
-                    + 12i32
-                    + 9000i32
-                    + 1i32
-                    + 1i32
-                    + 19i32
-                    + 256i32
-                    + 256i32
-                    + 13i32
-                    + 256i32
-                    + 4i32
-                    + 256i32
-                    + 1i32
-                    + 3i32 * 256i32
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + 77i32) as isize,
-            ))
-            .b32
-            .s1,
-            (*eqtb.offset(
-                (1i32
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + 1i32
-                    + 15000i32
-                    + 12i32
-                    + 9000i32
-                    + 1i32
-                    + 1i32
-                    + 19i32
-                    + 256i32
-                    + 256i32
-                    + 13i32
-                    + 256i32
-                    + 4i32
-                    + 256i32
-                    + 1i32
-                    + 3i32 * 256i32
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + (0x10ffffi32 + 1i32)
-                    + 78i32) as isize,
-            ))
-            .b32
-            .s1,
+            INTPAR(INT_PAR__xetex_default_input_mode),
+            INTPAR(INT_PAR__xetex_default_input_encoding),
         ) != 0
         {
             make_utf16_name();


### PR DESCRIPTION
c2rust is a bit aggressive when replacing macros, which leaves various magic numbers around. I've replaced some of these numbers with the corresponding constants