### PR TITLE
Replace qsort

### DIFF
--- a/dpx/src/dpx_pdfnames.rs
+++ b/dpx/src/dpx_pdfnames.rs
@@ -31,6 +31,8 @@ use crate::mfree;
 use crate::warn;
 use crate::DisplayExt;
 use std::ffi::CStr;
+use std::slice;
+use std::cmp::Ordering;
 
 use super::dpx_dpxutil::{
     ht_append_table, ht_clear_iter, ht_clear_table, ht_init_table, ht_iter_getkey, ht_iter_getval,
@@ -262,9 +264,7 @@ pub unsafe extern "C" fn pdf_names_close_object(
     0i32
 }
 #[inline]
-fn cmp_key(sd1: &named_object, sd2: &named_object) -> ::core::cmp::Ordering {
-    use ::core::cmp::Ordering;
-    use ::core::slice;
+fn cmp_key(sd1: &named_object, sd2: &named_object) -> Ordering {
     if sd1.key.is_null() {
         Ordering::Less
     } else if sd2.key.is_null() {
@@ -436,7 +436,7 @@ pub unsafe extern "C" fn pdf_names_create_tree(
     if flat.is_null() {
         name_tree = 0 as *mut pdf_obj
     } else {
-        ::core::slice::from_raw_parts_mut(
+        slice::from_raw_parts_mut(
             flat,
             *count as usize,
         ).sort_unstable_by(cmp_key);

--- a/dpx/src/dpx_pdfnames.rs
+++ b/dpx/src/dpx_pdfnames.rs
@@ -37,13 +37,12 @@ use super::dpx_dpxutil::{
     ht_iter_next, ht_lookup_table, ht_set_iter,
 };
 use super::dpx_mem::{new, renew};
-use super::qsort;
 use crate::dpx_pdfobj::{
     pdf_add_array, pdf_add_dict, pdf_link_obj, pdf_new_array, pdf_new_dict, pdf_new_null,
     pdf_new_string, pdf_new_undefined, pdf_obj, pdf_obj_typeof, pdf_ref_obj, pdf_release_obj,
     pdf_string_length, pdf_string_value, pdf_transfer_label, PdfObjType,
 };
-use libc::{free, memcmp};
+use libc::free;
 
 pub type size_t = u64;
 pub type __compar_fn_t =

--- a/dpx/src/dpx_t1_char.rs
+++ b/dpx/src/dpx_t1_char.rs
@@ -31,6 +31,7 @@ use super::dpx_mem::new;
 use crate::mfree;
 use crate::warn;
 use libc::{free, memcpy, memset};
+use std::cmp::Ordering;
 
 pub type size_t = u64;
 
@@ -172,14 +173,13 @@ static mut ps_arg_stack: [f64; 194] = [0.; 194];
  *  Convert ghost hint to edge hint, Counter control for hstem3/vstem3.
  */
 #[inline]
-fn stem_compare(s1: &t1_stem, s2: &t1_stem) -> ::core::cmp::Ordering {
-    use ::core::cmp::Ordering;
+fn stem_compare(s1: &t1_stem, s2: &t1_stem) -> Ordering {
     // the order of comparing : dir, pos, del
-    if (*s1).dir == (*s2).dir {
-        (*s1).pos
-            .partial_cmp(&(*s2).pos).unwrap()
-            .then_with(||(*s1).del.partial_cmp(&(*s2).del).unwrap())
-    } else if (*s1).dir == 0 {
+    if s1.dir == s2.dir {
+        s1.pos
+            .partial_cmp(&s2.pos).unwrap()
+            .then_with(||s1.del.partial_cmp(&s2.del).unwrap())
+    } else if s1.dir == 0 {
         Ordering::Less
     } else {
         Ordering::Greater
@@ -1932,7 +1932,7 @@ pub unsafe extern "C" fn t1char_convert_charstring(
         warn!("Stack not empty. ({}, {})", cs_stack_top, ps_stack_top,);
     }
     do_postproc(cd);
-    (*cd).stems[..(*cd).num_stems as usize].sort_unstable_by(stem_compare);
+    cd.stems[..cd.num_stems as usize].sort_unstable_by(stem_compare);
     let length = t1char_encode_charpath(
         cd,
         default_width,

--- a/dpx/src/dpx_t1_char.rs
+++ b/dpx/src/dpx_t1_char.rs
@@ -173,24 +173,18 @@ static mut ps_arg_stack: [f64; 194] = [0.; 194];
  *  Convert ghost hint to edge hint, Counter control for hstem3/vstem3.
  */
 #[inline]
-unsafe extern "C" fn stem_compare(mut v1: *const libc::c_void, mut v2: *const libc::c_void) -> i32 {
-    let mut cmp;
-    let s1 = v1 as *const t1_stem;
-    let s2 = v2 as *const t1_stem;
+fn stem_compare(s1: &t1_stem, s2: &t1_stem) -> ::core::cmp::Ordering {
+    use ::core::cmp::Ordering;
+    // the order of comparing : dir, pos, del
     if (*s1).dir == (*s2).dir {
-        if (*s1).pos == (*s2).pos {
-            if (*s1).del == (*s2).del {
-                cmp = 0i32
-            } else {
-                cmp = if (*s1).del < (*s2).del { -1i32 } else { 1i32 }
-            }
-        } else {
-            cmp = if (*s1).pos < (*s2).pos { -1i32 } else { 1i32 }
-        }
+        (*s1).pos
+            .partial_cmp(&(*s2).pos).unwrap()
+            .then_with(||(*s1).del.partial_cmp(&(*s2).del).unwrap())
+    } else if (*s1).dir == 0 {
+        Ordering::Less
     } else {
-        cmp = if (*s1).dir == 0i32 { -1i32 } else { 1i32 }
+        Ordering::Greater
     }
-    cmp
 }
 unsafe fn get_stem(mut cd: *mut t1_chardesc, mut stem_id: i32) -> i32 {
     let mut i = 0;
@@ -1939,15 +1933,7 @@ pub unsafe extern "C" fn t1char_convert_charstring(
         warn!("Stack not empty. ({}, {})", cs_stack_top, ps_stack_top,);
     }
     do_postproc(cd);
-    qsort(
-        (*cd).stems.as_mut_ptr() as *mut libc::c_void,
-        (*cd).num_stems as size_t,
-        ::std::mem::size_of::<t1_stem>() as u64,
-        Some(
-            stem_compare
-                as unsafe extern "C" fn(_: *const libc::c_void, _: *const libc::c_void) -> i32,
-        ),
-    );
+    (*cd).stems[..(*cd).num_stems as usize].sort_unstable_by(stem_compare);
     let length = t1char_encode_charpath(
         cd,
         default_width,

--- a/dpx/src/dpx_t1_char.rs
+++ b/dpx/src/dpx_t1_char.rs
@@ -29,7 +29,6 @@
 
 use super::dpx_mem::new;
 use crate::mfree;
-use crate::qsort;
 use crate::warn;
 use libc::{free, memcpy, memset};
 

--- a/dpx/src/dpx_tt_glyf.rs
+++ b/dpx/src/dpx_tt_glyf.rs
@@ -458,14 +458,10 @@ pub unsafe extern "C" fn tt_build_tables(mut sfont: *mut sfnt, mut g: *mut tt_gl
         }
     }
     free(w_stat as *mut libc::c_void);
-    qsort(
-        (*g).gd as *mut libc::c_void,
-        (*g).num_glyphs as size_t,
-        ::std::mem::size_of::<tt_glyph_desc>() as u64,
-        Some(
-            glyf_cmp as unsafe extern "C" fn(_: *const libc::c_void, _: *const libc::c_void) -> i32,
-        ),
-    );
+    ::core::slice::from_raw_parts_mut(
+        (*g).gd,
+        (*g).num_glyphs as usize
+    ).sort_unstable_by_key(|sv| sv.gid);
     let mut glyf_table_size = 0u64 as u32;
     let mut num_hm_known = 0;
     let last_advw = (*(*g).gd.offset(((*g).num_glyphs as i32 - 1i32) as isize)).advw;

--- a/dpx/src/dpx_tt_glyf.rs
+++ b/dpx/src/dpx_tt_glyf.rs
@@ -38,7 +38,6 @@ use super::dpx_tt_table::{
     tt_read_vhea_table,
 };
 use crate::dpx_truetype::sfnt_table_info;
-use crate::qsort;
 use crate::{ttstub_input_read};
 use libc::{free, memcpy, memset};
 

--- a/dpx/src/dpx_tt_glyf.rs
+++ b/dpx/src/dpx_tt_glyf.rs
@@ -42,6 +42,7 @@ use crate::{ttstub_input_read};
 use libc::{free, memcpy, memset};
 
 use std::io::{Seek, SeekFrom};
+use std::slice;
 
 pub type __ssize_t = i64;
 pub type size_t = u64;
@@ -457,7 +458,7 @@ pub unsafe extern "C" fn tt_build_tables(mut sfont: *mut sfnt, mut g: *mut tt_gl
         }
     }
     free(w_stat as *mut libc::c_void);
-    ::core::slice::from_raw_parts_mut(
+    slice::from_raw_parts_mut(
         (*g).gd,
         (*g).num_glyphs as usize
     ).sort_unstable_by_key(|sv| sv.gid);

--- a/dpx/src/lib.rs
+++ b/dpx/src/lib.rs
@@ -211,11 +211,7 @@ pub mod specials;
 
 pub use crate::dpx_dvipdfmx::dvipdfmx_main;
 
-pub type __ComparFn =
-    Option<unsafe extern "C" fn(_: *const libc::c_void, _: *const libc::c_void) -> i32>;
 extern "C" {
-    #[no_mangle]
-    fn qsort(__base: *mut libc::c_void, __nmemb: size_t, __size: size_t, __compar: __ComparFn);
     #[no_mangle]
     fn strtoll(_: *const i8, _: *mut *mut i8, _: i32) -> libc::c_longlong;
     #[no_mangle]


### PR DESCRIPTION
#79 
Replace `qsort` with `slice::sort_unstable*` in
- dpx/src/dpx_pdfnames.rs
- dpx/src/dpx_tt_glyf.rs
- dpx/src/dpx_t1_char.rs