### PR TITLE
change unsafe ffi to safe rust function

### DIFF
--- a/engine/src/xetex_aatfont.rs
+++ b/engine/src/xetex_aatfont.rs
@@ -469,7 +469,7 @@ pub unsafe fn do_aat_layout(mut p: *mut libc::c_void, mut justify: libc::c_int) 
     let mut line: CTLineRef = ptr::null_mut();
     let mut node: *mut memory_word = p as *mut memory_word;
     let mut f: libc::c_uint = (*node.offset(4)).b16.s2 as libc::c_uint;
-    if *font_area.offset(f as isize) as libc::c_uint != 0xffffu32 {
+    if font_area[f as usize] as u32 != 0xffffu32 {
         panic!("do_aat_layout called for non-AAT font");
     }
     txtLen = (*node.offset(4)).b16.s1 as libc::c_long;

--- a/engine/src/xetex_ext.rs
+++ b/engine/src/xetex_ext.rs
@@ -174,7 +174,7 @@ pub unsafe extern "C" fn linebreak_start(
 ) {
     let mut status: icu::UErrorCode = icu::U_ZERO_ERROR;
     let mut locale: *mut i8 = gettexstring(localeStrNum);
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32
+    if font_area[f as usize] as u32 == 0xfffeu32
         && streq_ptr(locale, b"G\x00" as *const u8 as *const i8) as i32 != 0
     {
         let mut engine: XeTeXLayoutEngine =
@@ -1508,7 +1508,7 @@ pub unsafe extern "C" fn make_font_def(mut f: i32) -> i32 {
     let mut extend: f32 = 1.0f64 as f32;
     let mut slant: f32 = 0.0f64 as f32;
     let mut embolden: f32 = 0.0f64 as f32;
-    match *font_area.offset(f as isize) as u32 {
+    match font_area[f as usize] as u32 {
         #[cfg(target_os = "macos")]
         0xffffu32 => {
             let mut attributes: CFDictionaryRef = 0 as CFDictionaryRef;
@@ -1723,7 +1723,7 @@ pub unsafe extern "C" fn get_native_char_height_depth(
     let mut ht: f32 = 0.0f64 as f32;
     let mut dp: f32 = 0.0f64 as f32;
     let mut fuzz: Fixed = 0;
-    match *font_area.offset(font as isize) as u32 {
+    match font_area[font as usize] as u32 {
         #[cfg(target_os = "macos")]
         0xffffu32 => {
             let mut attributes: CFDictionaryRef =
@@ -1788,7 +1788,7 @@ pub unsafe extern "C" fn get_native_char_sidebearings(
 ) {
     let mut l: f32 = 0.;
     let mut r: f32 = 0.;
-    match *font_area.offset(font as isize) as u32 {
+    match font_area[font as usize] as u32 {
         #[cfg(target_os = "macos")]
         0xffffu32 => {
             let mut attributes: CFDictionaryRef =
@@ -1814,7 +1814,7 @@ pub unsafe extern "C" fn get_glyph_bounds(mut font: i32, mut edge: i32, mut gid:
     /* edge codes 1,2,3,4 => L T R B */
     let mut a: f32 = 0.;
     let mut b: f32 = 0.;
-    match *font_area.offset(font as isize) as u32 {
+    match font_area[font as usize] as u32 {
         #[cfg(target_os = "macos")]
         0xffffu32 => {
             let mut attributes: CFDictionaryRef =
@@ -1855,7 +1855,7 @@ pub unsafe extern "C" fn getnativecharic(mut f: i32, mut c: i32) -> scaled_t {
 #[no_mangle]
 pub unsafe extern "C" fn getnativecharwd(mut f: i32, mut c: i32) -> scaled_t {
     let mut wd: scaled_t = 0i32;
-    match *font_area.offset(f as isize) as u32 {
+    match font_area[f as usize] as u32 {
         #[cfg(target_os = "macos")]
         0xffffu32 => {
             let mut attributes: CFDictionaryRef =
@@ -1894,7 +1894,7 @@ pub unsafe extern "C" fn real_get_native_glyph(
 pub unsafe extern "C" fn store_justified_native_glyphs(mut pNode: *mut libc::c_void) {
     let mut node: *mut memory_word = pNode as *mut memory_word;
     let mut f: u32 = (*node.offset(4)).b16.s2 as u32;
-    match *font_area.offset(f as isize) as u32 {
+    match font_area[f as usize] as u32 {
         #[cfg(target_os = "macos")]
         0xffffu32 => {
             /* separate Mac-only codepath for AAT fonts */
@@ -1961,7 +1961,7 @@ pub unsafe extern "C" fn measure_native_node(
     let mut txtLen: i32 = (*node.offset(4)).b16.s1 as i32;
     let mut txtPtr: *mut u16 = node.offset(6) as *mut u16;
     let mut f: u32 = (*node.offset(4)).b16.s2 as u32;
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32 {
+    if font_area[f as usize] as u32 == 0xfffeu32 {
         /* using this font in OT Layout mode, so font_layout_engine[f] is actually a XeTeXLayoutEngine */
         let mut engine: XeTeXLayoutEngine =
             *font_layout_engine.offset(f as isize) as XeTeXLayoutEngine;
@@ -2178,7 +2178,7 @@ pub unsafe extern "C" fn measure_native_node(
                 yMax: 0.,
             };
             if getCachedGlyphBBox(f as u16, *glyphIDs_0.offset(i_2 as isize), &mut bbox) == 0i32 {
-                match *font_area.offset(f as isize) as u32 {
+                match font_area[f as usize] as u32 {
                     #[cfg(target_os = "macos")]
                     0xffffu32 => {
                         aat::GetGlyphBBox_AAT(
@@ -2220,7 +2220,7 @@ pub unsafe extern "C" fn real_get_native_italic_correction(mut pNode: *mut libc:
     if n > 0_u32 {
         let mut locations: *mut FixedPoint = (*node.offset(5)).ptr as *mut FixedPoint;
         let mut glyphIDs: *mut u16 = locations.offset(n as isize) as *mut u16;
-        match *font_area.offset(f as isize) as u32 {
+        match font_area[f as usize] as u32 {
             #[cfg(target_os = "macos")]
             0xffffu32 => {
                 return D2Fix(aat::GetGlyphItalCorr_AAT(
@@ -2248,7 +2248,7 @@ pub unsafe extern "C" fn real_get_native_glyph_italic_correction(
     let mut node: *mut memory_word = pNode as *mut memory_word;
     let mut gid: u16 = (*node.offset(4)).b16.s1;
     let mut f: u32 = (*node.offset(4)).b16.s2 as u32;
-    match *font_area.offset(f as isize) as u32 {
+    match font_area[f as usize] as u32 {
         #[cfg(target_os = "macos")]
         0xffffu32 => {
             return D2Fix(aat::GetGlyphItalCorr_AAT(
@@ -2278,7 +2278,7 @@ pub unsafe extern "C" fn measure_native_glyph(
     let mut f: u32 = (*node.offset(4)).b16.s2 as u32;
     let mut ht: f32 = 0.0f64 as f32;
     let mut dp: f32 = 0.0f64 as f32;
-    match *font_area.offset(f as isize) as u32 {
+    match font_area[f as usize] as u32 {
         #[cfg(target_os = "macos")]
         0xffffu32 => {
             let mut attributes: CFDictionaryRef =
@@ -2314,7 +2314,7 @@ pub unsafe extern "C" fn map_char_to_glyph(mut font: i32, mut ch: i32) -> i32 {
     if ch > 0x10ffffi32 || ch >= 0xd800i32 && ch <= 0xdfffi32 {
         return 0i32;
     }
-    match *font_area.offset(font as isize) as u32 {
+    match font_area[font as usize] as u32 {
         #[cfg(target_os = "macos")]
         0xffffu32 => {
             return aat::MapCharToGlyph_AAT(
@@ -2336,7 +2336,7 @@ pub unsafe extern "C" fn map_char_to_glyph(mut font: i32, mut ch: i32) -> i32 {
 #[no_mangle]
 pub unsafe extern "C" fn map_glyph_to_index(mut font: i32) -> i32
 /* glyph name is at name_of_file */ {
-    match *font_area.offset(font as isize) as u32 {
+    match font_area[font as usize] as u32 {
         #[cfg(target_os = "macos")]
         0xffffu32 => {
             return aat::MapGlyphToIndex_AAT(
@@ -2357,7 +2357,7 @@ pub unsafe extern "C" fn map_glyph_to_index(mut font: i32) -> i32
 }
 #[no_mangle]
 pub unsafe extern "C" fn get_font_char_range(mut font: i32, mut first: i32) -> i32 {
-    match *font_area.offset(font as isize) as u32 {
+    match font_area[font as usize] as u32 {
         #[cfg(target_os = "macos")]
         0xffffu32 => {
             return aat::GetFontCharRange_AAT(
@@ -2390,7 +2390,7 @@ pub unsafe extern "C" fn Fix2D(mut f: Fixed) -> f64 {
 pub unsafe extern "C" fn print_glyph_name(mut font: i32, mut gid: i32) {
     let mut s: *const i8 = 0 as *const i8;
     let mut len: i32 = 0i32;
-    match *font_area.offset(font as isize) as u32 {
+    match font_area[font as usize] as u32 {
         #[cfg(target_os = "macos")]
         0xffffu32 => {
             s = aat::GetGlyphNameFromCTFont(aat::font_from_integer(font), gid as u16, &mut len);

--- a/engine/src/xetex_font_info.rs
+++ b/engine/src/xetex_font_info.rs
@@ -533,6 +533,7 @@ extern "C" {
         length: *mut FT_ULong,
     ) -> FT_Error;
     // TODO: NOTE: this api doesn't included in harfbuzz_sys
+    // kerning -> advences?
     #[no_mangle]
     fn hb_font_funcs_set_glyph_h_kerning_func(
         ffuncs: *mut hb_font_funcs_t,
@@ -1739,6 +1740,7 @@ pub type hb_font_get_glyph_kerning_func_t = Option<
     ) -> hb_position_t,
 >;
 pub type hb_font_get_glyph_h_kerning_func_t = hb_font_get_glyph_kerning_func_t;
+// TODO: deprecated by hb_font_get_contour_point_func_t
 pub type hb_font_get_glyph_func_t = Option<
     unsafe extern "C" fn(
         _: *mut hb_font_t,

--- a/engine/src/xetex_ini.rs
+++ b/engine/src/xetex_ini.rs
@@ -4704,7 +4704,7 @@ unsafe extern "C" fn store_fmt_file() {
         fmt_out,
     );
     do_dump(
-        font_area[0] as *mut i8,
+        &mut font_area[0] as *mut str_number as *mut i8,
         ::std::mem::size_of::<str_number>() as u64,
         (font_ptr + 1i32) as size_t,
         fmt_out,
@@ -6399,7 +6399,6 @@ unsafe extern "C" fn load_fmt_file() -> bool {
                                                                                                                                                          u64))
                                                                                                                 as
                                                                                                                 *mut str_number;
-                                                                                                        // TODO: init font_area here
 
                                                                                                         font_bc
                                                                                                             =
@@ -6835,14 +6834,14 @@ unsafe extern "C" fn load_fmt_file() -> bool {
                                                                                                                {
                                                                                                                 panic!("Item {} (={}) of .fmt array at {:x} >{}",
                                                                                                                           i_2,
-                                                                                                                          *(font_area[0]
+                                                                                                                          *(&mut font_area[0]
                                                                                                                                 as
                                                                                                                                 *mut str_number).offset(i_2
                                                                                                                                                             as
                                                                                                                                                             isize)
                                                                                                                               as
                                                                                                                               uintptr_t,
-                                                                                                                          font_area[0]
+                                                                                                                          &mut font_area[0]
                                                                                                                               as
                                                                                                                               *mut str_number
                                                                                                                               as
@@ -15454,7 +15453,6 @@ pub unsafe extern "C" fn tt_run_engine(
             (font_max + 1i32) as size_t,
             ::std::mem::size_of::<str_number>() as u64,
         ) as *mut str_number;
-        // TODO: init font_area here
         font_bc = xcalloc(
             (font_max + 1i32) as size_t,
             ::std::mem::size_of::<UTF16_code>() as u64,

--- a/engine/src/xetex_layout_engine.rs
+++ b/engine/src/xetex_layout_engine.rs
@@ -27,8 +27,6 @@ extern "C" {
     pub type XeTeXFont_rec;
     pub type XeTeXLayoutEngine_rec;
     #[no_mangle]
-    pub fn get_ot_math_constant(f: i32, n: i32) -> i32;
-    #[no_mangle]
     pub fn set_cp_code(fontNum: i32, code: u32, side: i32, value: i32);
     #[no_mangle]
     pub fn get_cp_code(fontNum: i32, code: u32, side: i32) -> i32;
@@ -43,8 +41,6 @@ extern "C" {
     #[no_mangle]
     pub fn destroy_font_manager();
     #[no_mangle]
-    pub fn get_native_mathsy_param(f: i32, n: i32) -> i32;
-    #[no_mangle]
     pub fn get_native_mathex_param(f: i32, n: i32) -> i32;
     #[no_mangle]
     pub fn get_ot_math_variant(f: i32, g: i32, v: i32, adv: *mut i32, horiz: i32) -> i32;
@@ -52,12 +48,6 @@ extern "C" {
     pub fn get_ot_assembly_ptr(f: i32, g: i32, horiz: i32) -> *mut libc::c_void;
     #[no_mangle]
     pub fn free_ot_assembly(a: *mut GlyphAssembly);
-    #[no_mangle]
-    pub fn get_ot_math_ital_corr(f: i32, g: i32) -> i32;
-    #[no_mangle]
-    pub fn get_ot_math_accent_pos(f: i32, g: i32) -> i32;
-    #[no_mangle]
-    pub fn get_ot_math_kern(f: i32, g: i32, sf: i32, sg: i32, cmd: i32, shift: i32) -> i32;
     #[no_mangle]
     pub fn ot_part_count(a: *const GlyphAssembly) -> i32;
     #[no_mangle]
@@ -70,8 +60,6 @@ extern "C" {
     pub fn ot_part_end_connector(f: i32, a: *const GlyphAssembly, i: i32) -> i32;
     #[no_mangle]
     pub fn ot_part_full_advance(f: i32, a: *const GlyphAssembly, i: i32) -> i32;
-    #[no_mangle]
-    pub fn ot_min_connector_overlap(f: i32) -> i32;
     #[no_mangle]
     pub fn getCachedGlyphBBox(fontID: u16, glyphID: u16, bbox: *mut GlyphBBox) -> i32;
     #[no_mangle]

--- a/engine/src/xetex_math.rs
+++ b/engine/src/xetex_math.rs
@@ -22,6 +22,10 @@ use crate::xetex_ini::{
 use crate::xetex_ini::{b16x4, b16x4_le_t, memory_word};
 use crate::xetex_layout_engine::*;
 use crate::xetex_linebreak::line_break;
+use crate::xetex_opentype_math::{
+    get_native_mathsy_param, get_ot_math_accent_pos, get_ot_math_constant, get_ot_math_ital_corr,
+    get_ot_math_kern, ot_min_connector_overlap,
+};
 use crate::xetex_output::{
     print, print_char, print_cstr, print_esc_cstr, print_file_line, print_int, print_nl_cstr,
     print_size,

--- a/engine/src/xetex_math.rs
+++ b/engine/src/xetex_math.rs
@@ -1979,7 +1979,7 @@ pub unsafe extern "C" fn after_math() {
         .b32
         .s1 as isize,
     ) < 22i32
-        && !(*font_area.offset(
+        && !(font_area[
             (*eqtb.offset(
                 (1i32
                     + (0x10ffffi32 + 1i32)
@@ -2001,9 +2001,7 @@ pub unsafe extern "C" fn after_math() {
                     + 2i32) as isize,
             ))
             .b32
-            .s1 as isize,
-        ) as u32
-            == 0xfffeu32
+            .s1 as usize] as u32 == 0xfffeu32
             && isOpenTypeMathFont(
                 *font_layout_engine.offset(
                     (*eqtb.offset(
@@ -2055,7 +2053,7 @@ pub unsafe extern "C" fn after_math() {
             .b32
             .s1 as isize,
         ) < 22i32
-            && !(*font_area.offset(
+            && !(font_area[
                 (*eqtb.offset(
                     (1i32
                         + (0x10ffffi32 + 1i32)
@@ -2077,9 +2075,7 @@ pub unsafe extern "C" fn after_math() {
                         + (2i32 + 256i32)) as isize,
                 ))
                 .b32
-                .s1 as isize,
-            ) as u32
-                == 0xfffeu32
+                .s1 as usize] as u32 == 0xfffeu32
                 && isOpenTypeMathFont(
                     *font_layout_engine.offset(
                         (*eqtb.offset(
@@ -2131,7 +2127,7 @@ pub unsafe extern "C" fn after_math() {
             .b32
             .s1 as isize,
         ) < 22i32
-            && !(*font_area.offset(
+            && !(font_area[
                 (*eqtb.offset(
                     (1i32
                         + (0x10ffffi32 + 1i32)
@@ -2153,9 +2149,7 @@ pub unsafe extern "C" fn after_math() {
                         + (2i32 + 2i32 * 256i32)) as isize,
                 ))
                 .b32
-                .s1 as isize,
-            ) as u32
-                == 0xfffeu32
+                .s1 as usize] as u32 == 0xfffeu32
                 && isOpenTypeMathFont(
                     *font_layout_engine.offset(
                         (*eqtb.offset(
@@ -2226,7 +2220,7 @@ pub unsafe extern "C" fn after_math() {
         .b32
         .s1 as isize,
     ) < 13i32
-        && !(*font_area.offset(
+        && !(font_area[
             (*eqtb.offset(
                 (1i32
                     + (0x10ffffi32 + 1i32)
@@ -2248,9 +2242,7 @@ pub unsafe extern "C" fn after_math() {
                     + (3i32 + 0i32)) as isize,
             ))
             .b32
-            .s1 as isize,
-        ) as u32
-            == 0xfffeu32
+            .s1 as usize] as u32 == 0xfffeu32
             && isOpenTypeMathFont(
                 *font_layout_engine.offset(
                     (*eqtb.offset(
@@ -2302,7 +2294,7 @@ pub unsafe extern "C" fn after_math() {
             .b32
             .s1 as isize,
         ) < 13i32
-            && !(*font_area.offset(
+            && !(font_area[
                 (*eqtb.offset(
                     (1i32
                         + (0x10ffffi32 + 1i32)
@@ -2324,9 +2316,7 @@ pub unsafe extern "C" fn after_math() {
                         + (3i32 + 256i32)) as isize,
                 ))
                 .b32
-                .s1 as isize,
-            ) as u32
-                == 0xfffeu32
+                .s1 as usize] as u32 == 0xfffeu32
                 && isOpenTypeMathFont(
                     *font_layout_engine.offset(
                         (*eqtb.offset(
@@ -2378,7 +2368,7 @@ pub unsafe extern "C" fn after_math() {
             .b32
             .s1 as isize,
         ) < 13i32
-            && !(*font_area.offset(
+            && !(font_area[
                 (*eqtb.offset(
                     (1i32
                         + (0x10ffffi32 + 1i32)
@@ -2400,9 +2390,7 @@ pub unsafe extern "C" fn after_math() {
                         + (3i32 + 2i32 * 256i32)) as isize,
                 ))
                 .b32
-                .s1 as isize,
-            ) as u32
-                == 0xfffeu32
+                .s1 as usize] as u32 == 0xfffeu32
                 && isOpenTypeMathFont(
                     *font_layout_engine.offset(
                         (*eqtb.offset(
@@ -2512,7 +2500,7 @@ pub unsafe extern "C" fn after_math() {
             .b32
             .s1 as isize,
         ) < 22i32
-            && !(*font_area.offset(
+            && !(font_area[
                 (*eqtb.offset(
                     (1i32
                         + (0x10ffffi32 + 1i32)
@@ -2534,9 +2522,7 @@ pub unsafe extern "C" fn after_math() {
                         + 2i32) as isize,
                 ))
                 .b32
-                .s1 as isize,
-            ) as u32
-                == 0xfffeu32
+                .s1 as usize] as u32 == 0xfffeu32
                 && isOpenTypeMathFont(
                     *font_layout_engine.offset(
                         (*eqtb.offset(
@@ -2588,7 +2574,7 @@ pub unsafe extern "C" fn after_math() {
                 .b32
                 .s1 as isize,
             ) < 22i32
-                && !(*font_area.offset(
+                && !(font_area[
                     (*eqtb.offset(
                         (1i32
                             + (0x10ffffi32 + 1i32)
@@ -2610,9 +2596,7 @@ pub unsafe extern "C" fn after_math() {
                             + (2i32 + 256i32)) as isize,
                     ))
                     .b32
-                    .s1 as isize,
-                ) as u32
-                    == 0xfffeu32
+                    .s1 as usize] as u32 == 0xfffeu32
                     && isOpenTypeMathFont(
                         *font_layout_engine.offset(
                             (*eqtb.offset(
@@ -2664,7 +2648,7 @@ pub unsafe extern "C" fn after_math() {
                 .b32
                 .s1 as isize,
             ) < 22i32
-                && !(*font_area.offset(
+                && !(font_area[
                     (*eqtb.offset(
                         (1i32
                             + (0x10ffffi32 + 1i32)
@@ -2686,9 +2670,7 @@ pub unsafe extern "C" fn after_math() {
                             + (2i32 + 2i32 * 256i32)) as isize,
                     ))
                     .b32
-                    .s1 as isize,
-                ) as u32
-                    == 0xfffeu32
+                    .s1 as usize] as u32 == 0xfffeu32
                     && isOpenTypeMathFont(
                         *font_layout_engine.offset(
                             (*eqtb.offset(
@@ -2760,7 +2742,7 @@ pub unsafe extern "C" fn after_math() {
             .b32
             .s1 as isize,
         ) < 13i32
-            && !(*font_area.offset(
+            && !(font_area[
                 (*eqtb.offset(
                     (1i32
                         + (0x10ffffi32 + 1i32)
@@ -2782,9 +2764,7 @@ pub unsafe extern "C" fn after_math() {
                         + (3i32 + 0i32)) as isize,
                 ))
                 .b32
-                .s1 as isize,
-            ) as u32
-                == 0xfffeu32
+                .s1 as usize] as u32 == 0xfffeu32
                 && isOpenTypeMathFont(
                     *font_layout_engine.offset(
                         (*eqtb.offset(
@@ -2836,7 +2816,7 @@ pub unsafe extern "C" fn after_math() {
                 .b32
                 .s1 as isize,
             ) < 13i32
-                && !(*font_area.offset(
+                && !(font_area[
                     (*eqtb.offset(
                         (1i32
                             + (0x10ffffi32 + 1i32)
@@ -2858,9 +2838,7 @@ pub unsafe extern "C" fn after_math() {
                             + (3i32 + 256i32)) as isize,
                     ))
                     .b32
-                    .s1 as isize,
-                ) as u32
-                    == 0xfffeu32
+                    .s1 as usize] as u32 == 0xfffeu32
                     && isOpenTypeMathFont(
                         *font_layout_engine.offset(
                             (*eqtb.offset(
@@ -2912,7 +2890,7 @@ pub unsafe extern "C" fn after_math() {
                 .b32
                 .s1 as isize,
             ) < 13i32
-                && !(*font_area.offset(
+                && !(font_area[
                     (*eqtb.offset(
                         (1i32
                             + (0x10ffffi32 + 1i32)
@@ -2934,9 +2912,7 @@ pub unsafe extern "C" fn after_math() {
                             + (3i32 + 2i32 * 256i32)) as isize,
                     ))
                     .b32
-                    .s1 as isize,
-                ) as u32
-                    == 0xfffeu32
+                    .s1 as usize] as u32 == 0xfffeu32
                     && isOpenTypeMathFont(
                         *font_layout_engine.offset(
                             (*eqtb.offset(
@@ -3598,7 +3574,7 @@ unsafe extern "C" fn math_x_height(mut size_code: i32) -> scaled_t {
     ))
     .b32
     .s1;
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32
+    if font_area[f as usize] as u32 == 0xfffeu32
         && isOpenTypeMathFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine) as i32
             != 0
     {
@@ -3635,7 +3611,7 @@ unsafe extern "C" fn math_quad(mut size_code: i32) -> scaled_t {
     ))
     .b32
     .s1;
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32
+    if font_area[f as usize] as u32 == 0xfffeu32
         && isOpenTypeMathFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine) as i32
             != 0
     {
@@ -3672,7 +3648,7 @@ unsafe extern "C" fn num1(mut size_code: i32) -> scaled_t {
     ))
     .b32
     .s1;
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32
+    if font_area[f as usize] as u32 == 0xfffeu32
         && isOpenTypeMathFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine) as i32
             != 0
     {
@@ -3709,7 +3685,7 @@ unsafe extern "C" fn num2(mut size_code: i32) -> scaled_t {
     ))
     .b32
     .s1;
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32
+    if font_area[f as usize] as u32 == 0xfffeu32
         && isOpenTypeMathFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine) as i32
             != 0
     {
@@ -3746,7 +3722,7 @@ unsafe extern "C" fn num3(mut size_code: i32) -> scaled_t {
     ))
     .b32
     .s1;
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32
+    if font_area[f as usize] as u32 == 0xfffeu32
         && isOpenTypeMathFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine) as i32
             != 0
     {
@@ -3783,7 +3759,7 @@ unsafe extern "C" fn denom1(mut size_code: i32) -> scaled_t {
     ))
     .b32
     .s1;
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32
+    if font_area[f as usize] as u32 == 0xfffeu32
         && isOpenTypeMathFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine) as i32
             != 0
     {
@@ -3820,7 +3796,7 @@ unsafe extern "C" fn denom2(mut size_code: i32) -> scaled_t {
     ))
     .b32
     .s1;
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32
+    if font_area[f as usize] as u32 == 0xfffeu32
         && isOpenTypeMathFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine) as i32
             != 0
     {
@@ -3857,7 +3833,7 @@ unsafe extern "C" fn sup1(mut size_code: i32) -> scaled_t {
     ))
     .b32
     .s1;
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32
+    if font_area[f as usize] as u32 == 0xfffeu32
         && isOpenTypeMathFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine) as i32
             != 0
     {
@@ -3894,7 +3870,7 @@ unsafe extern "C" fn sup2(mut size_code: i32) -> scaled_t {
     ))
     .b32
     .s1;
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32
+    if font_area[f as usize] as u32 == 0xfffeu32
         && isOpenTypeMathFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine) as i32
             != 0
     {
@@ -3931,7 +3907,7 @@ unsafe extern "C" fn sup3(mut size_code: i32) -> scaled_t {
     ))
     .b32
     .s1;
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32
+    if font_area[f as usize] as u32 == 0xfffeu32
         && isOpenTypeMathFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine) as i32
             != 0
     {
@@ -3968,7 +3944,7 @@ unsafe extern "C" fn sub1(mut size_code: i32) -> scaled_t {
     ))
     .b32
     .s1;
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32
+    if font_area[f as usize] as u32 == 0xfffeu32
         && isOpenTypeMathFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine) as i32
             != 0
     {
@@ -4005,7 +3981,7 @@ unsafe extern "C" fn sub2(mut size_code: i32) -> scaled_t {
     ))
     .b32
     .s1;
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32
+    if font_area[f as usize] as u32 == 0xfffeu32
         && isOpenTypeMathFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine) as i32
             != 0
     {
@@ -4042,7 +4018,7 @@ unsafe extern "C" fn sup_drop(mut size_code: i32) -> scaled_t {
     ))
     .b32
     .s1;
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32
+    if font_area[f as usize] as u32 == 0xfffeu32
         && isOpenTypeMathFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine) as i32
             != 0
     {
@@ -4079,7 +4055,7 @@ unsafe extern "C" fn sub_drop(mut size_code: i32) -> scaled_t {
     ))
     .b32
     .s1;
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32
+    if font_area[f as usize] as u32 == 0xfffeu32
         && isOpenTypeMathFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine) as i32
             != 0
     {
@@ -4116,7 +4092,7 @@ unsafe extern "C" fn delim1(mut size_code: i32) -> scaled_t {
     ))
     .b32
     .s1;
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32
+    if font_area[f as usize] as u32 == 0xfffeu32
         && isOpenTypeMathFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine) as i32
             != 0
     {
@@ -4153,7 +4129,7 @@ unsafe extern "C" fn delim2(mut size_code: i32) -> scaled_t {
     ))
     .b32
     .s1;
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32
+    if font_area[f as usize] as u32 == 0xfffeu32
         && isOpenTypeMathFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine) as i32
             != 0
     {
@@ -4190,7 +4166,7 @@ unsafe extern "C" fn axis_height(mut size_code: i32) -> scaled_t {
     ))
     .b32
     .s1;
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32
+    if font_area[f as usize] as u32 == 0xfffeu32
         && isOpenTypeMathFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine) as i32
             != 0
     {
@@ -4227,7 +4203,7 @@ unsafe extern "C" fn default_rule_thickness() -> scaled_t {
     ))
     .b32
     .s1;
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32
+    if font_area[f as usize] as u32 == 0xfffeu32
         && isOpenTypeMathFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine) as i32
             != 0
     {
@@ -4264,7 +4240,7 @@ unsafe extern "C" fn big_op_spacing1() -> scaled_t {
     ))
     .b32
     .s1;
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32
+    if font_area[f as usize] as u32 == 0xfffeu32
         && isOpenTypeMathFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine) as i32
             != 0
     {
@@ -4301,7 +4277,7 @@ unsafe extern "C" fn big_op_spacing2() -> scaled_t {
     ))
     .b32
     .s1;
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32
+    if font_area[f as usize] as u32 == 0xfffeu32
         && isOpenTypeMathFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine) as i32
             != 0
     {
@@ -4338,7 +4314,7 @@ unsafe extern "C" fn big_op_spacing3() -> scaled_t {
     ))
     .b32
     .s1;
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32
+    if font_area[f as usize] as u32 == 0xfffeu32
         && isOpenTypeMathFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine) as i32
             != 0
     {
@@ -4375,7 +4351,7 @@ unsafe extern "C" fn big_op_spacing4() -> scaled_t {
     ))
     .b32
     .s1;
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32
+    if font_area[f as usize] as u32 == 0xfffeu32
         && isOpenTypeMathFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine) as i32
             != 0
     {
@@ -4412,7 +4388,7 @@ unsafe extern "C" fn big_op_spacing5() -> scaled_t {
     ))
     .b32
     .s1;
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32
+    if font_area[f as usize] as u32 == 0xfffeu32
         && isOpenTypeMathFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine) as i32
             != 0
     {
@@ -4630,8 +4606,8 @@ unsafe extern "C" fn fetch(mut a: i32) {
         error();
         cur_i = null_character;
         (*mem.offset(a as isize)).b32.s1 = 0i32
-    } else if *font_area.offset(cur_f as isize) as u32 == 0xffffu32
-        || *font_area.offset(cur_f as isize) as u32 == 0xfffeu32
+    } else if font_area[cur_f as usize] as u32 == 0xffffu32
+        || font_area[cur_f as usize] as u32 == 0xfffeu32
     {
         cur_i = null_character
     } else {
@@ -4718,7 +4694,7 @@ unsafe extern "C" fn make_radical(mut q: i32) {
     ))
     .b32
     .s1;
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32
+    if font_area[f as usize] as u32 == 0xfffeu32
         && isOpenTypeMathFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine) as i32
             != 0
     {
@@ -4730,7 +4706,7 @@ unsafe extern "C" fn make_radical(mut q: i32) {
         q + 1i32,
         (2i32 * (cur_style as i32 / 2i32) + 1i32) as small_number,
     );
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32
+    if font_area[f as usize] as u32 == 0xfffeu32
         && isOpenTypeMathFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine) as i32
             != 0
     {
@@ -4753,7 +4729,7 @@ unsafe extern "C" fn make_radical(mut q: i32) {
             + clr
             + rule_thickness,
     );
-    if *font_area.offset(f as isize) as u32 == 0xfffeu32
+    if font_area[f as usize] as u32 == 0xfffeu32
         && isOpenTypeMathFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine) as i32
             != 0
     {
@@ -4823,8 +4799,8 @@ unsafe extern "C" fn make_math_accent(mut q: i32) {
     fetch(q + 4i32);
     x = -0xfffffffi32;
     ot_assembly_ptr = 0 as *mut libc::c_void;
-    if *font_area.offset(cur_f as isize) as u32 == 0xffffu32
-        || *font_area.offset(cur_f as isize) as u32 == 0xfffeu32
+    if font_area[cur_f as usize] as u32 == 0xffffu32
+        || font_area[cur_f as usize] as u32 == 0xfffeu32
     {
         c = cur_c;
         f = cur_f;
@@ -4908,7 +4884,7 @@ unsafe extern "C" fn make_math_accent(mut q: i32) {
     }
     /*:767*/
     if x != -0xfffffffi32 {
-        if *font_area.offset(f as isize) as u32 == 0xfffeu32
+        if font_area[f as usize] as u32 == 0xfffeu32
             && isOpenTypeMathFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine)
                 as i32
                 != 0
@@ -4953,8 +4929,8 @@ unsafe extern "C" fn make_math_accent(mut q: i32) {
             }
         }
         y = char_box(f, c);
-        if *font_area.offset(f as isize) as u32 == 0xffffu32
-            || *font_area.offset(f as isize) as u32 == 0xfffeu32
+        if font_area[f as usize] as u32 == 0xffffu32
+            || font_area[f as usize] as u32 == 0xfffeu32
         {
             p = get_node(5i32);
             (*mem.offset(p as isize)).b16.s1 = 8_u16;
@@ -5116,7 +5092,7 @@ unsafe extern "C" fn make_fraction(mut q: i32) {
     }
     if (*mem.offset((q + 1i32) as isize)).b32.s1 == 0i32 {
         /*772:*/
-        if *font_area.offset(cur_f as isize) as u32 == 0xfffeu32
+        if font_area[cur_f as usize] as u32 == 0xfffeu32
             && isOpenTypeMathFont(*font_layout_engine.offset(cur_f as isize) as XeTeXLayoutEngine)
                 as i32
                 != 0
@@ -5141,7 +5117,7 @@ unsafe extern "C" fn make_fraction(mut q: i32) {
             shift_down = shift_down + delta
         }
     } else {
-        if *font_area.offset(cur_f as isize) as u32 == 0xfffeu32
+        if font_area[cur_f as usize] as u32 == 0xfffeu32
             && isOpenTypeMathFont(*font_layout_engine.offset(cur_f as isize) as XeTeXLayoutEngine)
                 as i32
                 != 0
@@ -5259,7 +5235,7 @@ unsafe extern "C" fn make_op(mut q: i32) -> scaled_t {
     ot_assembly_ptr = 0 as *mut libc::c_void;
     if (*mem.offset((q + 1i32) as isize)).b32.s1 == 1i32 {
         fetch(q + 1i32);
-        if !(*font_area.offset(cur_f as isize) as u32 == 0xfffeu32
+        if !(font_area[cur_f as usize] as u32 == 0xfffeu32
             && usingOpenType(*font_layout_engine.offset(cur_f as isize) as XeTeXLayoutEngine)
                 as i32
                 != 0)
@@ -5280,7 +5256,7 @@ unsafe extern "C" fn make_op(mut q: i32) -> scaled_t {
             .s1
         }
         x = clean_box(q + 1i32, cur_style);
-        if *font_area.offset(cur_f as isize) as u32 == 0xfffeu32
+        if font_area[cur_f as usize] as u32 == 0xfffeu32
             && isOpenTypeMathFont(*font_layout_engine.offset(cur_f as isize) as XeTeXLayoutEngine)
                 as i32
                 != 0
@@ -5645,7 +5621,7 @@ unsafe extern "C" fn make_scripts(mut q: i32, mut delta: scaled_t) {
         if shift_down < sub1(cur_size) {
             shift_down = sub1(cur_size)
         }
-        if *font_area.offset(cur_f as isize) as u32 == 0xfffeu32
+        if font_area[cur_f as usize] as u32 == 0xfffeu32
             && isOpenTypeMathFont(*font_layout_engine.offset(cur_f as isize) as XeTeXLayoutEngine)
                 as i32
                 != 0
@@ -5659,7 +5635,7 @@ unsafe extern "C" fn make_scripts(mut q: i32, mut delta: scaled_t) {
             shift_down = clr
         }
         (*mem.offset((x + 4i32) as isize)).b32.s1 = shift_down;
-        if *font_area.offset(cur_f as isize) as u32 == 0xfffeu32
+        if font_area[cur_f as usize] as u32 == 0xfffeu32
             && isOpenTypeMathFont(*font_layout_engine.offset(cur_f as isize) as XeTeXLayoutEngine)
                 as i32
                 != 0
@@ -5668,7 +5644,7 @@ unsafe extern "C" fn make_scripts(mut q: i32, mut delta: scaled_t) {
             if (*mem.offset((q + 3i32) as isize)).b32.s1 == 1i32 {
                 save_f = cur_f;
                 fetch(q + 3i32);
-                if *font_area.offset(cur_f as isize) as u32 == 0xfffeu32
+                if font_area[cur_f as usize] as u32 == 0xfffeu32
                     && isOpenTypeMathFont(
                         *font_layout_engine.offset(cur_f as isize) as XeTeXLayoutEngine
                     ) as i32
@@ -5755,7 +5731,7 @@ unsafe extern "C" fn make_scripts(mut q: i32, mut delta: scaled_t) {
         if shift_up < clr {
             shift_up = clr
         }
-        if *font_area.offset(cur_f as isize) as u32 == 0xfffeu32
+        if font_area[cur_f as usize] as u32 == 0xfffeu32
             && isOpenTypeMathFont(*font_layout_engine.offset(cur_f as isize) as XeTeXLayoutEngine)
                 as i32
                 != 0
@@ -5767,7 +5743,7 @@ unsafe extern "C" fn make_scripts(mut q: i32, mut delta: scaled_t) {
         if shift_up < clr {
             shift_up = clr
         }
-        if *font_area.offset(cur_f as isize) as u32 == 0xfffeu32
+        if font_area[cur_f as usize] as u32 == 0xfffeu32
             && isOpenTypeMathFont(*font_layout_engine.offset(cur_f as isize) as XeTeXLayoutEngine)
                 as i32
                 != 0
@@ -5776,7 +5752,7 @@ unsafe extern "C" fn make_scripts(mut q: i32, mut delta: scaled_t) {
             if (*mem.offset((q + 2i32) as isize)).b32.s1 == 1i32 {
                 save_f = cur_f;
                 fetch(q + 2i32);
-                if *font_area.offset(cur_f as isize) as u32 == 0xfffeu32
+                if font_area[cur_f as usize] as u32 == 0xfffeu32
                     && isOpenTypeMathFont(
                         *font_layout_engine.offset(cur_f as isize) as XeTeXLayoutEngine
                     ) as i32
@@ -5859,7 +5835,7 @@ unsafe extern "C" fn make_scripts(mut q: i32, mut delta: scaled_t) {
             if shift_down < sub2(cur_size) {
                 shift_down = sub2(cur_size)
             }
-            if *font_area.offset(cur_f as isize) as u32 == 0xfffeu32
+            if font_area[cur_f as usize] as u32 == 0xfffeu32
                 && isOpenTypeMathFont(
                     *font_layout_engine.offset(cur_f as isize) as XeTeXLayoutEngine
                 ) as i32
@@ -5877,7 +5853,7 @@ unsafe extern "C" fn make_scripts(mut q: i32, mut delta: scaled_t) {
             }
             if clr > 0i32 {
                 shift_down = shift_down + clr;
-                if *font_area.offset(cur_f as isize) as u32 == 0xfffeu32
+                if font_area[cur_f as usize] as u32 == 0xfffeu32
                     && isOpenTypeMathFont(
                         *font_layout_engine.offset(cur_f as isize) as XeTeXLayoutEngine
                     ) as i32
@@ -5894,7 +5870,7 @@ unsafe extern "C" fn make_scripts(mut q: i32, mut delta: scaled_t) {
                     shift_down = shift_down - clr
                 }
             }
-            if *font_area.offset(cur_f as isize) as u32 == 0xfffeu32
+            if font_area[cur_f as usize] as u32 == 0xfffeu32
                 && isOpenTypeMathFont(
                     *font_layout_engine.offset(cur_f as isize) as XeTeXLayoutEngine
                 ) as i32
@@ -5903,7 +5879,7 @@ unsafe extern "C" fn make_scripts(mut q: i32, mut delta: scaled_t) {
                 if (*mem.offset((q + 3i32) as isize)).b32.s1 == 1i32 {
                     save_f = cur_f;
                     fetch(q + 3i32);
-                    if *font_area.offset(cur_f as isize) as u32 == 0xfffeu32
+                    if font_area[cur_f as usize] as u32 == 0xfffeu32
                         && isOpenTypeMathFont(
                             *font_layout_engine.offset(cur_f as isize) as XeTeXLayoutEngine
                         ) as i32
@@ -5942,7 +5918,7 @@ unsafe extern "C" fn make_scripts(mut q: i32, mut delta: scaled_t) {
                 if (*mem.offset((q + 2i32) as isize)).b32.s1 == 1i32 {
                     save_f = cur_f;
                     fetch(q + 2i32);
-                    if *font_area.offset(cur_f as isize) as u32 == 0xfffeu32
+                    if font_area[cur_f as usize] as u32 == 0xfffeu32
                         && isOpenTypeMathFont(
                             *font_layout_engine.offset(cur_f as isize) as XeTeXLayoutEngine
                         ) as i32
@@ -6306,8 +6282,8 @@ unsafe extern "C" fn mlist_to_hlist() {
                 match (*mem.offset((q + 1i32) as isize)).b32.s1 {
                     1 | 4 => {
                         fetch(q + 1i32);
-                        if *font_area.offset(cur_f as isize) as u32 == 0xffffu32
-                            || *font_area.offset(cur_f as isize) as u32 == 0xfffeu32
+                        if font_area[cur_f as usize] as u32 == 0xffffu32
+                            || font_area[cur_f as usize] as u32 == 0xfffeu32
                         {
                             z = new_native_character(cur_f, cur_c);
                             p = get_node(5i32);
@@ -6330,7 +6306,7 @@ unsafe extern "C" fn mlist_to_hlist() {
                                 (*mem.offset((p + 4i32) as isize)).b16.s1 as i32,
                             );
                             if (*mem.offset((q + 1i32) as isize)).b32.s1 == 4i32
-                                && !(*font_area.offset(cur_f as isize) as u32 == 0xfffeu32
+                                && !(font_area[cur_f as usize] as u32 == 0xfffeu32
                                     && isOpenTypeMathFont(
                                         *font_layout_engine.offset(cur_f as isize)
                                             as XeTeXLayoutEngine,
@@ -6766,7 +6742,7 @@ unsafe extern "C" fn var_delimiter(mut d: i32, mut s: i32, mut v: scaled_t) -> i
                 .s1;
                 if g != 0i32 {
                     /*734: */
-                    if *font_area.offset(g as isize) as u32 == 0xfffeu32
+                    if font_area[g as usize] as u32 == 0xfffeu32
                         && usingOpenType(*font_layout_engine.offset(g as isize) as XeTeXLayoutEngine)
                             as i32
                             != 0
@@ -6853,7 +6829,7 @@ unsafe extern "C" fn var_delimiter(mut d: i32, mut s: i32, mut v: scaled_t) -> i
             + ((*mem.offset(d as isize)).b16.s1 as i32 / 256i32) as i64 * 65536) as u16
     }
     if f != 0i32 {
-        if !(*font_area.offset(f as isize) as u32 == 0xfffeu32
+        if !(font_area[f as usize] as u32 == 0xfffeu32
             && usingOpenType(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine) as i32
                 != 0)
         {
@@ -7032,8 +7008,8 @@ unsafe extern "C" fn char_box(mut f: internal_font_number, mut c: i32) -> i32 {
     };
     let mut b: i32 = 0;
     let mut p: i32 = 0;
-    if *font_area.offset(f as isize) as u32 == 0xffffu32
-        || *font_area.offset(f as isize) as u32 == 0xfffeu32
+    if font_area[f as usize] as u32 == 0xffffu32
+        || font_area[f as usize] as u32 == 0xfffeu32
     {
         b = new_null_box();
         p = new_native_character(f, c);

--- a/engine/src/xetex_opentype_math.rs
+++ b/engine/src/xetex_opentype_math.rs
@@ -1,10 +1,12 @@
-#![allow(dead_code,
-         mutable_transmutes,
-         non_camel_case_types,
-         non_snake_case,
-         non_upper_case_globals,
-         unused_assignments,
-         unused_mut)]
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
 #![feature(const_raw_ptr_to_usize_cast, extern_types, label_break_value)]
 
 use crate::core_memory::xmalloc;
@@ -1259,8 +1261,6 @@ pub struct FT_GlyphSlotRec_ {
 pub type FT_Slot_Internal = *mut FT_Slot_InternalRec_;
 pub type FT_SubGlyph = *mut FT_SubGlyphRec_;
 
-pub const HB_OT_MATH_GLYPH_PART_FLAG_EXTENDER: hb_ot_math_glyph_part_flags_t = 1;
-
 /* tectonic/xetex-core.h: core XeTeX types and #includes.
    Copyright 2016 the Tectonic Project
    Licensed under the MIT License.
@@ -1332,26 +1332,24 @@ shall not be used in advertising or otherwise to promote the sale,
 use or other dealings in this Software without prior written
 authorization from the copyright holders.
 \****************************************************************************/
-#[no_mangle]
-pub unsafe extern "C" fn get_ot_math_constant(
-    mut f: libc::c_int,
-    mut n: libc::c_int,
-) -> libc::c_int {
+pub fn get_ot_math_constant(f: i32, n: i32) -> i32 {
     let mut constant: hb_ot_math_constant_t = n as hb_ot_math_constant_t;
     let mut rval: hb_position_t = 0i32;
-    if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
-        let mut font: *mut XeTeXFontInst =
-            getFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine)
-                as *mut XeTeXFontInst;
-        let mut hbFont: *mut hb_font_t = XeTeXFontInst_getHbFont(font);
-        rval = hb_ot_math_get_constant(hbFont, constant);
-        /* scale according to font size, except the ones that are percentages */
-        match constant as libc::c_uint {
-            0 | 1 | 55 => {}
-            _ => {
-                rval = D2Fix(
-                    XeTeXFontInst_unitsToPoints(font, rval as libc::c_float) as libc::c_double
-                )
+    unsafe {
+        if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
+            let mut font: *mut XeTeXFontInst =
+                getFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine)
+                    as *mut XeTeXFontInst;
+            let mut hbFont: *mut hb_font_t = XeTeXFontInst_getHbFont(font);
+            rval = hb_ot_math_get_constant(hbFont, constant);
+            /* scale according to font size, except the ones that are percentages */
+            match constant as libc::c_uint {
+                0 | 1 | 55 => {}
+                _ => {
+                    rval =
+                        D2Fix(XeTeXFontInst_unitsToPoints(font, rval as libc::c_float)
+                            as libc::c_double)
+                }
             }
         }
     }
@@ -1360,7 +1358,7 @@ pub unsafe extern "C" fn get_ot_math_constant(
 /* size of \.{\\atopwithdelims} delimiters in non-displays */
 /* height of fraction lines above the baseline */
 #[no_mangle]
-pub static mut TeX_sym_to_OT_map: [hb_ot_math_constant_t; 23] = [
+pub static TeX_sym_to_OT_map: [hb_ot_math_constant_t; 23] = [
     4294967295 as hb_ot_math_constant_t,
     4294967295 as hb_ot_math_constant_t,
     4294967295 as hb_ot_math_constant_t,
@@ -1385,35 +1383,38 @@ pub static mut TeX_sym_to_OT_map: [hb_ot_math_constant_t; 23] = [
     4294967295 as hb_ot_math_constant_t,
     HB_OT_MATH_CONSTANT_AXIS_HEIGHT,
 ];
-unsafe extern "C" fn min_int(mut a: libc::c_int, mut b: libc::c_int) -> libc::c_int {
-    return if a < b { a } else { b };
+fn min_int(a: i32, b: i32) -> i32 {
+    if a < b {
+        a
+    } else {
+        b
+    }
 }
-#[no_mangle]
-pub unsafe extern "C" fn get_native_mathsy_param(
-    mut f: libc::c_int,
-    mut n: libc::c_int,
-) -> libc::c_int {
-    let mut rval: libc::c_int = 0i32;
-    if n == 6i32 {
-        rval = *font_size.offset(f as isize)
-    } else if n == 21i32 {
-        // XXX not sure what OT parameter we should use here;
-        // for now we use 1.5em, clamped to delim1 height
-        rval = min_int(
-            (1.5f64 * *font_size.offset(f as isize) as libc::c_double) as libc::c_int,
-            get_native_mathsy_param(f, 20i32),
-        )
-    } else if n
-        < (::std::mem::size_of::<[hb_ot_math_constant_t; 23]>() as libc::c_ulong)
-            .wrapping_div(::std::mem::size_of::<hb_ot_math_constant_t>() as libc::c_ulong)
-            as libc::c_int
-    {
-        let mut ot_index: hb_ot_math_constant_t = TeX_sym_to_OT_map[n as usize];
-        if ot_index as libc::c_uint != 4294967295 as hb_ot_math_constant_t as libc::c_uint {
-            rval = get_ot_math_constant(f, ot_index as libc::c_int)
+
+pub fn get_native_mathsy_param(f: i32, n: i32) -> i32 {
+    let mut rval: i32 = 0i32;
+    unsafe {
+        if n == 6i32 {
+            rval = *font_size.offset(f as isize)
+        } else if n == 21i32 {
+            // XXX not sure what OT parameter we should use here;
+            // for now we use 1.5em, clamped to delim1 height
+            rval = min_int(
+                (1.5f64 * *font_size.offset(f as isize) as libc::c_double) as i32,
+                get_native_mathsy_param(f, 20i32),
+            )
+        } else if n
+            < (::std::mem::size_of::<[hb_ot_math_constant_t; 23]>() as libc::c_ulong)
+                .wrapping_div(::std::mem::size_of::<hb_ot_math_constant_t>() as libc::c_ulong)
+                as i32
+        {
+            let mut ot_index: hb_ot_math_constant_t = TeX_sym_to_OT_map[n as usize];
+            if ot_index as libc::c_uint != 4294967295 as hb_ot_math_constant_t as libc::c_uint {
+                rval = get_ot_math_constant(f, ot_index as libc::c_int)
+            }
         }
     }
-    //  fprintf(stderr, " math_sy(%d, %d) returns %.3f\n", f, n, Fix2D(rval));
+    
     return rval;
 }
 /* fontdimen IDs for math extension font (family 3) */
@@ -1424,7 +1425,7 @@ pub unsafe extern "C" fn get_native_mathsy_param(
 /* minimum baselineskip below displayed op */
 /* padding above and below displayed limits */
 #[no_mangle]
-pub static mut TeX_ext_to_OT_map: [hb_ot_math_constant_t; 14] = [
+pub static TeX_ext_to_OT_map: [hb_ot_math_constant_t; 14] = [
     4294967295 as hb_ot_math_constant_t,
     4294967295 as hb_ot_math_constant_t,
     4294967295 as hb_ot_math_constant_t,
@@ -1441,24 +1442,22 @@ pub static mut TeX_ext_to_OT_map: [hb_ot_math_constant_t; 14] = [
     HB_OT_MATH_CONSTANT_STACK_GAP_MIN,
 ];
 #[no_mangle]
-pub unsafe extern "C" fn get_native_mathex_param(
-    mut f: libc::c_int,
-    mut n: libc::c_int,
-) -> libc::c_int {
-    let mut rval: libc::c_int = 0i32;
-    if n == 6i32 {
-        rval = *font_size.offset(f as isize)
-    } else if n
-        < (::std::mem::size_of::<[hb_ot_math_constant_t; 14]>() as libc::c_ulong)
-            .wrapping_div(::std::mem::size_of::<hb_ot_math_constant_t>() as libc::c_ulong)
-            as libc::c_int
-    {
-        let mut ot_index: hb_ot_math_constant_t = TeX_ext_to_OT_map[n as usize];
-        if ot_index as libc::c_uint != 4294967295 as hb_ot_math_constant_t as libc::c_uint {
-            rval = get_ot_math_constant(f, ot_index as libc::c_int)
+pub fn get_native_mathex_param(f: i32, n: i32) -> i32 {
+    let mut rval = 0i32;
+    unsafe {
+        if n == 6i32 {
+            rval = *font_size.offset(f as isize);
+        } else if n
+            < (::std::mem::size_of::<[hb_ot_math_constant_t; 14]>() as libc::c_ulong)
+                .wrapping_div(::std::mem::size_of::<hb_ot_math_constant_t>() as libc::c_ulong)
+                as libc::c_int
+        {
+            let mut ot_index: hb_ot_math_constant_t = TeX_ext_to_OT_map[n as usize];
+            if ot_index as libc::c_uint != 4294967295 as hb_ot_math_constant_t as libc::c_uint {
+                rval = get_ot_math_constant(f, ot_index as libc::c_int)
+            }
         }
     }
-    //  fprintf(stderr, " math_ex(%d, %d) returns %.3f\n", f, n, Fix2D(rval));
     return rval;
 }
 #[no_mangle]
@@ -1563,51 +1562,52 @@ pub unsafe extern "C" fn free_ot_assembly(mut a: *mut GlyphAssembly) {
     free((*a).parts as *mut libc::c_void);
     free(a as *mut libc::c_void);
 }
-#[no_mangle]
-pub unsafe extern "C" fn get_ot_math_ital_corr(
-    mut f: libc::c_int,
-    mut g: libc::c_int,
-) -> libc::c_int {
+
+pub fn get_ot_math_ital_corr(f: i32, g: i32) -> i32 {
     let mut rval: hb_position_t = 0i32;
-    if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
-        let mut font: *mut XeTeXFontInst =
-            getFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine)
-                as *mut XeTeXFontInst;
-        let mut hbFont: *mut hb_font_t = XeTeXFontInst_getHbFont(font);
-        rval = hb_ot_math_get_glyph_italics_correction(hbFont, g as hb_codepoint_t);
-        rval = D2Fix(XeTeXFontInst_unitsToPoints(font, rval as libc::c_float) as libc::c_double)
+    unsafe {
+        if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
+            let mut font: *mut XeTeXFontInst =
+                getFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine)
+                    as *mut XeTeXFontInst;
+            let mut hbFont: *mut hb_font_t = XeTeXFontInst_getHbFont(font);
+            rval = hb_ot_math_get_glyph_italics_correction(hbFont, g as hb_codepoint_t);
+            rval = D2Fix(XeTeXFontInst_unitsToPoints(font, rval as libc::c_float) as libc::c_double)
+        }
     }
     return rval;
 }
-#[no_mangle]
-pub unsafe extern "C" fn get_ot_math_accent_pos(
-    mut f: libc::c_int,
-    mut g: libc::c_int,
-) -> libc::c_int {
+
+pub fn get_ot_math_accent_pos(f: i32, g: i32) -> i32 {
     let mut rval: hb_position_t = 0x7fffffffu64 as hb_position_t;
-    if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
-        let mut font: *mut XeTeXFontInst =
-            getFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine)
-                as *mut XeTeXFontInst;
-        let mut hbFont: *mut hb_font_t = XeTeXFontInst_getHbFont(font);
-        rval = hb_ot_math_get_glyph_top_accent_attachment(hbFont, g as hb_codepoint_t);
-        rval = D2Fix(XeTeXFontInst_unitsToPoints(font, rval as libc::c_float) as libc::c_double)
+    unsafe {
+        if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
+            let mut font: *mut XeTeXFontInst =
+                getFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine)
+                    as *mut XeTeXFontInst;
+            let mut hbFont: *mut hb_font_t = XeTeXFontInst_getHbFont(font);
+            rval = hb_ot_math_get_glyph_top_accent_attachment(hbFont, g as hb_codepoint_t);
+            rval = D2Fix(XeTeXFontInst_unitsToPoints(font, rval as libc::c_float) as libc::c_double)
+        }
     }
     return rval;
 }
-#[no_mangle]
-pub unsafe extern "C" fn ot_min_connector_overlap(mut f: libc::c_int) -> libc::c_int {
+
+pub fn ot_min_connector_overlap(f: i32) -> i32 {
     let mut rval: hb_position_t = 0i32;
-    if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
-        let mut font: *mut XeTeXFontInst =
-            getFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine)
-                as *mut XeTeXFontInst;
-        let mut hbFont: *mut hb_font_t = XeTeXFontInst_getHbFont(font);
-        rval = hb_ot_math_get_min_connector_overlap(hbFont, HB_DIRECTION_RTL);
-        rval = D2Fix(XeTeXFontInst_unitsToPoints(font, rval as libc::c_float) as libc::c_double)
+    unsafe {
+        if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
+            let mut font: *mut XeTeXFontInst =
+                getFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine)
+                    as *mut XeTeXFontInst;
+            let mut hbFont: *mut hb_font_t = XeTeXFontInst_getHbFont(font);
+            rval = hb_ot_math_get_min_connector_overlap(hbFont, HB_DIRECTION_RTL);
+            rval = D2Fix(XeTeXFontInst_unitsToPoints(font, rval as libc::c_float) as libc::c_double)
+        }
     }
     return rval;
 }
+
 unsafe extern "C" fn getMathKernAt(
     mut f: libc::c_int,
     mut g: libc::c_int,
@@ -1624,120 +1624,125 @@ unsafe extern "C" fn getMathKernAt(
     }
     return rval;
 }
-unsafe extern "C" fn glyph_height(mut f: libc::c_int, mut g: libc::c_int) -> libc::c_float {
-    let mut rval: libc::c_float = 0.0f64 as libc::c_float;
-    if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
-        let mut engine: XeTeXLayoutEngine =
-            *font_layout_engine.offset(f as isize) as XeTeXLayoutEngine;
-        getGlyphHeightDepth(engine, g as uint32_t, &mut rval, 0 as *mut libc::c_float);
-    }
-    return rval;
-}
-unsafe extern "C" fn glyph_depth(mut f: libc::c_int, mut g: libc::c_int) -> libc::c_float {
-    let mut rval: libc::c_float = 0.0f64 as libc::c_float;
-    if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
-        let mut engine: XeTeXLayoutEngine =
-            *font_layout_engine.offset(f as isize) as XeTeXLayoutEngine;
-        getGlyphHeightDepth(engine, g as uint32_t, 0 as *mut libc::c_float, &mut rval);
-    }
-    return rval;
-}
-#[no_mangle]
-pub unsafe extern "C" fn get_ot_math_kern(
-    mut f: libc::c_int,
-    mut g: libc::c_int,
-    mut sf: libc::c_int,
-    mut sg: libc::c_int,
-    mut cmd: libc::c_int,
-    mut shift: libc::c_int,
-) -> libc::c_int {
-    let mut rval: libc::c_int = 0i32;
-    if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
-        let mut font: *mut XeTeXFontInst =
-            getFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine)
-                as *mut XeTeXFontInst;
-        let mut kern: libc::c_int = 0i32;
-        let mut skern: libc::c_int = 0i32;
-        let mut corr_height_top: libc::c_float = 0.0f64 as libc::c_float;
-        let mut corr_height_bot: libc::c_float = 0.0f64 as libc::c_float;
-        if cmd == 0i32 {
-            // superscript
-            corr_height_top = XeTeXFontInst_pointsToUnits(font, glyph_height(f, g));
-            corr_height_bot = -XeTeXFontInst_pointsToUnits(
-                font,
-                (glyph_depth(sf, sg) as libc::c_double + Fix2D(shift)) as libc::c_float,
-            );
-            kern = getMathKernAt(
-                f,
-                g,
-                HB_OT_MATH_KERN_TOP_RIGHT,
-                corr_height_top as libc::c_int,
-            );
-            skern = getMathKernAt(
-                sf,
-                sg,
-                HB_OT_MATH_KERN_BOTTOM_LEFT,
-                corr_height_top as libc::c_int,
-            );
-            rval = kern + skern;
-            kern = getMathKernAt(
-                f,
-                g,
-                HB_OT_MATH_KERN_TOP_RIGHT,
-                corr_height_bot as libc::c_int,
-            );
-            skern = getMathKernAt(
-                sf,
-                sg,
-                HB_OT_MATH_KERN_BOTTOM_LEFT,
-                corr_height_bot as libc::c_int,
-            );
-            if kern + skern < rval {
-                rval = kern + skern
-            }
-        } else if cmd == 1i32 {
-            // subscript
-            corr_height_top = XeTeXFontInst_pointsToUnits(
-                font,
-                (glyph_height(sf, sg) as libc::c_double - Fix2D(shift)) as libc::c_float,
-            );
-            corr_height_bot = -XeTeXFontInst_pointsToUnits(font, glyph_depth(f, g));
-            kern = getMathKernAt(
-                f,
-                g,
-                HB_OT_MATH_KERN_BOTTOM_RIGHT,
-                corr_height_top as libc::c_int,
-            );
-            skern = getMathKernAt(
-                sf,
-                sg,
-                HB_OT_MATH_KERN_TOP_LEFT,
-                corr_height_top as libc::c_int,
-            );
-            rval = kern + skern;
-            kern = getMathKernAt(
-                f,
-                g,
-                HB_OT_MATH_KERN_BOTTOM_RIGHT,
-                corr_height_bot as libc::c_int,
-            );
-            skern = getMathKernAt(
-                sf,
-                sg,
-                HB_OT_MATH_KERN_TOP_LEFT,
-                corr_height_bot as libc::c_int,
-            );
-            if kern + skern < rval {
-                rval = kern + skern
-            }
-        } else {
-            unreachable!()
-            // we should not reach here
+
+fn glyph_height(f: i32, g: i32) -> f32 {
+    let mut rval = 0.0f32;
+    unsafe {
+        if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
+            let mut engine: XeTeXLayoutEngine =
+                *font_layout_engine.offset(f as isize) as XeTeXLayoutEngine;
+            getGlyphHeightDepth(engine, g as uint32_t, &mut rval, 0 as *mut libc::c_float);
         }
-        return D2Fix(XeTeXFontInst_unitsToPoints(font, rval as libc::c_float) as libc::c_double);
     }
+    return rval;
+}
+
+fn glyph_depth(f: i32, g: i32) -> f32 {
+    let mut rval = 0.0f32;
+    unsafe {
+        if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
+            let mut engine: XeTeXLayoutEngine =
+                *font_layout_engine.offset(f as isize) as XeTeXLayoutEngine;
+            getGlyphHeightDepth(engine, g as uint32_t, 0 as *mut libc::c_float, &mut rval);
+        }
+    }
+    return rval;
+}
+
+pub fn get_ot_math_kern(f: i32, g: i32, sf: i32, sg: i32, cmd: i32, shift: i32) -> i32 {
+    let mut rval = 0i32;
+    unsafe {
+        if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
+            let mut font: *mut XeTeXFontInst =
+                getFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine)
+                    as *mut XeTeXFontInst;
+            let mut kern: libc::c_int = 0i32;
+            let mut skern: libc::c_int = 0i32;
+            let mut corr_height_top: libc::c_float = 0.0f64 as libc::c_float;
+            let mut corr_height_bot: libc::c_float = 0.0f64 as libc::c_float;
+            if cmd == 0i32 {
+                // superscript
+                corr_height_top = XeTeXFontInst_pointsToUnits(font, glyph_height(f, g));
+                corr_height_bot = -XeTeXFontInst_pointsToUnits(
+                    font,
+                    (glyph_depth(sf, sg) as libc::c_double + Fix2D(shift)) as libc::c_float,
+                );
+                kern = getMathKernAt(
+                    f,
+                    g,
+                    HB_OT_MATH_KERN_TOP_RIGHT,
+                    corr_height_top as libc::c_int,
+                );
+                skern = getMathKernAt(
+                    sf,
+                    sg,
+                    HB_OT_MATH_KERN_BOTTOM_LEFT,
+                    corr_height_top as libc::c_int,
+                );
+                rval = kern + skern;
+                kern = getMathKernAt(
+                    f,
+                    g,
+                    HB_OT_MATH_KERN_TOP_RIGHT,
+                    corr_height_bot as libc::c_int,
+                );
+                skern = getMathKernAt(
+                    sf,
+                    sg,
+                    HB_OT_MATH_KERN_BOTTOM_LEFT,
+                    corr_height_bot as libc::c_int,
+                );
+                if kern + skern < rval {
+                    rval = kern + skern
+                }
+            } else if cmd == 1i32 {
+                // subscript
+                corr_height_top = XeTeXFontInst_pointsToUnits(
+                    font,
+                    (glyph_height(sf, sg) as libc::c_double - Fix2D(shift)) as libc::c_float,
+                );
+                corr_height_bot = -XeTeXFontInst_pointsToUnits(font, glyph_depth(f, g));
+                kern = getMathKernAt(
+                    f,
+                    g,
+                    HB_OT_MATH_KERN_BOTTOM_RIGHT,
+                    corr_height_top as libc::c_int,
+                );
+                skern = getMathKernAt(
+                    sf,
+                    sg,
+                    HB_OT_MATH_KERN_TOP_LEFT,
+                    corr_height_top as libc::c_int,
+                );
+                rval = kern + skern;
+                kern = getMathKernAt(
+                    f,
+                    g,
+                    HB_OT_MATH_KERN_BOTTOM_RIGHT,
+                    corr_height_bot as libc::c_int,
+                );
+                skern = getMathKernAt(
+                    sf,
+                    sg,
+                    HB_OT_MATH_KERN_TOP_LEFT,
+                    corr_height_bot as libc::c_int,
+                );
+                if kern + skern < rval {
+                    rval = kern + skern
+                }
+            } else {
+                unreachable!()
+                // we should not reach here
+            }
+            return D2Fix(
+                XeTeXFontInst_unitsToPoints(font, rval as libc::c_float) as libc::c_double
+            );
+        }
+    }
+
     return 0i32;
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn ot_part_count(mut a: *const GlyphAssembly) -> libc::c_int {
     return (*a).count as libc::c_int;
@@ -1755,7 +1760,7 @@ pub unsafe extern "C" fn ot_part_is_extender(
     mut i: libc::c_int,
 ) -> bool {
     return (*(*a).parts.offset(i as isize)).flags as libc::c_uint
-        & HB_OT_MATH_GLYPH_PART_FLAG_EXTENDER as libc::c_int as libc::c_uint
+        & HB_MATH_GLYPH_PART_FLAG_EXTENDER as libc::c_int as libc::c_uint
         != 0i32 as libc::c_uint;
 }
 #[no_mangle]

--- a/engine/src/xetex_opentype_math.rs
+++ b/engine/src/xetex_opentype_math.rs
@@ -11,6 +11,7 @@
 
 use crate::core_memory::xmalloc;
 use harfbuzz_sys::*;
+use crate::xetex_ini::font_area;
 
 extern "C" {
     pub type FT_LibraryRec_;
@@ -39,8 +40,6 @@ extern "C" {
     #[no_mangle]
     static mut font_layout_engine: *mut *mut libc::c_void;
     #[no_mangle]
-    static mut font_area: *mut int32_t;
-    #[no_mangle]
     static mut font_size: *mut int32_t;
     #[no_mangle]
     fn XeTeXFontInst_getHbFont(self_0: *const XeTeXFontInst) -> *mut hb_font_t;
@@ -55,6 +54,7 @@ extern "C" {
         points: libc::c_float,
     ) -> libc::c_float;
 }
+
 pub type size_t = usize;
 pub type int32_t = i32;
 pub type uint32_t = u32;
@@ -1336,7 +1336,7 @@ pub fn get_ot_math_constant(f: i32, n: i32) -> i32 {
     let mut constant: hb_ot_math_constant_t = n as hb_ot_math_constant_t;
     let mut rval: hb_position_t = 0i32;
     unsafe {
-        if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
+        if font_area[f as usize] as u32 == 0xfffeu32 {
             let mut font: *mut XeTeXFontInst =
                 getFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine)
                     as *mut XeTeXFontInst;
@@ -1470,7 +1470,7 @@ pub unsafe extern "C" fn get_ot_math_variant(
 ) -> libc::c_int {
     let mut rval: hb_codepoint_t = g as hb_codepoint_t;
     *adv = -1i32;
-    if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
+    if font_area[f as usize] as u32 == 0xfffeu32 {
         let mut font: *mut XeTeXFontInst =
             getFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine)
                 as *mut XeTeXFontInst;
@@ -1509,7 +1509,7 @@ pub unsafe extern "C" fn get_ot_assembly_ptr(
     mut horiz: libc::c_int,
 ) -> *mut libc::c_void {
     let mut rval: *mut libc::c_void = 0 as *mut libc::c_void;
-    if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
+    if font_area[f as usize] as u32 == 0xfffeu32 {
         let mut font: *mut XeTeXFontInst =
             getFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine)
                 as *mut XeTeXFontInst;
@@ -1566,7 +1566,7 @@ pub unsafe extern "C" fn free_ot_assembly(mut a: *mut GlyphAssembly) {
 pub fn get_ot_math_ital_corr(f: i32, g: i32) -> i32 {
     let mut rval: hb_position_t = 0i32;
     unsafe {
-        if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
+        if font_area[f as usize] as u32 == 0xfffeu32 {
             let mut font: *mut XeTeXFontInst =
                 getFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine)
                     as *mut XeTeXFontInst;
@@ -1581,7 +1581,7 @@ pub fn get_ot_math_ital_corr(f: i32, g: i32) -> i32 {
 pub fn get_ot_math_accent_pos(f: i32, g: i32) -> i32 {
     let mut rval: hb_position_t = 0x7fffffffu64 as hb_position_t;
     unsafe {
-        if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
+        if font_area[f as usize] as u32 == 0xfffeu32 {
             let mut font: *mut XeTeXFontInst =
                 getFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine)
                     as *mut XeTeXFontInst;
@@ -1596,7 +1596,7 @@ pub fn get_ot_math_accent_pos(f: i32, g: i32) -> i32 {
 pub fn ot_min_connector_overlap(f: i32) -> i32 {
     let mut rval: hb_position_t = 0i32;
     unsafe {
-        if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
+        if font_area[f as usize] as u32 == 0xfffeu32 {
             let mut font: *mut XeTeXFontInst =
                 getFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine)
                     as *mut XeTeXFontInst;
@@ -1615,7 +1615,7 @@ unsafe extern "C" fn getMathKernAt(
     mut height: libc::c_int,
 ) -> libc::c_int {
     let mut rval: hb_position_t = 0i32;
-    if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
+    if font_area[f as usize] as u32 == 0xfffeu32 {
         let mut font: *mut XeTeXFontInst =
             getFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine)
                 as *mut XeTeXFontInst;
@@ -1628,7 +1628,7 @@ unsafe extern "C" fn getMathKernAt(
 fn glyph_height(f: i32, g: i32) -> f32 {
     let mut rval = 0.0f32;
     unsafe {
-        if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
+        if font_area[f as usize] as u32 == 0xfffeu32 {
             let mut engine: XeTeXLayoutEngine =
                 *font_layout_engine.offset(f as isize) as XeTeXLayoutEngine;
             getGlyphHeightDepth(engine, g as uint32_t, &mut rval, 0 as *mut libc::c_float);
@@ -1640,7 +1640,7 @@ fn glyph_height(f: i32, g: i32) -> f32 {
 fn glyph_depth(f: i32, g: i32) -> f32 {
     let mut rval = 0.0f32;
     unsafe {
-        if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
+        if font_area[f as usize] as u32 == 0xfffeu32 {
             let mut engine: XeTeXLayoutEngine =
                 *font_layout_engine.offset(f as isize) as XeTeXLayoutEngine;
             getGlyphHeightDepth(engine, g as uint32_t, 0 as *mut libc::c_float, &mut rval);
@@ -1652,7 +1652,7 @@ fn glyph_depth(f: i32, g: i32) -> f32 {
 pub fn get_ot_math_kern(f: i32, g: i32, sf: i32, sg: i32, cmd: i32, shift: i32) -> i32 {
     let mut rval = 0i32;
     unsafe {
-        if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
+        if font_area[f as usize] as u32 == 0xfffeu32 {
             let mut font: *mut XeTeXFontInst =
                 getFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine)
                     as *mut XeTeXFontInst;
@@ -1770,7 +1770,7 @@ pub unsafe extern "C" fn ot_part_start_connector(
     mut i: libc::c_int,
 ) -> libc::c_int {
     let mut rval: libc::c_int = 0i32;
-    if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
+    if font_area[f as usize] as u32 == 0xfffeu32 {
         let mut font: *mut XeTeXFontInst =
             getFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine)
                 as *mut XeTeXFontInst;
@@ -1788,7 +1788,7 @@ pub unsafe extern "C" fn ot_part_end_connector(
     mut i: libc::c_int,
 ) -> libc::c_int {
     let mut rval: libc::c_int = 0i32;
-    if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
+    if font_area[f as usize] as u32 == 0xfffeu32 {
         let mut font: *mut XeTeXFontInst =
             getFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine)
                 as *mut XeTeXFontInst;
@@ -1837,7 +1837,7 @@ pub unsafe extern "C" fn ot_part_full_advance(
     mut i: libc::c_int,
 ) -> libc::c_int {
     let mut rval: libc::c_int = 0i32;
-    if *font_area.offset(f as isize) as libc::c_uint == 0xfffeu32 {
+    if font_area[f as usize] as u32 == 0xfffeu32 {
         let mut font: *mut XeTeXFontInst =
             getFont(*font_layout_engine.offset(f as isize) as XeTeXLayoutEngine)
                 as *mut XeTeXFontInst;

--- a/engine/src/xetex_shipout.rs
+++ b/engine/src/xetex_shipout.rs
@@ -2972,8 +2972,8 @@ unsafe extern "C" fn dvi_native_font_def(mut f: internal_font_number) {
 unsafe extern "C" fn dvi_font_def(mut f: internal_font_number) {
     let mut k: pool_pointer = 0;
     let mut l: i32 = 0;
-    if *font_area.offset(f as isize) as u32 == 0xffffu32
-        || *font_area.offset(f as isize) as u32 == 0xfffeu32
+    if font_area[f as usize] as u32 == 0xffffu32
+        || font_area[f as usize] as u32 == 0xfffeu32
     {
         dvi_native_font_def(f);
     } else {
@@ -2991,7 +2991,7 @@ unsafe extern "C" fn dvi_font_def(mut f: internal_font_number) {
         dvi_out((*font_check.offset(f as isize)).s0 as u8);
         dvi_four(*font_size.offset(f as isize));
         dvi_four(*font_dsize.offset(f as isize));
-        dvi_out(length(*font_area.offset(f as isize)) as u8);
+        dvi_out(length(font_area[f as usize]) as u8);
         l = 0i32;
         k = *str_start.offset((*font_name.offset(f as isize) as i64 - 65536) as isize);
         while l == 0i32
@@ -3008,9 +3008,9 @@ unsafe extern "C" fn dvi_font_def(mut f: internal_font_number) {
         }
         dvi_out(l as u8);
         let mut for_end: i32 = 0;
-        k = *str_start.offset((*font_area.offset(f as isize) as i64 - 65536) as isize);
+        k = *str_start.offset((font_area[f as usize] as i64 - 65536) as isize);
         for_end = *str_start
-            .offset(((*font_area.offset(f as isize) + 1i32) as i64 - 65536) as isize)
+            .offset(((font_area[f as usize] + 1i32) as i64 - 65536) as isize)
             - 1i32;
         if k <= for_end {
             loop {

--- a/engine/src/xetex_xetex0.rs
+++ b/engine/src/xetex_xetex0.rs
@@ -4292,8 +4292,8 @@ pub unsafe extern "C" fn print_cmd_chr(mut cmd: u16, mut chr_code: i32) {
         89 => {
             print_cstr(b"select font \x00" as *const u8 as *const i8);
             font_name_str = *font_name.offset(chr_code as isize);
-            if *font_area.offset(chr_code as isize) as u32 == 0xffffu32
-                || *font_area.offset(chr_code as isize) as u32 == 0xfffeu32
+            if font_area[chr_code as u8 as usize] as u32 == 0xffffu32
+                || font_area[chr_code as u8 as usize] as u32 == 0xfffeu32
             {
                 let mut for_end: i32 = length(font_name_str) - 1i32;
                 quote_char = '\"' as i32 as UTF16_code;
@@ -10479,8 +10479,8 @@ pub unsafe extern "C" fn scan_something_internal(mut level: small_number, mut ne
                 cur_val_level = 0_u8
             } else {
                 n = cur_val;
-                if *font_area.offset(n as isize) as u32 == 0xffffu32
-                    || *font_area.offset(n as isize) as u32 == 0xfffeu32
+                if font_area[n as usize] as u32 == 0xffffu32
+                    || font_area[n as usize] as u32 == 0xfffeu32
                 {
                     scan_glyph_number(n);
                 } else {
@@ -10687,7 +10687,7 @@ pub unsafe extern "C" fn scan_something_internal(mut level: small_number, mut ne
                     match m {
                         47 => {
                             /*1435:*/
-                            if *font_area.offset(
+                            if font_area[
                                 (*eqtb.offset(
                                     (1i32
                                         + (0x10ffffi32 + 1i32)
@@ -10707,10 +10707,8 @@ pub unsafe extern "C" fn scan_something_internal(mut level: small_number, mut ne
                                         + 256i32) as isize,
                                 ))
                                 .b32
-                                .s1 as isize,
-                            ) as u32
-                                == 0xffffu32
-                                || *font_area.offset(
+                                .s1 as usize] as u32 == 0xffffu32
+                                || font_area[
                                     (*eqtb.offset(
                                         (1i32
                                             + (0x10ffffi32 + 1i32)
@@ -10731,9 +10729,7 @@ pub unsafe extern "C" fn scan_something_internal(mut level: small_number, mut ne
                                             as isize,
                                     ))
                                     .b32
-                                    .s1 as isize,
-                                ) as u32
-                                    == 0xfffeu32
+                                    .s1 as usize] as u32 == 0xfffeu32
                             {
                                 scan_int(); /* shellenabledp */
                                 n = cur_val;
@@ -10814,8 +10810,8 @@ pub unsafe extern "C" fn scan_something_internal(mut level: small_number, mut ne
                             scan_font_ident();
                             q = cur_val;
                             scan_usv_num();
-                            if *font_area.offset(q as isize) as u32 == 0xffffu32
-                                || *font_area.offset(q as isize) as u32 == 0xfffeu32
+                            if font_area[q as usize] as u32 == 0xffffu32
+                                || font_area[q as usize] as u32 == 0xfffeu32
                             {
                                 match m {
                                     48 => cur_val = getnativecharwd(q, cur_val),
@@ -10995,7 +10991,7 @@ pub unsafe extern "C" fn scan_something_internal(mut level: small_number, mut ne
                         15 => {
                             scan_font_ident();
                             n = cur_val;
-                            match *font_area.offset(n as isize) as u32 {
+                            match font_area[n as usize] as u32 {
                                 #[cfg(target_os = "macos")]
                                 0xffffu32 => {
                                     cur_val = aat::aat_font_get(
@@ -11015,7 +11011,7 @@ pub unsafe extern "C" fn scan_something_internal(mut level: small_number, mut ne
                         22 => {
                             scan_font_ident();
                             n = cur_val;
-                            match *font_area.offset(n as isize) as u32 {
+                            match font_area[n as usize] as u32 {
                                 #[cfg(target_os = "macos")]
                                 0xffffu32 => {
                                     cur_val = aat::aat_font_get(
@@ -11054,7 +11050,7 @@ pub unsafe extern "C" fn scan_something_internal(mut level: small_number, mut ne
                         23 | 25 | 26 => {
                             scan_font_ident();
                             n = cur_val;
-                            match *font_area.offset(n as isize) as u32 {
+                            match font_area[n as usize] as u32 {
                                 #[cfg(target_os = "macos")]
                                 0xffffu32 => {
                                     scan_int();
@@ -11098,7 +11094,7 @@ pub unsafe extern "C" fn scan_something_internal(mut level: small_number, mut ne
                         27 | 29 => {
                             scan_font_ident();
                             n = cur_val;
-                            match *font_area.offset(n as isize) as u32 {
+                            match font_area[n as usize] as u32 {
                                 #[cfg(target_os = "macos")]
                                 0xffffu32 => {
                                     scan_int();
@@ -11147,7 +11143,7 @@ pub unsafe extern "C" fn scan_something_internal(mut level: small_number, mut ne
                         18 => {
                             scan_font_ident();
                             n = cur_val;
-                            match *font_area.offset(n as isize) as u32 {
+                            match font_area[n as usize] as u32 {
                                 #[cfg(target_os = "macos")]
                                 0xffffu32 => {
                                     scan_and_pack_name();
@@ -11170,7 +11166,7 @@ pub unsafe extern "C" fn scan_something_internal(mut level: small_number, mut ne
                         24 => {
                             scan_font_ident();
                             n = cur_val;
-                            match *font_area.offset(n as isize) as u32 {
+                            match font_area[n as usize] as u32 {
                                 #[cfg(target_os = "macos")]
                                 0xffffu32 => {
                                     scan_and_pack_name();
@@ -11209,7 +11205,7 @@ pub unsafe extern "C" fn scan_something_internal(mut level: small_number, mut ne
                         28 => {
                             scan_font_ident();
                             n = cur_val;
-                            match *font_area.offset(n as isize) as u32 {
+                            match font_area[n as usize] as u32 {
                                 #[cfg(target_os = "macos")]
                                 0xffffu32 => {
                                     scan_int();
@@ -11256,7 +11252,7 @@ pub unsafe extern "C" fn scan_something_internal(mut level: small_number, mut ne
                         30 => {
                             scan_font_ident();
                             n = cur_val;
-                            if *font_area.offset(n as isize) as u32 == 0xfffeu32
+                            if font_area[n as usize] as u32 == 0xfffeu32
                                 && usingOpenType(
                                     *font_layout_engine.offset(n as isize) as XeTeXLayoutEngine
                                 ) as i32
@@ -11271,7 +11267,7 @@ pub unsafe extern "C" fn scan_something_internal(mut level: small_number, mut ne
                         31 | 33 => {
                             scan_font_ident();
                             n = cur_val;
-                            if *font_area.offset(n as isize) as u32 == 0xfffeu32
+                            if font_area[n as usize] as u32 == 0xfffeu32
                                 && usingOpenType(
                                     *font_layout_engine.offset(n as isize) as XeTeXLayoutEngine
                                 ) as i32
@@ -11291,7 +11287,7 @@ pub unsafe extern "C" fn scan_something_internal(mut level: small_number, mut ne
                         32 | 34 => {
                             scan_font_ident();
                             n = cur_val;
-                            if *font_area.offset(n as isize) as u32 == 0xfffeu32
+                            if font_area[n as usize] as u32 == 0xfffeu32
                                 && usingOpenType(
                                     *font_layout_engine.offset(n as isize) as XeTeXLayoutEngine
                                 ) as i32
@@ -11314,7 +11310,7 @@ pub unsafe extern "C" fn scan_something_internal(mut level: small_number, mut ne
                         35 => {
                             scan_font_ident();
                             n = cur_val;
-                            if *font_area.offset(n as isize) as u32 == 0xfffeu32
+                            if font_area[n as usize] as u32 == 0xfffeu32
                                 && usingOpenType(
                                     *font_layout_engine.offset(n as isize) as XeTeXLayoutEngine
                                 ) as i32
@@ -11338,7 +11334,7 @@ pub unsafe extern "C" fn scan_something_internal(mut level: small_number, mut ne
                             }
                         }
                         36 => {
-                            if *font_area.offset(
+                            if font_area[
                                 (*eqtb.offset(
                                     (1i32
                                         + (0x10ffffi32 + 1i32)
@@ -11358,10 +11354,8 @@ pub unsafe extern "C" fn scan_something_internal(mut level: small_number, mut ne
                                         + 256i32) as isize,
                                 ))
                                 .b32
-                                .s1 as isize,
-                            ) as u32
-                                == 0xffffu32
-                                || *font_area.offset(
+                                .s1 as usize] as u32 == 0xffffu32
+                                || font_area[
                                     (*eqtb.offset(
                                         (1i32
                                             + (0x10ffffi32 + 1i32)
@@ -11382,9 +11376,7 @@ pub unsafe extern "C" fn scan_something_internal(mut level: small_number, mut ne
                                             as isize,
                                     ))
                                     .b32
-                                    .s1 as isize,
-                                ) as u32
-                                    == 0xfffeu32
+                                    .s1 as usize] as u32 == 0xfffeu32
                             {
                                 scan_int();
                                 n = cur_val;
@@ -11442,7 +11434,7 @@ pub unsafe extern "C" fn scan_something_internal(mut level: small_number, mut ne
                             }
                         }
                         37 => {
-                            if *font_area.offset(
+                            if font_area[
                                 (*eqtb.offset(
                                     (1i32
                                         + (0x10ffffi32 + 1i32)
@@ -11462,10 +11454,8 @@ pub unsafe extern "C" fn scan_something_internal(mut level: small_number, mut ne
                                         + 256i32) as isize,
                                 ))
                                 .b32
-                                .s1 as isize,
-                            ) as u32
-                                == 0xffffu32
-                                || *font_area.offset(
+                                .s1 as usize] as u32 == 0xffffu32
+                                || font_area[
                                     (*eqtb.offset(
                                         (1i32
                                             + (0x10ffffi32 + 1i32)
@@ -11486,9 +11476,7 @@ pub unsafe extern "C" fn scan_something_internal(mut level: small_number, mut ne
                                             as isize,
                                     ))
                                     .b32
-                                    .s1 as isize,
-                                ) as u32
-                                    == 0xfffeu32
+                                    .s1 as usize] as u32 == 0xfffeu32
                             {
                                 scan_and_pack_name();
                                 cur_val = map_glyph_to_index(
@@ -11546,16 +11534,16 @@ pub unsafe extern "C" fn scan_something_internal(mut level: small_number, mut ne
                         38 => {
                             scan_font_ident();
                             n = cur_val;
-                            if *font_area.offset(n as isize) as u32 == 0xffffu32 {
+                            if font_area[n as usize] as u32 == 0xffffu32 {
                                 cur_val = 1i32
-                            } else if *font_area.offset(n as isize) as u32 == 0xfffeu32
+                            } else if font_area[n as usize] as u32 == 0xfffeu32
                                 && usingOpenType(
                                     *font_layout_engine.offset(n as isize) as XeTeXLayoutEngine
                                 ) as i32
                                     != 0
                             {
                                 cur_val = 2i32
-                            } else if *font_area.offset(n as isize) as u32 == 0xfffeu32
+                            } else if font_area[n as usize] as u32 == 0xfffeu32
                                 && usingGraphite(
                                     *font_layout_engine.offset(n as isize) as XeTeXLayoutEngine
                                 ) as i32
@@ -11569,8 +11557,8 @@ pub unsafe extern "C" fn scan_something_internal(mut level: small_number, mut ne
                         39 | 40 => {
                             scan_font_ident();
                             n = cur_val;
-                            if *font_area.offset(n as isize) as u32 == 0xffffu32
-                                || *font_area.offset(n as isize) as u32 == 0xfffeu32
+                            if font_area[n as usize] as u32 == 0xffffu32
+                                || font_area[n as usize] as u32 == 0xfffeu32
                             {
                                 cur_val = get_font_char_range(n, (m == 39i32) as i32)
                             } else if m == 39i32 {
@@ -13560,7 +13548,7 @@ pub unsafe extern "C" fn conv_toks() {
         7 => {
             scan_font_ident();
             fnt = cur_val;
-            if *font_area.offset(fnt as isize) as u32 == 0xffffu32 {
+            if font_area[fnt as usize] as u32 == 0xffffu32 {
                 scan_int();
                 arg1 = cur_val;
                 arg2 = 0i32
@@ -13571,8 +13559,8 @@ pub unsafe extern "C" fn conv_toks() {
         8 => {
             scan_font_ident();
             fnt = cur_val;
-            if *font_area.offset(fnt as isize) as u32 == 0xffffu32
-                || *font_area.offset(fnt as isize) as u32 == 0xfffeu32
+            if font_area[fnt as usize] as u32 == 0xffffu32
+                || font_area[fnt as usize] as u32 == 0xfffeu32
                     && usingGraphite(*font_layout_engine.offset(fnt as isize) as XeTeXLayoutEngine)
                         as i32
                         != 0
@@ -13587,8 +13575,8 @@ pub unsafe extern "C" fn conv_toks() {
         9 => {
             scan_font_ident();
             fnt = cur_val;
-            if *font_area.offset(fnt as isize) as u32 == 0xffffu32
-                || *font_area.offset(fnt as isize) as u32 == 0xfffeu32
+            if font_area[fnt as usize] as u32 == 0xffffu32
+                || font_area[fnt as usize] as u32 == 0xfffeu32
                     && usingGraphite(*font_layout_engine.offset(fnt as isize) as XeTeXLayoutEngine)
                         as i32
                         != 0
@@ -13604,8 +13592,8 @@ pub unsafe extern "C" fn conv_toks() {
         10 => {
             scan_font_ident();
             fnt = cur_val;
-            if *font_area.offset(fnt as isize) as u32 == 0xffffu32
-                || *font_area.offset(fnt as isize) as u32 == 0xfffeu32
+            if font_area[fnt as usize] as u32 == 0xffffu32
+                || font_area[fnt as usize] as u32 == 0xfffeu32
             {
                 scan_int();
                 arg1 = cur_val
@@ -13680,7 +13668,7 @@ pub unsafe extern "C" fn conv_toks() {
         }
         4 => {
             font_name_str = *font_name.offset(cur_val as isize);
-            match *font_area.offset(cur_val as isize) as u32 {
+            match font_area[cur_val as usize] as u32 {
                 0xffffu32 | 0xfffeu32 => {
                     quote_char = '\"' as i32 as UTF16_code;
                     i = 0i32 as small_number;
@@ -13722,7 +13710,7 @@ pub unsafe extern "C" fn conv_toks() {
             print_cstr(b".99998\x00" as *const u8 as *const i8);
         }
         7 => {
-            match *font_area.offset(fnt as isize) as u32 {
+            match font_area[fnt as usize] as u32 {
                 #[cfg(target_os = "macos")]
                 0xffffu32 => {
                     aat::aat_print_font_name(
@@ -13742,7 +13730,7 @@ pub unsafe extern "C" fn conv_toks() {
             }
         }
         8 | 9 => {
-            match *font_area.offset(fnt as isize) as u32 {
+            match font_area[fnt as usize] as u32 {
                 #[cfg(target_os = "macos")]
                 0xffffu32 => {
                     aat::aat_print_font_name(
@@ -13772,7 +13760,7 @@ pub unsafe extern "C" fn conv_toks() {
                 _ => {}
             }
         }
-        10 => match *font_area.offset(fnt as isize) as u32 {
+        10 => match font_area[fnt as usize] as u32 {
             0xffffu32 | 0xfffeu32 => {
                 print_glyph_name(fnt, arg1);
             }
@@ -14726,8 +14714,8 @@ pub unsafe extern "C" fn conditional() {
             scan_font_ident();
             n = cur_val;
             scan_usv_num();
-            if *font_area.offset(n as isize) as u32 == 0xffffu32
-                || *font_area.offset(n as isize) as u32 == 0xfffeu32
+            if font_area[n as usize] as u32 == 0xffffu32
+                || font_area[n as usize] as u32 == 0xfffeu32
             {
                 b = map_char_to_glyph(n, cur_val) > 0i32
             } else if *font_bc.offset(n as isize) as i32 <= cur_val
@@ -16088,7 +16076,7 @@ pub unsafe extern "C" fn load_native_font(
     full_name = make_string();
     f = 0i32 + 1i32;
     while f <= font_ptr {
-        if *font_area.offset(f as isize) == native_font_type_flag
+        if font_area[f as usize] == native_font_type_flag
             && str_eq_str(*font_name.offset(f as isize), full_name) as i32 != 0
             && *font_size.offset(f as isize) == actual_size
         {
@@ -16144,7 +16132,7 @@ pub unsafe extern "C" fn load_native_font(
         return 0i32;
     }
     font_ptr += 1;
-    *font_area.offset(font_ptr as isize) = native_font_type_flag;
+    font_area[font_ptr as usize] = native_font_type_flag;
     *font_name.offset(font_ptr as isize) = full_name;
     (*font_check.offset(font_ptr as isize)).s3 = 0_u16;
     (*font_check.offset(font_ptr as isize)).s2 = 0_u16;
@@ -18589,11 +18577,7 @@ pub unsafe extern "C" fn read_font_info(
                                                                                                                                                                       isize)
                                                                                                                                                     =
                                                                                                                                                     nom;
-                                                                                                                                                *font_area.offset(f
-                                                                                                                                                                      as
-                                                                                                                                                                      isize)
-                                                                                                                                                    =
-                                                                                                                                                    aire;
+                                                                                                                                                font_area[f as usize] = aire as i32;
                                                                                                                                                 *font_bc.offset(f
                                                                                                                                                                     as
                                                                                                                                                                     isize)
@@ -18816,8 +18800,8 @@ pub unsafe extern "C" fn read_font_info(
 pub unsafe extern "C" fn new_character(mut f: internal_font_number, mut c: UTF16_code) -> i32 {
     let mut p: i32 = 0;
     let mut ec: u16 = 0;
-    if *font_area.offset(f as isize) as u32 == 0xffffu32
-        || *font_area.offset(f as isize) as u32 == 0xfffeu32
+    if font_area[f as usize] as u32 == 0xffffu32
+        || font_area[f as usize] as u32 == 0xfffeu32
     {
         return new_native_character(f, c as UnicodeScalar);
     }
@@ -24790,8 +24774,8 @@ pub unsafe extern "C" fn make_accent() {
             .b32
             .s1 as f64
             / 65536.0f64;
-        if *font_area.offset(f as isize) as u32 == 0xffffu32
-            || *font_area.offset(f as isize) as u32 == 0xfffeu32
+        if font_area[f as usize] as u32 == 0xffffu32
+            || font_area[f as usize] as u32 == 0xfffeu32
         {
             a = (*mem.offset((p + 1i32) as isize)).b32.s1;
             if a == 0i32 {
@@ -24848,8 +24832,8 @@ pub unsafe extern "C" fn make_accent() {
                 .b32
                 .s1 as f64
                 / 65536.0f64;
-            if *font_area.offset(f as isize) as u32 == 0xffffu32
-                || *font_area.offset(f as isize) as u32 == 0xfffeu32
+            if font_area[f as usize] as u32 == 0xffffu32
+                || font_area[f as usize] as u32 == 0xfffeu32
             {
                 w = (*mem.offset((q + 1i32) as isize)).b32.s1;
                 get_native_char_height_depth(f, cur_val, &mut h, &mut delta);
@@ -24872,8 +24856,8 @@ pub unsafe extern "C" fn make_accent() {
                 p = hpack(p, 0i32, 1i32 as small_number);
                 (*mem.offset((p + 4i32) as isize)).b32.s1 = x - h
             }
-            if (*font_area.offset(f as isize) as u32 == 0xffffu32
-                || *font_area.offset(f as isize) as u32 == 0xfffeu32)
+            if (font_area[f as usize] as u32 == 0xffffu32
+                || font_area[f as usize] as u32 == 0xfffeu32)
                 && a == 0i32
             {
                 delta = tex_round((w - lsb + rsb) as f64 / 2.0f64 + h as f64 * t - x as f64 * s)
@@ -25899,9 +25883,9 @@ pub unsafe extern "C" fn new_font(mut a: small_number) {
             _ => {
                 if str_eq_str(*font_name.offset(f as isize), cur_name) as i32 != 0
                     && (length(cur_area) == 0i32
-                        && (*font_area.offset(f as isize) as u32 == 0xffffu32
-                            || *font_area.offset(f as isize) as u32 == 0xfffeu32)
-                        || str_eq_str(*font_area.offset(f as isize), cur_area) as i32 != 0)
+                        && (font_area[f as usize] as u32 == 0xffffu32
+                            || font_area[f as usize] as u32 == 0xfffeu32)
+                        || str_eq_str(font_area[f as usize], cur_area) as i32 != 0)
                 {
                     if s > 0i32 {
                         if s == *font_size.offset(f as isize) {
@@ -25919,8 +25903,8 @@ pub unsafe extern "C" fn new_font(mut a: small_number) {
                 if str_eq_str(*font_name.offset(f as isize), make_string()) {
                     str_ptr -= 1;
                     pool_ptr = *str_start.offset((str_ptr - 65536i32) as isize);
-                    if *font_area.offset(f as isize) as u32 == 0xffffu32
-                        || *font_area.offset(f as isize) as u32 == 0xfffeu32
+                    if font_area[f as usize] as u32 == 0xffffu32
+                        || font_area[f as usize] as u32 == 0xfffeu32
                     {
                         if s > 0i32 {
                             if s == *font_size.offset(f as isize) {
@@ -26462,7 +26446,7 @@ pub unsafe extern "C" fn do_extension() {
                 new_graf(1i32 != 0);
             } else if (cur_list.mode as i32).abs() == 207i32 {
                 report_illegal_case();
-            } else if *font_area.offset(
+            } else if font_area[
                 (*eqtb.offset(
                     (1i32
                         + (0x10ffffi32 + 1i32)
@@ -26482,10 +26466,8 @@ pub unsafe extern "C" fn do_extension() {
                         + 256i32) as isize,
                 ))
                 .b32
-                .s1 as isize,
-            ) as u32
-                == 0xffffu32
-                || *font_area.offset(
+                .s1 as usize] as u32 == 0xffffu32
+                || font_area[
                     (*eqtb.offset(
                         (1i32
                             + (0x10ffffi32 + 1i32)
@@ -26505,9 +26487,7 @@ pub unsafe extern "C" fn do_extension() {
                             + 256i32) as isize,
                     ))
                     .b32
-                    .s1 as isize,
-                ) as u32
-                    == 0xfffeu32
+                    .s1 as usize] as u32 == 0xfffeu32
             {
                 new_whatsit(42i32 as small_number, 5i32 as small_number);
                 scan_int();
@@ -28049,7 +28029,7 @@ pub unsafe extern "C" fn main_control() {
                 }
             }
             prev_class = 4096i32 - 1i32;
-            if *font_area.offset(
+            if font_area[
                 (*eqtb.offset(
                     (1i32
                         + (0x10ffffi32 + 1i32)
@@ -28069,10 +28049,9 @@ pub unsafe extern "C" fn main_control() {
                         + 256i32) as isize,
                 ))
                 .b32
-                .s1 as isize,
-            ) as u32
+                .s1 as usize] as u32
                 == 0xffffu32
-                || *font_area.offset(
+                || font_area[
                     (*eqtb.offset(
                         (1i32
                             + (0x10ffffi32 + 1i32)
@@ -28092,9 +28071,7 @@ pub unsafe extern "C" fn main_control() {
                             + 256i32) as isize,
                     ))
                     .b32
-                    .s1 as isize,
-                ) as u32
-                    == 0xfffeu32
+                    .s1 as usize] as u32 == 0xfffeu32
             {
                 if cur_list.mode as i32 > 0i32 {
                     if (*eqtb.offset(

--- a/engine/src/xetex_xetex0.rs
+++ b/engine/src/xetex_xetex0.rs
@@ -101,6 +101,7 @@ use crate::{
 };
 use bridge::_tt_abort;
 use libc::{free, memcpy, strcat, strcpy, strlen};
+use crate::xetex_opentype_math::get_ot_math_constant;
 
 pub type size_t = u64;
 /* tectonic/core-bridge.h: declarations of C/C++ => Rust bridge API


### PR DESCRIPTION
I'm planning to clean those unsafe C FFI, I will start from `xetex_opentype_math.rs` because it's relatively small and contains many pure functions that can be easily converted to safe rust code.

It's still work in progress, final goal is every api in this file becomes safe