### PR TITLE
Rebuild control flow

### DIFF
--- a/dpx/src/dpx_epdf.rs
+++ b/dpx/src/dpx_epdf.rs
@@ -414,14 +414,13 @@ pub unsafe extern "C" fn pdf_include_page(
     mut ident: *const i8,
     mut options: load_options,
 ) -> i32 {
-    let mut current_block: u64;
     let mut info = xform_info::default();
     let mut contents: *mut pdf_obj = 0 as *mut pdf_obj;
     let mut resources: *mut pdf_obj = 0 as *mut pdf_obj;
     let mut markinfo: *mut pdf_obj = 0 as *mut pdf_obj;
     let pf = pdf_open(ident, handle);
     if pf.is_null() {
-        return -1i32;
+        return -1;
     }
     if pdf_file_get_version(pf) > pdf_get_version() {
         warn!(
@@ -441,122 +440,114 @@ pub unsafe extern "C" fn pdf_include_page(
         &mut info.matrix,
         &mut resources,
     );
-    if !page.is_null() {
-        let catalog = pdf_file_get_catalog(pf);
-        markinfo = pdf_deref_obj(pdf_lookup_dict(catalog, "MarkInfo"));
-        if !markinfo.is_null() {
-            let mut tmp: *mut pdf_obj = pdf_deref_obj(pdf_lookup_dict(markinfo, "Marked"));
-            pdf_release_obj(markinfo);
-            if !(!tmp.is_null() && (*tmp).is_boolean()) {
-                pdf_release_obj(tmp);
-                current_block = 3699483483911207084;
-            } else {
-                if pdf_boolean_value(tmp) != 0 {
-                    warn!("PDF file is tagged... Ignoring tags.");
-                }
-                pdf_release_obj(tmp);
-                current_block = 1109700713171191020;
-            }
-        } else {
-            current_block = 1109700713171191020;
-        }
-        match current_block {
-            1109700713171191020 => {
-                contents = pdf_deref_obj(pdf_lookup_dict(page, "Contents"));
-                pdf_release_obj(page);
-                page = 0 as *mut pdf_obj;
-                /*
-                 * Handle page content stream.
-                 */
-                let mut content_new: *mut pdf_obj = 0 as *mut pdf_obj;
-                if contents.is_null() {
-                    /*
-                     * Empty page
-                     */
-                    content_new = pdf_new_stream(0i32);
-                    current_block = 2480299350034459858;
-                /* TODO: better don't include anything if the page is empty */
-                } else if !contents.is_null() && (*contents).is_stream() {
-                    /*
-                     * We must import the stream because its dictionary
-                     * may contain indirect references.
-                     */
-                    content_new = pdf_import_object(contents);
-                    current_block = 2480299350034459858;
-                } else if !contents.is_null() && (*contents).is_array() {
-                    /*
-                     * Concatenate all content streams.
-                     */
-                    let mut len: i32 = pdf_array_length(contents) as i32;
-                    content_new = pdf_new_stream(1i32 << 0i32);
-                    let mut idx = 0;
-                    loop {
-                        if !(idx < len) {
-                            current_block = 2480299350034459858;
-                            break;
-                        }
-                        let mut content_seg: *mut pdf_obj =
-                            pdf_deref_obj(Some(pdf_get_array(contents, idx)));
-                        if !(!content_seg.is_null()
-                            && (*content_seg).is_stream())
-                            || pdf_concat_stream(content_new, content_seg) < 0i32
-                        {
-                            pdf_release_obj(content_seg);
-                            pdf_release_obj(content_new);
-                            current_block = 3699483483911207084;
-                            break;
-                        } else {
-                            pdf_release_obj(content_seg);
-                            idx += 1
-                        }
-                    }
-                } else {
-                    current_block = 3699483483911207084;
-                }
-                match current_block {
-                    3699483483911207084 => {}
-                    _ => {
-                        pdf_release_obj(contents);
-                        contents = content_new;
-                        /*
-                         * Add entries to contents stream dictionary.
-                         */
-                        let contents_dict = pdf_stream_dict(contents);
-                        pdf_add_dict(contents_dict, "Type", pdf_new_name("XObject"));
-                        pdf_add_dict(contents_dict, "Subtype", pdf_new_name("Form"));
-                        pdf_add_dict(contents_dict, "FormType", pdf_new_number(1.0f64));
-                        let bbox = pdf_new_array();
-                        pdf_add_array(bbox, pdf_new_number(info.bbox.ll.x));
-                        pdf_add_array(bbox, pdf_new_number(info.bbox.ll.y));
-                        pdf_add_array(bbox, pdf_new_number(info.bbox.ur.x));
-                        pdf_add_array(bbox, pdf_new_number(info.bbox.ur.y));
-                        pdf_add_dict(contents_dict, "BBox", bbox);
-                        let matrix = pdf_new_array();
-                        pdf_add_array(matrix, pdf_new_number(info.matrix.a));
-                        pdf_add_array(matrix, pdf_new_number(info.matrix.b));
-                        pdf_add_array(matrix, pdf_new_number(info.matrix.c));
-                        pdf_add_array(matrix, pdf_new_number(info.matrix.d));
-                        pdf_add_array(matrix, pdf_new_number(info.matrix.e));
-                        pdf_add_array(matrix, pdf_new_number(info.matrix.f));
-                        pdf_add_dict(contents_dict, "Matrix", matrix);
-                        pdf_add_dict(contents_dict, "Resources", pdf_import_object(resources));
-                        pdf_release_obj(resources);
-                        pdf_close(pf);
-                        pdf_ximage_set_form(ximage, &mut info, contents);
-                        return 0i32;
-                    }
-                }
-            }
-            _ => {}
-        }
+
+    let error_silent = move || {
+        pdf_release_obj(resources);
+        pdf_release_obj(markinfo);
+        pdf_release_obj(page);
+        pdf_release_obj(contents);
+        pdf_close(pf);
+    };
+    let error = || {
         warn!("Cannot parse document. Broken PDF file?");
+        error_silent();
+    };
+
+    if page.is_null() {
+        error_silent();
+        return -1;
     }
-    pdf_release_obj(resources);
-    pdf_release_obj(markinfo);
+
+    let catalog = pdf_file_get_catalog(pf);
+    markinfo = pdf_deref_obj(pdf_lookup_dict(catalog, "MarkInfo"));
+    if !markinfo.is_null() {
+        let mut tmp: *mut pdf_obj = pdf_deref_obj(pdf_lookup_dict(markinfo, "Marked"));
+        pdf_release_obj(markinfo);
+        if tmp.is_null() || !(*tmp).is_boolean() {
+            pdf_release_obj(tmp);
+            error();
+            return -1;
+        } else if pdf_boolean_value(tmp) != 0 {
+            warn!("PDF file is tagged... Ignoring tags.");
+        }
+        pdf_release_obj(tmp);
+    }
+
+    contents = pdf_deref_obj(pdf_lookup_dict(page, "Contents"));
     pdf_release_obj(page);
+    /*
+     * Handle page content stream.
+     */
+    let mut content_new: *mut pdf_obj;
+    if contents.is_null() {
+        /*
+         * Empty page
+         */
+        content_new = pdf_new_stream(0i32);
+        /* TODO: better don't include anything if the page is empty */
+    } else if !contents.is_null() && (*contents).is_stream() {
+        /*
+         * We must import the stream because its dictionary
+         * may contain indirect references.
+         */
+        content_new = pdf_import_object(contents);
+    } else if !contents.is_null() && (*contents).is_array() {
+        /*
+         * Concatenate all content streams.
+         */
+        let mut len: i32 = pdf_array_length(contents) as i32;
+        content_new = pdf_new_stream(1i32 << 0i32);
+        for idx in 0..len {
+            let mut content_seg: *mut pdf_obj =
+                pdf_deref_obj(Some(pdf_get_array(contents, idx)));
+            if content_seg.is_null()
+            || !(*content_seg).is_stream()
+            || pdf_concat_stream(content_new, content_seg) < 0
+            {
+                pdf_release_obj(content_seg);
+                pdf_release_obj(content_new);
+                error();
+                return -1;
+            }
+            pdf_release_obj(content_seg);
+        }
+    } else {
+        error();
+        return -1;
+    }
+
     pdf_release_obj(contents);
+    contents = content_new;
+
+    /*
+     * Add entries to contents stream dictionary.
+     */
+    let contents_dict = pdf_stream_dict(contents);
+    pdf_add_dict(contents_dict, "Type", pdf_new_name("XObject"));
+    pdf_add_dict(contents_dict, "Subtype", pdf_new_name("Form"));
+    pdf_add_dict(contents_dict, "FormType", pdf_new_number(1.0f64));
+    let bbox = pdf_new_array();
+    pdf_add_array(bbox, pdf_new_number(info.bbox.ll.x));
+    pdf_add_array(bbox, pdf_new_number(info.bbox.ll.y));
+    pdf_add_array(bbox, pdf_new_number(info.bbox.ur.x));
+    pdf_add_array(bbox, pdf_new_number(info.bbox.ur.y));
+    pdf_add_dict(contents_dict, "BBox", bbox);
+    let matrix = pdf_new_array();
+    pdf_add_array(matrix, pdf_new_number(info.matrix.a));
+    pdf_add_array(matrix, pdf_new_number(info.matrix.b));
+    pdf_add_array(matrix, pdf_new_number(info.matrix.c));
+    pdf_add_array(matrix, pdf_new_number(info.matrix.d));
+    pdf_add_array(matrix, pdf_new_number(info.matrix.e));
+    pdf_add_array(matrix, pdf_new_number(info.matrix.f));
+    pdf_add_dict(contents_dict, "Matrix", matrix);
+    pdf_add_dict(contents_dict, "Resources", pdf_import_object(resources));
+    pdf_release_obj(resources);
+
     pdf_close(pf);
-    -1i32
+
+    pdf_ximage_set_form(ximage, &mut info, contents);
+
+    0
 }
 /*static mut pdf_operators: [operator; 39] = [
     {

--- a/dpx/src/dpx_jpegimage.rs
+++ b/dpx/src/dpx_jpegimage.rs
@@ -525,7 +525,7 @@ unsafe fn read_APP1_Exif(
     let mut xres_ms: u32 = 0_u32;
     let mut yres_ms: u32 = 0_u32;
     let mut res_unit_ms: f64 = 0.0f64;
-    let mut buffer_box: Box<[u8]> = Box::new_uninit_slice(length as usize).assume_init(); // auto destruct
+    let mut buffer_box: Box<[u8]> = vec![0u8; length as usize].into_boxed_slice(); // auto destruct
     let buffer = buffer_box.as_mut_ptr();
     let r = ttstub_input_read(handle.0.as_ptr(), buffer as *mut i8, length);
     if r < 0 || r as size_t != length {

--- a/dpx/src/dpx_mpost.rs
+++ b/dpx/src/dpx_mpost.rs
@@ -3017,7 +3017,6 @@ unsafe fn do_operator(mut token: *const i8, mut x_user: f64, mut y_user: f64) ->
     let mut matrix = TMatrix::new();
     let mut cp = Coord::zero();
     let opcode = get_opcode(token);
-    let mut current_block_294: u64;
     match opcode {
         1 => {
             /*
@@ -3395,9 +3394,7 @@ unsafe fn do_operator(mut token: *const i8, mut x_user: f64, mut y_user: f64) ->
             if !tmp.is_null() && (*tmp).is_array() {
                 error = cvr_array(tmp, values.as_mut_ptr(), 6i32);
                 tmp = 0 as *mut pdf_obj;
-                if error != 0 {
-                    current_block_294 = 9125367800366194000;
-                } else {
+                if error == 0 {
                     matrix.a = values[0];
                     matrix.b = values[1];
                     matrix.c = values[2];
@@ -3411,53 +3408,47 @@ unsafe fn do_operator(mut token: *const i8, mut x_user: f64, mut y_user: f64) ->
                         0 as *mut pdf_obj
                     };
                     has_matrix = 1i32;
-                    current_block_294 = 15375688482130298215;
                 }
-            } else {
-                current_block_294 = 15375688482130298215;
-            }
-            match current_block_294 {
-                9125367800366194000 => {}
-                _ => {
+            } 
+            if error == 0 {
+                if !(!tmp.is_null() && (*tmp).is_number()) {
+                    error = 1i32
+                } else {
+                    cp.y = pdf_number_value(tmp);
+                    pdf_release_obj(tmp);
+                    tmp = if top_stack > 0_u32 {
+                        top_stack = top_stack.wrapping_sub(1);
+                        stack[top_stack as usize]
+                    } else {
+                        0 as *mut pdf_obj
+                    };
                     if !(!tmp.is_null() && (*tmp).is_number()) {
                         error = 1i32
                     } else {
-                        cp.y = pdf_number_value(tmp);
+                        cp.x = pdf_number_value(tmp);
                         pdf_release_obj(tmp);
-                        tmp = if top_stack > 0_u32 {
-                            top_stack = top_stack.wrapping_sub(1);
-                            stack[top_stack as usize]
-                        } else {
-                            0 as *mut pdf_obj
-                        };
-                        if !(!tmp.is_null() && (*tmp).is_number()) {
-                            error = 1i32
-                        } else {
-                            cp.x = pdf_number_value(tmp);
-                            pdf_release_obj(tmp);
-                            if has_matrix == 0 {
-                                ps_dev_CTM(&mut matrix);
-                                /* Here, we need real PostScript CTM */
-                            } /* This does pdf_release_obj() */
-                            pdf_dev_dtransform(&mut cp, Some(&mut matrix));
+                        if has_matrix == 0 {
+                            ps_dev_CTM(&mut matrix);
+                            /* Here, we need real PostScript CTM */
+                        } /* This does pdf_release_obj() */
+                        pdf_dev_dtransform(&mut cp, Some(&mut matrix));
+                        if top_stack < 1024_u32 {
+                            let fresh14 = top_stack;
+                            top_stack = top_stack.wrapping_add(1);
+                            stack[fresh14 as usize] = pdf_new_number(cp.x);
                             if top_stack < 1024_u32 {
-                                let fresh14 = top_stack;
+                                let fresh15 = top_stack;
                                 top_stack = top_stack.wrapping_add(1);
-                                stack[fresh14 as usize] = pdf_new_number(cp.x);
-                                if top_stack < 1024_u32 {
-                                    let fresh15 = top_stack;
-                                    top_stack = top_stack.wrapping_add(1);
-                                    stack[fresh15 as usize] = pdf_new_number(cp.y)
-                                } else {
-                                    warn!("PS stack overflow including MetaPost file or inline PS code");
-                                    error = 1i32
-                                }
+                                stack[fresh15 as usize] = pdf_new_number(cp.y)
                             } else {
-                                warn!(
-                                    "PS stack overflow including MetaPost file or inline PS code"
-                                );
+                                warn!("PS stack overflow including MetaPost file or inline PS code");
                                 error = 1i32
                             }
+                        } else {
+                            warn!(
+                                "PS stack overflow including MetaPost file or inline PS code"
+                            );
+                            error = 1i32
                         }
                     }
                 }
@@ -3474,9 +3465,7 @@ unsafe fn do_operator(mut token: *const i8, mut x_user: f64, mut y_user: f64) ->
             if !tmp.is_null() && (*tmp).is_array() {
                 error = cvr_array(tmp, values.as_mut_ptr(), 6i32);
                 tmp = 0 as *mut pdf_obj;
-                if error != 0 {
-                    current_block_294 = 9125367800366194000;
-                } else {
+                if error == 0 {
                     matrix.a = values[0];
                     matrix.b = values[1];
                     matrix.c = values[2];
@@ -3490,53 +3479,47 @@ unsafe fn do_operator(mut token: *const i8, mut x_user: f64, mut y_user: f64) ->
                         0 as *mut pdf_obj
                     };
                     has_matrix_0 = 1i32;
-                    current_block_294 = 9910899284672532069;
                 }
-            } else {
-                current_block_294 = 9910899284672532069;
-            }
-            match current_block_294 {
-                9125367800366194000 => {}
-                _ => {
+            } 
+            if error == 0 {
+                if !(!tmp.is_null() && (*tmp).is_number()) {
+                    error = 1i32
+                } else {
+                    cp.y = pdf_number_value(tmp);
+                    pdf_release_obj(tmp);
+                    tmp = if top_stack > 0_u32 {
+                        top_stack = top_stack.wrapping_sub(1);
+                        stack[top_stack as usize]
+                    } else {
+                        0 as *mut pdf_obj
+                    };
                     if !(!tmp.is_null() && (*tmp).is_number()) {
                         error = 1i32
                     } else {
-                        cp.y = pdf_number_value(tmp);
+                        cp.x = pdf_number_value(tmp);
                         pdf_release_obj(tmp);
-                        tmp = if top_stack > 0_u32 {
-                            top_stack = top_stack.wrapping_sub(1);
-                            stack[top_stack as usize]
-                        } else {
-                            0 as *mut pdf_obj
-                        };
-                        if !(!tmp.is_null() && (*tmp).is_number()) {
-                            error = 1i32
-                        } else {
-                            cp.x = pdf_number_value(tmp);
-                            pdf_release_obj(tmp);
-                            if has_matrix_0 == 0 {
-                                ps_dev_CTM(&mut matrix);
-                                /* Here, we need real PostScript CTM */
-                            }
-                            pdf_dev_idtransform(&mut cp, Some(&matrix));
+                        if has_matrix_0 == 0 {
+                            ps_dev_CTM(&mut matrix);
+                            /* Here, we need real PostScript CTM */
+                        }
+                        pdf_dev_idtransform(&mut cp, Some(&matrix));
+                        if top_stack < 1024_u32 {
+                            let fresh16 = top_stack;
+                            top_stack = top_stack.wrapping_add(1);
+                            stack[fresh16 as usize] = pdf_new_number(cp.x);
                             if top_stack < 1024_u32 {
-                                let fresh16 = top_stack;
+                                let fresh17 = top_stack;
                                 top_stack = top_stack.wrapping_add(1);
-                                stack[fresh16 as usize] = pdf_new_number(cp.x);
-                                if top_stack < 1024_u32 {
-                                    let fresh17 = top_stack;
-                                    top_stack = top_stack.wrapping_add(1);
-                                    stack[fresh17 as usize] = pdf_new_number(cp.y)
-                                } else {
-                                    warn!("PS stack overflow including MetaPost file or inline PS code");
-                                    error = 1i32
-                                }
+                                stack[fresh17 as usize] = pdf_new_number(cp.y)
                             } else {
-                                warn!(
-                                    "PS stack overflow including MetaPost file or inline PS code"
-                                );
+                                warn!("PS stack overflow including MetaPost file or inline PS code");
                                 error = 1i32
                             }
+                        } else {
+                            warn!(
+                                "PS stack overflow including MetaPost file or inline PS code"
+                            );
+                            error = 1i32
                         }
                     }
                 }

--- a/dpx/src/dpx_numbers.rs
+++ b/dpx/src/dpx_numbers.rs
@@ -119,34 +119,22 @@ pub unsafe extern "C" fn get_unsigned_quad(mut file: *mut FILE) -> u32 {
 #[no_mangle]
 pub unsafe extern "C" fn get_unsigned_num(mut file: *mut FILE, mut num: u8) -> u32 {
     let mut val = get_unsigned_byte(file) as u32;
-    let mut current_block_4: u64;
-    match num as i32 {
+    match num {
         3 => {
             if val > 0x7f_u32 {
-                val = (val as u32).wrapping_sub(0x100_u32) as u32
+                val = val.wrapping_sub(0x100_u32);
             }
-            val = val << 8i32 | get_unsigned_byte(file) as u32;
-            current_block_4 = 10942825333195857913;
+            val = (val << 8) | get_unsigned_byte(file) as u32;
+            val = (val << 8) | get_unsigned_byte(file) as u32;
+            val = (val << 8) | get_unsigned_byte(file) as u32;
         }
         2 => {
-            current_block_4 = 10942825333195857913;
+            val = (val << 8) | get_unsigned_byte(file) as u32;
+            val = (val << 8) | get_unsigned_byte(file) as u32;
         }
         1 => {
-            current_block_4 = 17819358871496454702;
+            val = (val << 8) | get_unsigned_byte(file) as u32;
         }
-        _ => {
-            current_block_4 = 7815301370352969686;
-        }
-    }
-    match current_block_4 {
-        10942825333195857913 => {
-            val = val << 8i32 | get_unsigned_byte(file) as u32;
-            current_block_4 = 17819358871496454702;
-        }
-        _ => {}
-    }
-    match current_block_4 {
-        17819358871496454702 => val = val << 8i32 | get_unsigned_byte(file) as u32,
         _ => {}
     }
     val
@@ -268,39 +256,21 @@ pub unsafe extern "C" fn tt_get_signed_quad(handle: &mut InputHandleWrapper) -> 
 #[no_mangle]
 pub unsafe extern "C" fn tt_get_unsigned_num(handle: &mut InputHandleWrapper, mut num: u8) -> u32 {
     let mut val: u32 = tt_get_unsigned_byte(handle) as u32;
-    let mut current_block_4: u64;
-    match num as i32 {
+    match num {
         3 => {
             if val > 0x7f_u32 {
-                val = (val as u32).wrapping_sub(0x100_u32) as u32 as u32
+                val = val.wrapping_sub(0x100_u32);
             }
-            val = val << 8i32 | tt_get_unsigned_byte(handle) as u32;
-            current_block_4 = 13589375657124263157;
+            val = (val << 8) | tt_get_unsigned_byte(handle) as u32;
+            val = (val << 8) | tt_get_unsigned_byte(handle) as u32;
+            val = (val << 8) | tt_get_unsigned_byte(handle) as u32;
         }
         2 => {
-            current_block_4 = 13589375657124263157;
+            val = (val << 8) | tt_get_unsigned_byte(handle) as u32;
+            val = (val << 8) | tt_get_unsigned_byte(handle) as u32;
         }
         1 => {
-            current_block_4 = 17178013025578009494;
-        }
-        _ => {
-            current_block_4 = 7815301370352969686;
-        }
-    }
-    match current_block_4 {
-        13589375657124263157 =>
-        /* fall through */
-        {
-            val = val << 8i32 | tt_get_unsigned_byte(handle) as u32;
-            current_block_4 = 17178013025578009494;
-        }
-        _ => {}
-    }
-    match current_block_4 {
-        17178013025578009494 =>
-        /* fall through */
-        {
-            val = val << 8i32 | tt_get_unsigned_byte(handle) as u32
+            val = (val << 8) | tt_get_unsigned_byte(handle) as u32;
         }
         _ => {}
     }

--- a/dpx/src/dpx_pdfdev.rs
+++ b/dpx/src/dpx_pdfdev.rs
@@ -691,32 +691,21 @@ unsafe fn text_mode() {
 }
 #[no_mangle]
 pub unsafe extern "C" fn graphics_mode() {
-    let mut current_block_3: u64;
     match motion_state {
-        MotionState::STRING_MODE => {
-            pdf_doc_add_page_content(if text_state.is_mb != 0 {
-                b">]TJ"
-            } else {
-                b")]TJ"
-            });
-            current_block_3 = 13064676843759196241;
-        }
-        MotionState::TEXT_MODE => {
-            current_block_3 = 13064676843759196241;
-        }
-        MotionState::GRAPHICS_MODE => {
-            current_block_3 = 11875828834189669668;
-        }
-    }
-    match current_block_3 {
-        13064676843759196241 =>
-        /* continue */
-        {
+        MotionState::GRAPHICS_MODE => {}
+        MotionState::STRING_MODE|MotionState::TEXT_MODE => {
+            if let MotionState::STRING_MODE = motion_state {
+                pdf_doc_add_page_content(if text_state.is_mb != 0 {
+                    b">]TJ"
+                } else {
+                    b")]TJ"
+                });
+            }
+            
             pdf_doc_add_page_content(b" ET"); /* op: ET */
             text_state.force_reset = 0i32;
             text_state.font_id = -1i32
         }
-        _ => {}
     }
     motion_state = MotionState::GRAPHICS_MODE;
 }

--- a/dpx/src/dpx_pdfdev.rs
+++ b/dpx/src/dpx_pdfdev.rs
@@ -904,23 +904,12 @@ unsafe fn string_mode(
     mut extend: f64,
     mut rotate: TextWMode,
 ) {
-    let mut current_block_7: u64;
     match motion_state {
-        MotionState::GRAPHICS_MODE => {
-            reset_text_state();
-            current_block_7 = 1909977495246269370;
-        }
-        MotionState::TEXT_MODE => {
-            current_block_7 = 1909977495246269370;
-        }
-        MotionState::STRING_MODE => {
-            current_block_7 = 3640593987805443782;
-        }
-    }
-    match current_block_7 {
-        1909977495246269370 =>
-        /* continue */
-        {
+        MotionState::GRAPHICS_MODE|MotionState::TEXT_MODE => {
+            if let MotionState::GRAPHICS_MODE = motion_state {
+                reset_text_state();
+            }
+            
             if text_state.force_reset != 0 {
                 dev_set_text_matrix(xpos, ypos, slant, extend, rotate); /* op: */
                 pdf_doc_add_page_content(if text_state.is_mb != 0 { b"[<" } else { b"[(" });
@@ -929,7 +918,7 @@ unsafe fn string_mode(
                 start_string(xpos, ypos, slant, extend, rotate);
             }
         }
-        _ => {}
+        MotionState::STRING_MODE => {}
     }
     motion_state = MotionState::STRING_MODE;
 }

--- a/dpx/src/dpx_pdfnames.rs
+++ b/dpx/src/dpx_pdfnames.rs
@@ -347,6 +347,9 @@ unsafe fn flat_table(
                 let mut new_obj: *mut pdf_obj =
                     ht_lookup_table(filter, key as *const libc::c_void, keylen) as *mut pdf_obj;
                 if new_obj.is_null() {
+                    if !(ht_iter_next(&mut iter) >= 0) {
+                        break;
+                    }
                     continue;
                 }
                 key = pdf_string_value(new_obj) as *mut i8;

--- a/dpx/src/dpx_type1.rs
+++ b/dpx/src/dpx_type1.rs
@@ -907,7 +907,6 @@ pub unsafe extern "C" fn pdf_font_load_type1(mut font: *mut pdf_font) -> i32 {
     let cstring = cff_new_index((*cffont.cstrings).count);
     (*cstring).data = 0 as *mut u8;
     *(*cstring).offset.offset(0) = 1i32 as l_offset;
-    let mut current_block_150: u64;
     /* The num_glyphs increases if "seac" operators are used. */
     let mut gid_0 = 0_u16;
     while (gid_0 as i32) < num_glyphs as i32 {
@@ -959,13 +958,13 @@ pub unsafe extern "C" fn pdf_font_load_type1(mut font: *mut pdf_font) -> i32 {
                     "Accent char \"{}\" not found. Invalid use of \"seac\" operator.",
                     CStr::from_ptr(achar_name).display(),
                 );
-                current_block_150 = 1069630499025798221;
+                continue;
             } else if bchar_gid < 0i32 {
                 warn!(
                     "Base char \"{}\" not found. Invalid use of \"seac\" operator.",
                     CStr::from_ptr(bchar_name).display(),
                 );
-                current_block_150 = 1069630499025798221;
+                continue;
             } else {
                 let mut i = 0;
                 while i < num_glyphs as i32 {
@@ -1009,16 +1008,10 @@ pub unsafe extern "C" fn pdf_font_load_type1(mut font: *mut pdf_font) -> i32 {
                         cff_get_seac_sid(cffont, bchar_name) as s_SID;
                     (*charset).num_entries = ((*charset).num_entries as i32 + 1i32) as u16
                 }
-                current_block_150 = 17100064147490331435;
             }
-        } else {
-            current_block_150 = 17100064147490331435;
         }
-        match current_block_150 {
-            17100064147490331435 => *widths.offset(gid_0 as isize) = gm.wx,
-            _ => {}
-        }
-        gid_0 = gid_0.wrapping_add(1)
+        *widths.offset(gid_0 as isize) = gm.wx;
+        gid_0 = gid_0.wrapping_add(1);
     }
     (*cstring).count = num_glyphs;
     cff_release_index(*cffont.subrs.offset(0));

--- a/dpx/src/dpx_vf.rs
+++ b/dpx/src/dpx_vf.rs
@@ -354,46 +354,16 @@ unsafe fn unsigned_byte(mut start: *mut *mut u8, mut end: *mut u8) -> i32 {
 unsafe fn get_pkt_signed_num(mut start: *mut *mut u8, mut end: *mut u8, mut num: u8) -> i32 {
     let mut val;
     if end.wrapping_offset_from(*start) as i64 > num as i64 {
-        let fresh11 = *start;
+        val = **start as i32;
         *start = (*start).offset(1);
-        val = *fresh11 as i32;
         if val > 0x7fi32 {
             val -= 0x100i32
         }
-        let mut current_block_5: u64;
-        match num as i32 {
-            3 => {
-                let fresh12 = *start;
+        if 1 <= num && num <=3 {
+            for _ in 0..num {
+                val = (val << 8) | **start as i32;
                 *start = (*start).offset(1);
-                val = val << 8i32 | *fresh12 as i32;
-                current_block_5 = 9698575669066167445;
             }
-            2 => {
-                current_block_5 = 9698575669066167445;
-            }
-            1 => {
-                current_block_5 = 18113473374131038547;
-            }
-            _ => {
-                current_block_5 = 13183875560443969876;
-            }
-        }
-        match current_block_5 {
-            9698575669066167445 => {
-                let fresh13 = *start;
-                *start = (*start).offset(1);
-                val = val << 8i32 | *fresh13 as i32;
-                current_block_5 = 18113473374131038547;
-            }
-            _ => {}
-        }
-        match current_block_5 {
-            18113473374131038547 => {
-                let fresh14 = *start;
-                *start = (*start).offset(1);
-                val = val << 8i32 | *fresh14 as i32
-            }
-            _ => {}
         }
     } else {
         panic!("Premature end of DVI byte stream in VF font\n");
@@ -403,44 +373,29 @@ unsafe fn get_pkt_signed_num(mut start: *mut *mut u8, mut end: *mut u8, mut num:
 unsafe fn get_pkt_unsigned_num(mut start: *mut *mut u8, mut end: *mut u8, mut num: u8) -> i32 {
     let mut val;
     if end.wrapping_offset_from(*start) as i64 > num as i64 {
-        let fresh15 = *start;
+        val = **start as i32;
         *start = (*start).offset(1);
-        val = *fresh15 as i32;
-        let mut current_block_5: u64;
         match num as i32 {
             3 => {
                 if val > 0x7fi32 {
                     val -= 0x100i32
                 }
-                let fresh16 = *start;
+                val = (val << 8) | **start as i32;
                 *start = (*start).offset(1);
-                val = val << 8i32 | *fresh16 as i32;
-                current_block_5 = 5559910912116893431;
+                val = (val << 8) | **start as i32;
+                *start = (*start).offset(1);
+                val = (val << 8) | **start as i32;
+                *start = (*start).offset(1);
             }
             2 => {
-                current_block_5 = 5559910912116893431;
+                val = (val << 8) | **start as i32;
+                *start = (*start).offset(1);
+                val = (val << 8) | **start as i32;
+                *start = (*start).offset(1);
             }
             1 => {
-                current_block_5 = 15700427407090132107;
-            }
-            _ => {
-                current_block_5 = 13183875560443969876;
-            }
-        }
-        match current_block_5 {
-            5559910912116893431 => {
-                let fresh17 = *start;
+                val = (val << 8) | **start as i32;
                 *start = (*start).offset(1);
-                val = val << 8i32 | *fresh17 as i32;
-                current_block_5 = 15700427407090132107;
-            }
-            _ => {}
-        }
-        match current_block_5 {
-            15700427407090132107 => {
-                let fresh18 = *start;
-                *start = (*start).offset(1);
-                val = val << 8i32 | *fresh18 as i32
             }
             _ => {}
         }

--- a/dpx/src/lib.rs
+++ b/dpx/src/lib.rs
@@ -2,6 +2,7 @@
 #![feature(ptr_wrapping_offset_from)]
 #![feature(c_variadic)]
 #![feature(const_transmute)]
+#![feature(new_uninit)]
 #![allow(unused_unsafe)]
 #![deny(unused_assignments)]
 #![deny(clippy::reverse_range_loop)]

--- a/dpx/src/lib.rs
+++ b/dpx/src/lib.rs
@@ -2,7 +2,6 @@
 #![feature(ptr_wrapping_offset_from)]
 #![feature(c_variadic)]
 #![feature(const_transmute)]
-#![feature(new_uninit)]
 #![allow(unused_unsafe)]
 #![deny(unused_assignments)]
 #![deny(clippy::reverse_range_loop)]


### PR DESCRIPTION
#38 
It will be easier to review if you compare the code with the original C code.
Explanation:
- `flat_table` in dpx/src/dpx_pdfnames.rs
problems about `continue` in `do ... while` block.
- `pdf_font_load_type1` in dpx/src/dpx_type1.rs
problems about `continue` in `for` block.
- `graphics_mode` in dpx/src/dpx_pdfdev.rs, `get_unsigned_num` and `tt_get_unsigned_num` in dpx/src/dpx_number.rs, `get_pkt_signed_num` and `get_pkt_unsigned_num` in dpx/src/dpx_vf.rs
problems about fallthrough in `swicth` block.
- `do_operator` in dpx/src/dpx_mpost.rs, `read_APP1_Exif` in dpx/src/dpx_jpegimage.rs, `load_image` in dpx/src/dpx_pdfximage.rs
the original C code use `goto` to handle errors.