### PR TITLE
Simplify initialization of some static variables

### DIFF
--- a/dpx/src/dpx_cff_dict.rs
+++ b/dpx/src/dpx_cff_dict.rs
@@ -94,432 +94,249 @@ pub unsafe extern "C" fn cff_release_dict(mut dict: *mut cff_dict) {
 static mut stack_top: i32 = 0i32;
 static mut arg_stack: [f64; 64] = [0.; 64];
 static mut dict_operator: [C2RustUnnamed_2; 61] = [
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"version\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 3i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"version\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 3i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"Notice\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 3i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"Notice\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 3i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"FullName\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 3i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"FullName\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 3i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"FamilyName\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 3i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"FamilyName\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 3i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"Weight\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 3i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"Weight\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 3i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"FontBBox\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 4i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"FontBBox\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 4i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"BlueValues\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 5i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"BlueValues\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 5i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"OtherBlues\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 5i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"OtherBlues\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 5i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"FamilyBlues\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 5i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"FamilyBlues\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 5i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"FamilyOtherBlues\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 5i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"FamilyOtherBlues\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 5i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"StdHW\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"StdHW\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 0i32 | 1i32 << 1i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"StdVW\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"StdVW\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 0i32 | 1i32 << 1i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: 0 as *const i8,
-            argtype: -1i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: 0 as *const i8,
+        argtype: -1i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"UniqueID\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"UniqueID\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 0i32 | 1i32 << 1i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"XUID\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 4i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"XUID\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 4i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"charset\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 7i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"charset\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 7i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"Encoding\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 7i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"Encoding\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 7i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"CharStrings\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 7i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"CharStrings\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 7i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"Private\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 8i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"Private\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 8i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"Subrs\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 7i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"Subrs\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 7i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"defaultWidthX\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"defaultWidthX\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 0i32 | 1i32 << 1i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"nominalWidthX\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"nominalWidthX\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 0i32 | 1i32 << 1i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"Copyright\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 3i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"Copyright\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 3i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"IsFixedPitch\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 2i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"IsFixedPitch\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 2i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"ItalicAngle\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"ItalicAngle\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 0i32 | 1i32 << 1i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"UnderlinePosition\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"UnderlinePosition\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 0i32 | 1i32 << 1i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"UnderlineThickness\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"UnderlineThickness\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 0i32 | 1i32 << 1i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"PaintType\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"PaintType\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 0i32 | 1i32 << 1i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"CharstringType\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"CharstringType\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 0i32 | 1i32 << 1i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"FontMatrix\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 4i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"FontMatrix\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 4i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"StrokeWidth\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"StrokeWidth\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 0i32 | 1i32 << 1i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"BlueScale\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"BlueScale\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 0i32 | 1i32 << 1i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"BlueShift\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"BlueShift\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 0i32 | 1i32 << 1i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"BlueFuzz\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"BlueFuzz\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 0i32 | 1i32 << 1i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"StemSnapH\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 5i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"StemSnapH\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 5i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"StemSnapV\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 5i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"StemSnapV\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 5i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"ForceBold\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 2i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"ForceBold\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 2i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: 0 as *const i8,
-            argtype: -1i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: 0 as *const i8,
+        argtype: -1i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: 0 as *const i8,
-            argtype: -1i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: 0 as *const i8,
+        argtype: -1i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"LanguageGroup\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"LanguageGroup\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 0i32 | 1i32 << 1i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"ExpansionFactor\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"ExpansionFactor\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 0i32 | 1i32 << 1i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"InitialRandomSeed\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"InitialRandomSeed\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 0i32 | 1i32 << 1i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"SyntheticBase\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"SyntheticBase\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 0i32 | 1i32 << 1i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"PostScript\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 3i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"PostScript\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 3i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"BaseFontName\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 3i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"BaseFontName\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 3i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"BaseFontBlend\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 5i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"BaseFontBlend\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 5i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: 0 as *const i8,
-            argtype: -1i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: 0 as *const i8,
+        argtype: -1i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: 0 as *const i8,
-            argtype: -1i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: 0 as *const i8,
+        argtype: -1i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: 0 as *const i8,
-            argtype: -1i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: 0 as *const i8,
+        argtype: -1i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: 0 as *const i8,
-            argtype: -1i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: 0 as *const i8,
+        argtype: -1i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: 0 as *const i8,
-            argtype: -1i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: 0 as *const i8,
+        argtype: -1i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: 0 as *const i8,
-            argtype: -1i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: 0 as *const i8,
+        argtype: -1i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"ROS\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 6i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"ROS\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 6i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"CIDFontVersion\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"CIDFontVersion\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 0i32 | 1i32 << 1i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"CIDFontRevision\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"CIDFontRevision\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 0i32 | 1i32 << 1i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"CIDFontType\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"CIDFontType\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 0i32 | 1i32 << 1i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"CIDCount\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"CIDCount\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 0i32 | 1i32 << 1i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"UIDBase\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"UIDBase\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 0i32 | 1i32 << 1i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"FDArray\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 7i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"FDArray\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 7i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"FDSelect\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 7i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"FDSelect\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 7i32,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            opname: b"FontName\x00" as *const u8 as *const i8,
-            argtype: 1i32 << 3i32,
-        };
-        init
+    C2RustUnnamed_2 {
+        opname: b"FontName\x00" as *const u8 as *const i8,
+        argtype: 1i32 << 3i32,
     },
 ];
 /* Parse DICT data */

--- a/dpx/src/dpx_cid.rs
+++ b/dpx/src/dpx_cid.rs
@@ -154,75 +154,54 @@ pub struct C2RustUnnamed_3 {
    Licensed under the MIT License.
 */
 static mut CIDFont_stdcc_def: [C2RustUnnamed_0; 7] = [
-    {
-        let mut init = C2RustUnnamed_0 {
-            registry: b"Adobe\x00" as *const u8 as *const i8,
-            ordering: b"UCS\x00" as *const u8 as *const i8,
-            supplement: [
-                -1i32, -1i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0, 0, 0, 0, 0, 0, 0, 0,
-            ],
-        };
-        init
+    C2RustUnnamed_0 {
+        registry: b"Adobe\x00" as *const u8 as *const i8,
+        ordering: b"UCS\x00" as *const u8 as *const i8,
+        supplement: [
+            -1i32, -1i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0, 0, 0, 0, 0, 0, 0, 0,
+        ],
     },
-    {
-        let mut init = C2RustUnnamed_0 {
-            registry: b"Adobe\x00" as *const u8 as *const i8,
-            ordering: b"GB1\x00" as *const u8 as *const i8,
-            supplement: [
-                -1i32, -1i32, 0i32, 2i32, 4i32, 4i32, 4i32, 4i32, 0, 0, 0, 0, 0, 0, 0, 0,
-            ],
-        };
-        init
+    C2RustUnnamed_0 {
+        registry: b"Adobe\x00" as *const u8 as *const i8,
+        ordering: b"GB1\x00" as *const u8 as *const i8,
+        supplement: [
+            -1i32, -1i32, 0i32, 2i32, 4i32, 4i32, 4i32, 4i32, 0, 0, 0, 0, 0, 0, 0, 0,
+        ],
     },
-    {
-        let mut init = C2RustUnnamed_0 {
-            registry: b"Adobe\x00" as *const u8 as *const i8,
-            ordering: b"CNS1\x00" as *const u8 as *const i8,
-            supplement: [
-                -1i32, -1i32, 0i32, 0i32, 3i32, 4i32, 4i32, 4i32, 0, 0, 0, 0, 0, 0, 0, 0,
-            ],
-        };
-        init
+    C2RustUnnamed_0 {
+        registry: b"Adobe\x00" as *const u8 as *const i8,
+        ordering: b"CNS1\x00" as *const u8 as *const i8,
+        supplement: [
+            -1i32, -1i32, 0i32, 0i32, 3i32, 4i32, 4i32, 4i32, 0, 0, 0, 0, 0, 0, 0, 0,
+        ],
     },
-    {
-        let mut init = C2RustUnnamed_0 {
-            registry: b"Adobe\x00" as *const u8 as *const i8,
-            ordering: b"Japan1\x00" as *const u8 as *const i8,
-            supplement: [
-                -1i32, -1i32, 2i32, 2i32, 4i32, 5i32, 6i32, 6i32, 0, 0, 0, 0, 0, 0, 0, 0,
-            ],
-        };
-        init
+    C2RustUnnamed_0 {
+        registry: b"Adobe\x00" as *const u8 as *const i8,
+        ordering: b"Japan1\x00" as *const u8 as *const i8,
+        supplement: [
+            -1i32, -1i32, 2i32, 2i32, 4i32, 5i32, 6i32, 6i32, 0, 0, 0, 0, 0, 0, 0, 0,
+        ],
     },
-    {
-        let mut init = C2RustUnnamed_0 {
-            registry: b"Adobe\x00" as *const u8 as *const i8,
-            ordering: b"Korea1\x00" as *const u8 as *const i8,
-            supplement: [
-                -1i32, -1i32, 1i32, 1i32, 2i32, 2i32, 2i32, 2i32, 0, 0, 0, 0, 0, 0, 0, 0,
-            ],
-        };
-        init
+    C2RustUnnamed_0 {
+        registry: b"Adobe\x00" as *const u8 as *const i8,
+        ordering: b"Korea1\x00" as *const u8 as *const i8,
+        supplement: [
+            -1i32, -1i32, 1i32, 1i32, 2i32, 2i32, 2i32, 2i32, 0, 0, 0, 0, 0, 0, 0, 0,
+        ],
     },
-    {
-        let mut init = C2RustUnnamed_0 {
-            registry: b"Adobe\x00" as *const u8 as *const i8,
-            ordering: b"Identity\x00" as *const u8 as *const i8,
-            supplement: [
-                -1i32, -1i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0, 0, 0, 0, 0, 0, 0, 0,
-            ],
-        };
-        init
+    C2RustUnnamed_0 {
+        registry: b"Adobe\x00" as *const u8 as *const i8,
+        ordering: b"Identity\x00" as *const u8 as *const i8,
+        supplement: [
+            -1i32, -1i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0, 0, 0, 0, 0, 0, 0, 0,
+        ],
     },
-    {
-        let mut init = C2RustUnnamed_0 {
-            registry: 0 as *const i8,
-            ordering: 0 as *const i8,
-            supplement: [
-                0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0, 0, 0, 0, 0, 0, 0, 0,
-            ],
-        };
-        init
+    C2RustUnnamed_0 {
+        registry: 0 as *const i8,
+        ordering: 0 as *const i8,
+        supplement: [
+            0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0, 0, 0, 0, 0, 0, 0, 0,
+        ],
     },
 ];
 static mut registry_Adobe: [i8; 6] = [65, 100, 111, 98, 101, 0];
@@ -230,159 +209,96 @@ static mut ordering_Identity: [i8; 9] = [73, 100, 101, 110, 116, 105, 116, 121, 
 static mut ordering_UCS: [i8; 4] = [85, 67, 83, 0];
 #[no_mangle]
 pub static mut CSI_IDENTITY: CIDSysInfo = unsafe {
-    {
-        let mut init = CIDSysInfo {
-            registry: registry_Adobe.as_ptr() as *mut _,
-            ordering: ordering_Identity.as_ptr() as *mut _,
-            supplement: 0i32,
-        };
-        init
+    CIDSysInfo {
+        registry: registry_Adobe.as_ptr() as *mut _,
+        ordering: ordering_Identity.as_ptr() as *mut _,
+        supplement: 0,
     }
 };
 #[no_mangle]
 pub static mut CSI_UNICODE: CIDSysInfo = unsafe {
-    {
-        let mut init = CIDSysInfo {
-            registry: registry_Adobe.as_ptr() as *mut _,
-            ordering: ordering_UCS.as_ptr() as *mut _,
-            supplement: 0i32,
-        };
-        init
+    CIDSysInfo {
+        registry: registry_Adobe.as_ptr() as *mut _,
+        ordering: ordering_UCS.as_ptr() as *mut _,
+        supplement: 0,
     }
 };
 static mut CIDFont_stdcc_alias: [C2RustUnnamed_3; 19] = [
-    {
-        let mut init = C2RustUnnamed_3 {
-            name: b"AU\x00" as *const u8 as *const i8,
-            index: 0i32,
-        };
-        init
+    C2RustUnnamed_3 {
+        name: b"AU\x00" as *const u8 as *const i8,
+        index: 0,
     },
-    {
-        let mut init = C2RustUnnamed_3 {
-            name: b"AG1\x00" as *const u8 as *const i8,
-            index: 1i32,
-        };
-        init
+    C2RustUnnamed_3 {
+        name: b"AG1\x00" as *const u8 as *const i8,
+        index: 1,
     },
-    {
-        let mut init = C2RustUnnamed_3 {
-            name: b"AC1\x00" as *const u8 as *const i8,
-            index: 2i32,
-        };
-        init
+    C2RustUnnamed_3 {
+        name: b"AC1\x00" as *const u8 as *const i8,
+        index: 2,
     },
-    {
-        let mut init = C2RustUnnamed_3 {
-            name: b"AJ1\x00" as *const u8 as *const i8,
-            index: 3i32,
-        };
-        init
+    C2RustUnnamed_3 {
+        name: b"AJ1\x00" as *const u8 as *const i8,
+        index: 3,
     },
-    {
-        let mut init = C2RustUnnamed_3 {
-            name: b"AK1\x00" as *const u8 as *const i8,
-            index: 4i32,
-        };
-        init
+    C2RustUnnamed_3 {
+        name: b"AK1\x00" as *const u8 as *const i8,
+        index: 4,
     },
-    {
-        let mut init = C2RustUnnamed_3 {
-            name: b"AI\x00" as *const u8 as *const i8,
-            index: 5i32,
-        };
-        init
+    C2RustUnnamed_3 {
+        name: b"AI\x00" as *const u8 as *const i8,
+        index: 5,
     },
-    {
-        let mut init = C2RustUnnamed_3 {
-            name: b"UCS\x00" as *const u8 as *const i8,
-            index: 0i32,
-        };
-        init
+    C2RustUnnamed_3 {
+        name: b"UCS\x00" as *const u8 as *const i8,
+        index: 0,
     },
-    {
-        let mut init = C2RustUnnamed_3 {
-            name: b"GB1\x00" as *const u8 as *const i8,
-            index: 1i32,
-        };
-        init
+    C2RustUnnamed_3 {
+        name: b"GB1\x00" as *const u8 as *const i8,
+        index: 1,
     },
-    {
-        let mut init = C2RustUnnamed_3 {
-            name: b"CNS1\x00" as *const u8 as *const i8,
-            index: 2i32,
-        };
-        init
+    C2RustUnnamed_3 {
+        name: b"CNS1\x00" as *const u8 as *const i8,
+        index: 2,
     },
-    {
-        let mut init = C2RustUnnamed_3 {
-            name: b"Japan1\x00" as *const u8 as *const i8,
-            index: 3i32,
-        };
-        init
+    C2RustUnnamed_3 {
+        name: b"Japan1\x00" as *const u8 as *const i8,
+        index: 3,
     },
-    {
-        let mut init = C2RustUnnamed_3 {
-            name: b"Korea1\x00" as *const u8 as *const i8,
-            index: 4i32,
-        };
-        init
+    C2RustUnnamed_3 {
+        name: b"Korea1\x00" as *const u8 as *const i8,
+        index: 4,
     },
-    {
-        let mut init = C2RustUnnamed_3 {
-            name: b"Identity\x00" as *const u8 as *const i8,
-            index: 5i32,
-        };
-        init
+    C2RustUnnamed_3 {
+        name: b"Identity\x00" as *const u8 as *const i8,
+        index: 5,
     },
-    {
-        let mut init = C2RustUnnamed_3 {
-            name: b"U\x00" as *const u8 as *const i8,
-            index: 0i32,
-        };
-        init
+    C2RustUnnamed_3 {
+        name: b"U\x00" as *const u8 as *const i8,
+        index: 0,
     },
-    {
-        let mut init = C2RustUnnamed_3 {
-            name: b"G\x00" as *const u8 as *const i8,
-            index: 1i32,
-        };
-        init
+    C2RustUnnamed_3 {
+        name: b"G\x00" as *const u8 as *const i8,
+        index: 1,
     },
-    {
-        let mut init = C2RustUnnamed_3 {
-            name: b"C\x00" as *const u8 as *const i8,
-            index: 2i32,
-        };
-        init
+    C2RustUnnamed_3 {
+        name: b"C\x00" as *const u8 as *const i8,
+        index: 2,
     },
-    {
-        let mut init = C2RustUnnamed_3 {
-            name: b"J\x00" as *const u8 as *const i8,
-            index: 3i32,
-        };
-        init
+    C2RustUnnamed_3 {
+        name: b"J\x00" as *const u8 as *const i8,
+        index: 3,
     },
-    {
-        let mut init = C2RustUnnamed_3 {
-            name: b"K\x00" as *const u8 as *const i8,
-            index: 4i32,
-        };
-        init
+    C2RustUnnamed_3 {
+        name: b"K\x00" as *const u8 as *const i8,
+        index: 4,
     },
-    {
-        let mut init = C2RustUnnamed_3 {
-            name: b"I\x00" as *const u8 as *const i8,
-            index: 5i32,
-        };
-        init
+    C2RustUnnamed_3 {
+        name: b"I\x00" as *const u8 as *const i8,
+        index: 5,
     },
-    {
-        let mut init = C2RustUnnamed_3 {
-            name: 0 as *const i8,
-            index: 0i32,
-        };
-        init
+    C2RustUnnamed_3 {
+        name: 0 as *const i8,
+        index: 0,
     },
 ];
 static mut __verbose: i32 = 0i32;
@@ -615,273 +531,112 @@ pub unsafe extern "C" fn CIDFont_is_BaseFont(mut font: *mut CIDFont) -> bool {
     (*font).flags & 1i32 << 0i32 != 0
 }
 static mut cid_basefont: [C2RustUnnamed_2; 21] = [
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
-                                 b"Ryumin-Light\x00" as *const u8 as
-                                     *const i8,
-                             fontdict:
-                                 b"<< /Subtype/CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (Japan1) /Supplement 2 >> /DW 1000 /W [  231   632 500  8718 [500 500] ]>>\x00"
-                                     as *const u8 as *const i8,
-                             descriptor:
-                                 b"<< /CapHeight 709 /Ascent 723 /Descent -241 /StemV 69 /FontBBox [-170 -331 1024 903] /ItalicAngle 0 /Flags 6 /Style << /Panose <010502020300000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+    C2RustUnnamed_2 {
+        fontname: b"Ryumin-Light\x00" as *const u8 as *const i8,
+        fontdict: b"<< /Subtype/CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (Japan1) /Supplement 2 >> /DW 1000 /W [  231   632 500  8718 [500 500] ]>>\x00" as *const u8 as *const i8,
+        descriptor: b"<< /CapHeight 709 /Ascent 723 /Descent -241 /StemV 69 /FontBBox [-170 -331 1024 903] /ItalicAngle 0 /Flags 6 /Style << /Panose <010502020300000000000000> >> >>\x00" as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
-                                 b"GothicBBB-Medium\x00" as *const u8 as
-                                     *const i8,
-                             fontdict:
-                                 b"<< /Subtype/CIDFontType0 /CIDSystemInfo <<  /Registry (Adobe) /Ordering (Japan1) /Supplement 2 >> /DW 1000 /W [  231   632 500  8718 [500 500] ]>>\x00"
-                                     as *const u8 as *const i8,
-                             descriptor:
-                                 b"<< /CapHeight 737 /Ascent 752 /Descent -271 /StemV 99 /FontBBox [-174 -268 1001 944] /ItalicAngle 0 /Flags 4 /Style << /Panose <0801020b0500000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+    C2RustUnnamed_2 {
+        fontname: b"GothicBBB-Medium\x00" as *const u8 as *const i8,
+        fontdict: b"<< /Subtype/CIDFontType0 /CIDSystemInfo <<  /Registry (Adobe) /Ordering (Japan1) /Supplement 2 >> /DW 1000 /W [  231   632 500  8718 [500 500] ]>>\x00" as *const u8 as *const i8,
+        descriptor: b"<< /CapHeight 737 /Ascent 752 /Descent -271 /StemV 99 /FontBBox [-174 -268 1001 944] /ItalicAngle 0 /Flags 4 /Style << /Panose <0801020b0500000000000000> >> >>\x00" as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
-                                 b"MHei-Medium-Acro\x00" as *const u8 as
-                                     *const i8,
-                             fontdict:
-                                 b"<< /Subtype /CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (CNS1) /Supplement 0 >> /DW 1000 /W [13648 13742 500 17603 [500] ]>>\x00"
-                                     as *const u8 as *const i8,
-                             descriptor:
-                                 b"<< /Ascent 752 /CapHeight 737 /Descent -271 /StemV 58 /FontBBox [-45 -250 1015 887] /ItalicAngle 0 /Flags 4 /XHeight 553 /Style << /Panose <000001000600000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+    C2RustUnnamed_2 {
+        fontname: b"MHei-Medium-Acro\x00" as *const u8 as *const i8,
+        fontdict: b"<< /Subtype /CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (CNS1) /Supplement 0 >> /DW 1000 /W [13648 13742 500 17603 [500] ]>>\x00" as *const u8 as *const i8,
+        descriptor: b"<< /Ascent 752 /CapHeight 737 /Descent -271 /StemV 58 /FontBBox [-45 -250 1015 887] /ItalicAngle 0 /Flags 4 /XHeight 553 /Style << /Panose <000001000600000000000000> >> >>\x00" as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
-                                 b"MSung-Light-Acro\x00" as *const u8 as
-                                     *const i8,
-                             fontdict:
-                                 b"<< /Subtype /CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (CNS1) /Supplement 0 >> /DW 1000 /W [13648 13742 500 17603 [500] ]>>\x00"
-                                     as *const u8 as *const i8,
-                             descriptor:
-                                 b"<< /Ascent 752 /CapHeight 737 /Descent -271 /StemV 58 /FontBBox [-160 -249 1015 888] /ItalicAngle 0 /Flags 6 /XHeight 553 /Style << /Panose <000000000400000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+    C2RustUnnamed_2 {
+        fontname: b"MSung-Light-Acro\x00" as *const u8 as *const i8,
+        fontdict: b"<< /Subtype /CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (CNS1) /Supplement 0 >> /DW 1000 /W [13648 13742 500 17603 [500] ]>>\x00" as *const u8 as *const i8,
+        descriptor: b"<< /Ascent 752 /CapHeight 737 /Descent -271 /StemV 58 /FontBBox [-160 -249 1015 888] /ItalicAngle 0 /Flags 6 /XHeight 553 /Style << /Panose <000000000400000000000000> >> >>\x00" as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
-                                 b"STSong-Light-Acro\x00" as *const u8 as
-                                     *const i8,
-                             fontdict:
-                                 b"<< /Subtype /CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (GB1) /Supplement 2 >> /DW 1000 /W [  814 939 500  7716 [500] 22355 [500 500] 22357 [500] ]>>\x00"
-                                     as *const u8 as *const i8,
-                             descriptor:
-                                 b"<< /Ascent 752 /CapHeight 737 /Descent -271 /StemV 58 /FontBBox [-25 -254 1000 880] /ItalicAngle 0 /Flags 6 /XHeight 599 /Style << /Panose <000000000400000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+    C2RustUnnamed_2 {
+        fontname: b"STSong-Light-Acro\x00" as *const u8 as *const i8,
+        fontdict: b"<< /Subtype /CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (GB1) /Supplement 2 >> /DW 1000 /W [  814 939 500  7716 [500] 22355 [500 500] 22357 [500] ]>>\x00" as *const u8 as *const i8,
+        descriptor: b"<< /Ascent 752 /CapHeight 737 /Descent -271 /StemV 58 /FontBBox [-25 -254 1000 880] /ItalicAngle 0 /Flags 6 /XHeight 599 /Style << /Panose <000000000400000000000000> >> >>\x00" as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
-                                 b"STHeiti-Regular-Acro\x00" as *const u8 as
-                                     *const i8,
-                             fontdict:
-                                 b"<< /Subtype /CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (GB1) /Supplement 1 >> /DW 1000 /W [  814 939 500  7716 [500] 22355 [500 500] 22357 [500] ]>>\x00"
-                                     as *const u8 as *const i8,
-                             descriptor:
-                                 b"<< /Ascent 752 /CapHeight 737 /Descent -271 /StemV 58 /FontBBox [-34 -250 1000 882] /ItalicAngle 0 /Flags 4 /XHeight 599 /Style << /Panose <000001000600000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+    C2RustUnnamed_2 {
+        fontname: b"STHeiti-Regular-Acro\x00" as *const u8 as *const i8,
+        fontdict: b"<< /Subtype /CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (GB1) /Supplement 1 >> /DW 1000 /W [  814 939 500  7716 [500] 22355 [500 500] 22357 [500] ]>>\x00" as *const u8 as *const i8,
+        descriptor: b"<< /Ascent 752 /CapHeight 737 /Descent -271 /StemV 58 /FontBBox [-34 -250 1000 882] /ItalicAngle 0 /Flags 4 /XHeight 599 /Style << /Panose <000001000600000000000000> >> >>\x00" as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
-                                 b"HeiseiKakuGo-W5-Acro\x00" as *const u8 as
-                                     *const i8,
-                             fontdict:
-                                 b"<< /Subtype /CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (Japan1) /Supplement  2 >> /DW 1000 /W [  231   632 500  8718 [500 500] ]>>\x00"
-                                     as *const u8 as *const i8,
-                             descriptor:
-                                 b"<< /Ascent 752 /CapHeight 737 /Descent -221 /StemV 114 /FontBBox [-92 -250 1010 922] /ItalicAngle 0 /Flags 4 /XHeight 553 /Style << /Panose <0801020b0600000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+    C2RustUnnamed_2 {
+        fontname: b"HeiseiKakuGo-W5-Acro\x00" as *const u8 as *const i8,
+        fontdict: b"<< /Subtype /CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (Japan1) /Supplement  2 >> /DW 1000 /W [  231   632 500  8718 [500 500] ]>>\x00" as *const u8 as *const i8,
+        descriptor: b"<< /Ascent 752 /CapHeight 737 /Descent -221 /StemV 114 /FontBBox [-92 -250 1010 922] /ItalicAngle 0 /Flags 4 /XHeight 553 /Style << /Panose <0801020b0600000000000000> >> >>\x00" as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
-                                 b"HeiseiMin-W3-Acro\x00" as *const u8 as
-                                     *const i8,
-                             fontdict:
-                                 b"<< /Subtype /CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (Japan1) /Supplement 2 >> /DW 1000 /W [  231   632 500  8718 [500 500] ]>>\x00"
-                                     as *const u8 as *const i8,
-                             descriptor:
-                                 b"<< /Ascent 723 /CapHeight 709 /Descent -241 /StemV 69 /FontBBox [-123 -257 1001 910] /ItalicAngle 0 /Flags 6 /XHeight 450 /Style << /Panose <010502020400000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+    C2RustUnnamed_2 {
+        fontname: b"HeiseiMin-W3-Acro\x00" as *const u8 as *const i8,
+        fontdict: b"<< /Subtype /CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (Japan1) /Supplement 2 >> /DW 1000 /W [  231   632 500  8718 [500 500] ]>>\x00" as *const u8 as *const i8,
+        descriptor: b"<< /Ascent 723 /CapHeight 709 /Descent -241 /StemV 69 /FontBBox [-123 -257 1001 910] /ItalicAngle 0 /Flags 6 /XHeight 450 /Style << /Panose <010502020400000000000000> >> >>\x00" as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
-                                 b"HYGoThic-Medium-Acro\x00" as *const u8 as
-                                     *const i8,
-                             fontdict:
-                                 b"<< /Subtype /CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (Korea1) /Supplement 1 >> /DW 1000 /W [   97 [500]  8094  8190 500 ]>>\x00"
-                                     as *const u8 as *const i8,
-                             descriptor:
-                                 b"<< /Ascent 752 /CapHeight 737 /Descent -271 /StemV 58 /FontBBox [-6 -145 1003 880] /ItalicAngle 0 /Flags 4 /XHeight 553 /Style << /Panose <000001000600000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+    C2RustUnnamed_2 {
+        fontname: b"HYGoThic-Medium-Acro\x00" as *const u8 as *const i8,
+        fontdict: b"<< /Subtype /CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (Korea1) /Supplement 1 >> /DW 1000 /W [   97 [500]  8094  8190 500 ]>>\x00" as *const u8 as *const i8,
+        descriptor: b"<< /Ascent 752 /CapHeight 737 /Descent -271 /StemV 58 /FontBBox [-6 -145 1003 880] /ItalicAngle 0 /Flags 4 /XHeight 553 /Style << /Panose <000001000600000000000000> >> >>\x00" as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
-                                 b"HYSMyeongJo-Medium-Acro\x00" as *const u8
-                                     as *const i8,
-                             fontdict:
-                                 b"<< /Subtype /CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (Korea1) /Supplement 1 >> /DW 1000 /W [   97 [500]  8094  8190 500 ]>>\x00"
-                                     as *const u8 as *const i8,
-                             descriptor:
-                                 b"<< /Ascent 752 /CapHeight 737 /Descent -271 /StemV 58 /FontBBox [-0 -148 1001 880] /ItalicAngle 0 /Flags 6 /XHeight 553 /Style << /Panose <000000000600000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+    C2RustUnnamed_2 {
+        fontname: b"HYSMyeongJo-Medium-Acro\x00" as *const u8 as *const i8,
+        fontdict: b"<< /Subtype /CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (Korea1) /Supplement 1 >> /DW 1000 /W [   97 [500]  8094  8190 500 ]>>\x00" as *const u8 as *const i8,
+        descriptor: b"<< /Ascent 752 /CapHeight 737 /Descent -271 /StemV 58 /FontBBox [-0 -148 1001 880] /ItalicAngle 0 /Flags 6 /XHeight 553 /Style << /Panose <000000000600000000000000> >> >>\x00" as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
-                                 b"MSungStd-Light-Acro\x00" as *const u8 as
-                                     *const i8,
-                             fontdict:
-                                 b"<< /Subtype /CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (CNS1) /Supplement 4 >> /DW 1000 /W [13648 13742 500 17603 [500] ]>>\x00"
-                                     as *const u8 as *const i8,
-                             descriptor:
-                                 b"<< /Ascent 880 /CapHeight 662 /Descent -120 /StemV 54 /FontBBox [-160 -249 1015 1071] /ItalicAngle 0 /Flags 6 /Style << /Panose <000000000400000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+    C2RustUnnamed_2 {
+        fontname: b"MSungStd-Light-Acro\x00" as *const u8 as *const i8,
+        fontdict: b"<< /Subtype /CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (CNS1) /Supplement 4 >> /DW 1000 /W [13648 13742 500 17603 [500] ]>>\x00" as *const u8 as *const i8,
+        descriptor: b"<< /Ascent 880 /CapHeight 662 /Descent -120 /StemV 54 /FontBBox [-160 -249 1015 1071] /ItalicAngle 0 /Flags 6 /Style << /Panose <000000000400000000000000> >> >>\x00" as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
-                                 b"STSongStd-Light-Acro\x00" as *const u8 as
-                                     *const i8,
-                             fontdict:
-                                 b"<< /Subtype /CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (GB1) /Supplement 4 >> /DW 1000 /W [  814 939 500  7716 [500] 22355 [500 500] 22357 [500] ]>>\x00"
-                                     as *const u8 as *const i8,
-                             descriptor:
-                                 b"<< /Ascent 880 /CapHeight 626 /Descent -120 /StemV 44 /FontBBox [-134 -254 1001 905] /ItalicAngle 0 /Flags 6 /Style << /Panose <000000000400000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+    C2RustUnnamed_2 {
+        fontname: b"STSongStd-Light-Acro\x00" as *const u8 as *const i8,
+        fontdict: b"<< /Subtype /CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (GB1) /Supplement 4 >> /DW 1000 /W [  814 939 500  7716 [500] 22355 [500 500] 22357 [500] ]>>\x00" as *const u8 as *const i8,
+        descriptor: b"<< /Ascent 880 /CapHeight 626 /Descent -120 /StemV 44 /FontBBox [-134 -254 1001 905] /ItalicAngle 0 /Flags 6 /Style << /Panose <000000000400000000000000> >> >>\x00" as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
+    C2RustUnnamed_2 {
+        fontname: 
                                  b"HYSMyeongJoStd-Medium-Acro\x00" as
                                      *const u8 as *const i8,
-                             fontdict:
-                                 b"<< /Subtype /CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (Korea1) /Supplement 2 >> /DW 1000 /W [   97 [500]  8094  8190 500 ]>>\x00"
-                                     as *const u8 as *const i8,
-                             descriptor:
-                                 b"<< /Ascent 880 /CapHeight 720 /Descent -120 /StemV 60 /FontBBox [-28 -148 1001 880] /ItalicAngle 0 /Flags 6 /Style << /Panose <000000000600000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+        fontdict: b"<< /Subtype /CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (Korea1) /Supplement 2 >> /DW 1000 /W [   97 [500]  8094  8190 500 ]>>\x00" as *const u8 as *const i8,
+        descriptor: b"<< /Ascent 880 /CapHeight 720 /Descent -120 /StemV 60 /FontBBox [-28 -148 1001 880] /ItalicAngle 0 /Flags 6 /Style << /Panose <000000000600000000000000> >> >>\x00" as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
-                                 b"AdobeMingStd-Light-Acro\x00" as *const u8
-                                     as *const i8,
-                             fontdict:
-                                 b"<< /Subtype/CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (CNS1) /Supplement 4 >> /DW 1000 /W [13648 13742 500 17603 [500] ]>>\x00"
-                                     as *const u8 as *const i8,
-                             descriptor:
-                                 b"<< /Ascent 880 /Descent -120 /StemV 48 /CapHeight 731 /FontBBox [-38 -121 1002 918] /ItalicAngle 0 /Flags 6 /XHeight 466 /Style << /Panose <000002020300000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+    C2RustUnnamed_2 {
+        fontname: b"AdobeMingStd-Light-Acro\x00" as *const u8 as *const i8,
+        fontdict: b"<< /Subtype/CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (CNS1) /Supplement 4 >> /DW 1000 /W [13648 13742 500 17603 [500] ]>>\x00" as *const u8 as *const i8,
+        descriptor: b"<< /Ascent 880 /Descent -120 /StemV 48 /CapHeight 731 /FontBBox [-38 -121 1002 918] /ItalicAngle 0 /Flags 6 /XHeight 466 /Style << /Panose <000002020300000000000000> >> >>\x00" as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
-                                 b"AdobeSongStd-Light-Acro\x00" as *const u8
-                                     as *const i8,
-                             fontdict:
-                                 b"<< /Subtype/CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (GB1) /Supplement 4 >> /DW 1000 /W [  814 939 500  7716 [500] 22355 [500 500] 22357 [500] ]>>\x00"
-                                     as *const u8 as *const i8,
-                             descriptor:
-                                 b"<< /Ascent 880 /Descent -120 /StemV 66 /CapHeight 626 /FontBBox [-134 -254 1001 905] /ItalicAngle 0 /Flags 6 /XHeight 416 /Style << /Panose <000002020300000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+    C2RustUnnamed_2 {
+        fontname: b"AdobeSongStd-Light-Acro\x00" as *const u8 as *const i8,
+        fontdict: b"<< /Subtype/CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (GB1) /Supplement 4 >> /DW 1000 /W [  814 939 500  7716 [500] 22355 [500 500] 22357 [500] ]>>\x00" as *const u8 as *const i8,
+        descriptor: b"<< /Ascent 880 /Descent -120 /StemV 66 /CapHeight 626 /FontBBox [-134 -254 1001 905] /ItalicAngle 0 /Flags 6 /XHeight 416 /Style << /Panose <000002020300000000000000> >> >>\x00" as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
-                                 b"KozMinPro-Regular-Acro\x00" as *const u8 as
-                                     *const i8,
-                             fontdict:
-                                 b"<< /Subtype/CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (Japan1) /Supplement 4 >> /DW 1000 /W [  231   632 500  8718 [500 500]  9738  9757 250  9758  9778 333 12063 12087 500 ]>>\x00"
-                                     as *const u8 as *const i8,
-                             descriptor:
-                                 b"<< /Ascent 880 /Descent -120 /StemV 86 /CapHeight 740 /FontBBox [-195 -272 1110 1075] /ItalicAngle 0 /Flags 6 /XHeight 502 /Style << /Panose <000002020400000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+    C2RustUnnamed_2 {
+        fontname: b"KozMinPro-Regular-Acro\x00" as *const u8 as *const i8,
+        fontdict: b"<< /Subtype/CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (Japan1) /Supplement 4 >> /DW 1000 /W [  231   632 500  8718 [500 500]  9738  9757 250  9758  9778 333 12063 12087 500 ]>>\x00" as *const u8 as *const i8,
+        descriptor: b"<< /Ascent 880 /Descent -120 /StemV 86 /CapHeight 740 /FontBBox [-195 -272 1110 1075] /ItalicAngle 0 /Flags 6 /XHeight 502 /Style << /Panose <000002020400000000000000> >> >>\x00" as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
-                                 b"KozGoPro-Medium-Acro\x00" as *const u8 as
-                                     *const i8,
-                             fontdict:
-                                 b"<< /Subtype/CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering(Japan1) /Supplement 4 >> /DW 1000 /W [  231   632 500  8718 [500 500]  9738  9757 250  9758  9778 333 12063 12087 500 ]>>\x00"
-                                     as *const u8 as *const i8,
-                             descriptor:
-                                 b"<< /Ascent 880 /Descent -120 /StemV 99 /CapHeight 763 /FontBBox [-149 -374 1254 1008] /ItalicAngle 0 /Flags 4 /XHeight 549 /Style << /Panose <0000020b0700000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+    C2RustUnnamed_2 {
+        fontname: b"KozGoPro-Medium-Acro\x00" as *const u8 as *const i8,
+        fontdict: b"<< /Subtype/CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering(Japan1) /Supplement 4 >> /DW 1000 /W [  231   632 500  8718 [500 500]  9738  9757 250  9758  9778 333 12063 12087 500 ]>>\x00" as *const u8 as *const i8,
+        descriptor: b"<< /Ascent 880 /Descent -120 /StemV 99 /CapHeight 763 /FontBBox [-149 -374 1254 1008] /ItalicAngle 0 /Flags 4 /XHeight 549 /Style << /Panose <0000020b0700000000000000> >> >>\x00" as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
-                                 b"AdobeMyungjoStd-Medium-Acro\x00" as
-                                     *const u8 as *const i8,
-                             fontdict:
-                                 b"<< /Subtype/CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (Korea1) /Supplement 2 >> /DW 1000 /W [   97 [500]  8094  8190 500 ]>>\x00"
-                                     as *const u8 as *const i8,
-                             descriptor:
-                                 b"<< /Ascent 880 /Descent -120 /StemV 99 /CapHeight 719 /FontBBox [-28 -148 1001 880] /ItalicAngle 0 /Flags 6 /XHeight 478 /Style << /Panose <000002020600000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+    C2RustUnnamed_2 {
+        fontname: b"AdobeMyungjoStd-Medium-Acro\x00" as *const u8 as *const i8,
+        fontdict: b"<< /Subtype/CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (Korea1) /Supplement 2 >> /DW 1000 /W [   97 [500]  8094  8190 500 ]>>\x00" as *const u8 as *const i8,
+        descriptor: b"<< /Ascent 880 /Descent -120 /StemV 99 /CapHeight 719 /FontBBox [-28 -148 1001 880] /ItalicAngle 0 /Flags 6 /XHeight 478 /Style << /Panose <000002020600000000000000> >> >>\x00" as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
-                                 b"KozMinProVI-Regular\x00" as *const u8 as
-                                     *const i8,
-                             fontdict:
-                                 b"<< /Subtype/CIDFontType0 /CIDSystemInfo <<   /Registry (Adobe)   /Ordering (Japan1)   /Supplement 6 >> /DW 1000 /W [  231   632 500   8718 [500 500]   9738  9757 250   9758  9778 333   12063 12087 500 ]        >>\x00"
-                                     as *const u8 as *const i8,
-                             descriptor:
-                                 b"<< /Ascent 880 /Descent -120 /StemV 86 /CapHeight 742 /FontBBox [-437 -340 1144 1317] /ItalicAngle 0 /Flags 6 /XHeight 503 /Style <<   /Panose <000002020400000000000000> >>      >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+    C2RustUnnamed_2 {
+        fontname: b"KozMinProVI-Regular\x00" as *const u8 as *const i8,
+        fontdict: b"<< /Subtype/CIDFontType0 /CIDSystemInfo <<   /Registry (Adobe)   /Ordering (Japan1)   /Supplement 6 >> /DW 1000 /W [  231   632 500   8718 [500 500]   9738  9757 250   9758  9778 333   12063 12087 500 ]        >>\x00" as *const u8 as *const i8,
+        descriptor: b"<< /Ascent 880 /Descent -120 /StemV 86 /CapHeight 742 /FontBBox [-437 -340 1144 1317] /ItalicAngle 0 /Flags 6 /XHeight 503 /Style <<   /Panose <000002020400000000000000> >>      >>\x00" as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
-                                 b"AdobeHeitiStd-Regular\x00" as *const u8 as
-                                     *const i8,
-                             fontdict:
-                                 b"<< /Subtype/CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (GB1) /Supplement 4 >> /DW 1000 /W [  814 939 500  7716 [500] 22355 [500 500] 22357 [500] ]>>\x00"
-                                     as *const u8 as *const i8,
-                             descriptor:
-                                 b"<< /Ascent 880 /Descent -120 /StemV 66 /CapHeight 626 /FontBBox [-134 -254 1001 905] /ItalicAngle 0 /Flags 6 /XHeight 416 /Style << /Panose <000002020300000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+    C2RustUnnamed_2 {
+        fontname: b"AdobeHeitiStd-Regular\x00" as *const u8 as *const i8,
+        fontdict: b"<< /Subtype/CIDFontType0 /CIDSystemInfo << /Registry (Adobe) /Ordering (GB1) /Supplement 4 >> /DW 1000 /W [  814 939 500  7716 [500] 22355 [500 500] 22357 [500] ]>>\x00" as *const u8 as *const i8,
+        descriptor: b"<< /Ascent 880 /Descent -120 /StemV 66 /CapHeight 626 /FontBBox [-134 -254 1001 905] /ItalicAngle 0 /Flags 6 /XHeight 416 /Style << /Panose <000002020300000000000000> >> >>\x00" as *const u8 as *const i8,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
-            fontname: 0 as *const i8,
-            fontdict: 0 as *const i8,
-            descriptor: 0 as *const i8,
-        };
-        init
+    C2RustUnnamed_2 {
+        fontname: 0 as *const i8,
+        fontdict: 0 as *const i8,
+        descriptor: 0 as *const i8,
     },
 ];
 unsafe fn CIDFont_base_open(

--- a/dpx/src/dpx_cidtype2.rs
+++ b/dpx/src/dpx_cidtype2.rs
@@ -202,159 +202,126 @@ unsafe fn validate_name(mut fontname: *mut i8, mut len: i32) {
     };
 }
 static mut known_encodings: [C2RustUnnamed_3; 11] = [
-    {
-        let mut init = C2RustUnnamed_3 {
-            platform: 3_u16,
-            encoding: 10_u16,
-            pdfnames: [
-                b"UCSms-UCS4\x00" as *const u8 as *const i8,
-                b"UCSms-UCS2\x00" as *const u8 as *const i8,
-                b"UCS4\x00" as *const u8 as *const i8,
-                b"UCS2\x00" as *const u8 as *const i8,
-                0 as *const i8,
-            ],
-        };
-        init
+    C2RustUnnamed_3 {
+        platform: 3_u16,
+        encoding: 10_u16,
+        pdfnames: [
+            b"UCSms-UCS4\x00" as *const u8 as *const i8,
+            b"UCSms-UCS2\x00" as *const u8 as *const i8,
+            b"UCS4\x00" as *const u8 as *const i8,
+            b"UCS2\x00" as *const u8 as *const i8,
+            0 as *const i8,
+        ],
     },
-    {
-        let mut init = C2RustUnnamed_3 {
-            platform: 3_u16,
-            encoding: 1_u16,
-            pdfnames: [
-                b"UCSms-UCS4\x00" as *const u8 as *const i8,
-                b"UCSms-UCS2\x00" as *const u8 as *const i8,
-                b"UCS4\x00" as *const u8 as *const i8,
-                b"UCS2\x00" as *const u8 as *const i8,
-                0 as *const i8,
-            ],
-        };
-        init
+    C2RustUnnamed_3 {
+        platform: 3_u16,
+        encoding: 1_u16,
+        pdfnames: [
+            b"UCSms-UCS4\x00" as *const u8 as *const i8,
+            b"UCSms-UCS2\x00" as *const u8 as *const i8,
+            b"UCS4\x00" as *const u8 as *const i8,
+            b"UCS2\x00" as *const u8 as *const i8,
+            0 as *const i8,
+        ],
     },
-    {
-        let mut init = C2RustUnnamed_3 {
-            platform: 3_u16,
-            encoding: 2_u16,
-            pdfnames: [
-                b"90ms-RKSJ\x00" as *const u8 as *const i8,
-                0 as *const i8,
-                0 as *const i8,
-                0 as *const i8,
-                0 as *const i8,
-            ],
-        };
-        init
+    C2RustUnnamed_3 {
+        platform: 3_u16,
+        encoding: 2_u16,
+        pdfnames: [
+            b"90ms-RKSJ\x00" as *const u8 as *const i8,
+            0 as *const i8,
+            0 as *const i8,
+            0 as *const i8,
+            0 as *const i8,
+        ],
     },
-    {
-        let mut init = C2RustUnnamed_3 {
-            platform: 3_u16,
-            encoding: 3_u16,
-            pdfnames: [
-                b"GBK-EUC\x00" as *const u8 as *const i8,
-                0 as *const i8,
-                0 as *const i8,
-                0 as *const i8,
-                0 as *const i8,
-            ],
-        };
-        init
+    C2RustUnnamed_3 {
+        platform: 3_u16,
+        encoding: 3_u16,
+        pdfnames: [
+            b"GBK-EUC\x00" as *const u8 as *const i8,
+            0 as *const i8,
+            0 as *const i8,
+            0 as *const i8,
+            0 as *const i8,
+        ],
     },
-    {
-        let mut init = C2RustUnnamed_3 {
-            platform: 3_u16,
-            encoding: 4_u16,
-            pdfnames: [
-                b"ETen-B5\x00" as *const u8 as *const i8,
-                0 as *const i8,
-                0 as *const i8,
-                0 as *const i8,
-                0 as *const i8,
-            ],
-        };
-        init
+    C2RustUnnamed_3 {
+        platform: 3_u16,
+        encoding: 4_u16,
+        pdfnames: [
+            b"ETen-B5\x00" as *const u8 as *const i8,
+            0 as *const i8,
+            0 as *const i8,
+            0 as *const i8,
+            0 as *const i8,
+        ],
     },
-    {
-        let mut init = C2RustUnnamed_3 {
-            platform: 3_u16,
-            encoding: 5_u16,
-            pdfnames: [
-                b"KSCms-UHC\x00" as *const u8 as *const i8,
-                0 as *const i8,
-                0 as *const i8,
-                0 as *const i8,
-                0 as *const i8,
-            ],
-        };
-        init
+    C2RustUnnamed_3 {
+        platform: 3_u16,
+        encoding: 5_u16,
+        pdfnames: [
+            b"KSCms-UHC\x00" as *const u8 as *const i8,
+            0 as *const i8,
+            0 as *const i8,
+            0 as *const i8,
+            0 as *const i8,
+        ],
     },
-    {
-        let mut init = C2RustUnnamed_3 {
-            platform: 1_u16,
-            encoding: 1_u16,
-            pdfnames: [
-                b"90pv-RKSJ\x00" as *const u8 as *const i8,
-                0 as *const i8,
-                0 as *const i8,
-                0 as *const i8,
-                0 as *const i8,
-            ],
-        };
-        init
+    C2RustUnnamed_3 {
+        platform: 1_u16,
+        encoding: 1_u16,
+        pdfnames: [
+            b"90pv-RKSJ\x00" as *const u8 as *const i8,
+            0 as *const i8,
+            0 as *const i8,
+            0 as *const i8,
+            0 as *const i8,
+        ],
     },
-    {
-        let mut init = C2RustUnnamed_3 {
-            platform: 1_u16,
-            encoding: 2_u16,
-            pdfnames: [
-                b"B5pc\x00" as *const u8 as *const i8,
-                0 as *const i8,
-                0 as *const i8,
-                0 as *const i8,
-                0 as *const i8,
-            ],
-        };
-        init
+    C2RustUnnamed_3 {
+        platform: 1_u16,
+        encoding: 2_u16,
+        pdfnames: [
+            b"B5pc\x00" as *const u8 as *const i8,
+            0 as *const i8,
+            0 as *const i8,
+            0 as *const i8,
+            0 as *const i8,
+        ],
     },
-    {
-        let mut init = C2RustUnnamed_3 {
-            platform: 1_u16,
-            encoding: 25_u16,
-            pdfnames: [
-                b"GBpc-EUC\x00" as *const u8 as *const i8,
-                0 as *const i8,
-                0 as *const i8,
-                0 as *const i8,
-                0 as *const i8,
-            ],
-        };
-        init
+    C2RustUnnamed_3 {
+        platform: 1_u16,
+        encoding: 25_u16,
+        pdfnames: [
+            b"GBpc-EUC\x00" as *const u8 as *const i8,
+            0 as *const i8,
+            0 as *const i8,
+            0 as *const i8,
+            0 as *const i8,
+        ],
     },
-    {
-        let mut init = C2RustUnnamed_3 {
-            platform: 1_u16,
-            encoding: 3_u16,
-            pdfnames: [
-                b"KSCpc-EUC\x00" as *const u8 as *const i8,
-                0 as *const i8,
-                0 as *const i8,
-                0 as *const i8,
-                0 as *const i8,
-            ],
-        };
-        init
+    C2RustUnnamed_3 {
+        platform: 1_u16,
+        encoding: 3_u16,
+        pdfnames: [
+            b"KSCpc-EUC\x00" as *const u8 as *const i8,
+            0 as *const i8,
+            0 as *const i8,
+            0 as *const i8,
+            0 as *const i8,
+        ],
     },
-    {
-        let mut init = C2RustUnnamed_3 {
-            platform: 0_u16,
-            encoding: 0_u16,
-            pdfnames: [
-                0 as *const i8,
-                0 as *const i8,
-                0 as *const i8,
-                0 as *const i8,
-                0 as *const i8,
-            ],
-        };
-        init
+    C2RustUnnamed_3 {
+        platform: 0_u16,
+        encoding: 0_u16,
+        pdfnames: [
+            0 as *const i8,
+            0 as *const i8,
+            0 as *const i8,
+            0 as *const i8,
+            0 as *const i8,
+        ],
     },
 ];
 unsafe fn find_tocode_cmap(mut reg: *const i8, mut ord: *const i8, mut select: i32) -> *mut CMap {
@@ -572,75 +539,45 @@ unsafe fn add_TTCIDVMetrics(
  */
 unsafe fn fix_CJK_symbols(mut code: u16) -> u16 {
     static mut CJK_Uni_symbols: [C2RustUnnamed_2; 10] = [
-        {
-            let mut init = C2RustUnnamed_2 {
-                alt1: 0x2014_u16,
-                alt2: 0x2015_u16,
-            };
-            init
+        C2RustUnnamed_2 {
+            alt1: 0x2014,
+            alt2: 0x2015,
         },
-        {
-            let mut init = C2RustUnnamed_2 {
-                alt1: 0x2016_u16,
-                alt2: 0x2225_u16,
-            };
-            init
+        C2RustUnnamed_2 {
+            alt1: 0x2016,
+            alt2: 0x2225,
         },
-        {
-            let mut init = C2RustUnnamed_2 {
-                alt1: 0x203e_u16,
-                alt2: 0xffe3_u16,
-            };
-            init
+        C2RustUnnamed_2 {
+            alt1: 0x203e,
+            alt2: 0xffe3,
         },
-        {
-            let mut init = C2RustUnnamed_2 {
-                alt1: 0x2026_u16,
-                alt2: 0x22ef_u16,
-            };
-            init
+        C2RustUnnamed_2 {
+            alt1: 0x2026,
+            alt2: 0x22ef,
         },
-        {
-            let mut init = C2RustUnnamed_2 {
-                alt1: 0x2212_u16,
-                alt2: 0xff0d_u16,
-            };
-            init
+        C2RustUnnamed_2 {
+            alt1: 0x2212,
+            alt2: 0xff0d,
         },
-        {
-            let mut init = C2RustUnnamed_2 {
-                alt1: 0x301c_u16,
-                alt2: 0xff5e_u16,
-            };
-            init
+        C2RustUnnamed_2 {
+            alt1: 0x301c,
+            alt2: 0xff5e,
         },
-        {
-            let mut init = C2RustUnnamed_2 {
-                alt1: 0xffe0_u16,
-                alt2: 0xa2_u16,
-            };
-            init
+        C2RustUnnamed_2 {
+            alt1: 0xffe0,
+            alt2: 0xa2,
         },
-        {
-            let mut init = C2RustUnnamed_2 {
-                alt1: 0xffe1_u16,
-                alt2: 0xa3_u16,
-            };
-            init
+        C2RustUnnamed_2 {
+            alt1: 0xffe1,
+            alt2: 0xa3,
         },
-        {
-            let mut init = C2RustUnnamed_2 {
-                alt1: 0xffe2_u16,
-                alt2: 0xac_u16,
-            };
-            init
+        C2RustUnnamed_2 {
+            alt1: 0xffe2,
+            alt2: 0xac,
         },
-        {
-            let mut init = C2RustUnnamed_2 {
-                alt1: 0xffff_u16,
-                alt2: 0xffff_u16,
-            };
-            init
+        C2RustUnnamed_2 {
+            alt1: 0xffff,
+            alt2: 0xffff,
         },
     ];
     let mut alt_code = code;

--- a/dpx/src/dpx_dpxconf.rs
+++ b/dpx/src/dpx_dpxconf.rs
@@ -40,181 +40,115 @@ pub struct paper {
 }
 #[no_mangle]
 pub static mut paperspecs: [paper; 22] = [
-    {
-        let mut init = paper {
-            name: b"letter\x00" as *const u8 as *const i8,
-            pswidth: 612.00f64,
-            psheight: 792.00f64,
-        };
-        init
+    paper {
+        name: b"letter\x00" as *const u8 as *const i8,
+        pswidth: 612.00,
+        psheight: 792.00,
     },
-    {
-        let mut init = paper {
-            name: b"legal\x00" as *const u8 as *const i8,
-            pswidth: 612.00f64,
-            psheight: 1008.00f64,
-        };
-        init
+    paper {
+        name: b"legal\x00" as *const u8 as *const i8,
+        pswidth: 612.00,
+        psheight: 1008.00,
     },
-    {
-        let mut init = paper {
-            name: b"ledger\x00" as *const u8 as *const i8,
-            pswidth: 1224.00f64,
-            psheight: 792.00f64,
-        };
-        init
+    paper {
+        name: b"ledger\x00" as *const u8 as *const i8,
+        pswidth: 1224.00,
+        psheight: 792.00,
     },
-    {
-        let mut init = paper {
-            name: b"tabloid\x00" as *const u8 as *const i8,
-            pswidth: 792.00f64,
-            psheight: 1224.00f64,
-        };
-        init
+    paper {
+        name: b"tabloid\x00" as *const u8 as *const i8,
+        pswidth: 792.00,
+        psheight: 1224.00,
     },
-    {
-        let mut init = paper {
-            name: b"a6\x00" as *const u8 as *const i8,
-            pswidth: 297.638f64,
-            psheight: 419.528f64,
-        };
-        init
+    paper {
+        name: b"a6\x00" as *const u8 as *const i8,
+        pswidth: 297.638,
+        psheight: 419.528,
     },
-    {
-        let mut init = paper {
-            name: b"a5\x00" as *const u8 as *const i8,
-            pswidth: 419.528f64,
-            psheight: 595.276f64,
-        };
-        init
+    paper {
+        name: b"a5\x00" as *const u8 as *const i8,
+        pswidth: 419.528,
+        psheight: 595.276,
     },
-    {
-        let mut init = paper {
-            name: b"a4\x00" as *const u8 as *const i8,
-            pswidth: 595.276f64,
-            psheight: 841.890f64,
-        };
-        init
+    paper {
+        name: b"a4\x00" as *const u8 as *const i8,
+        pswidth: 595.276,
+        psheight: 841.890,
     },
-    {
-        let mut init = paper {
-            name: b"a3\x00" as *const u8 as *const i8,
-            pswidth: 841.890f64,
-            psheight: 1190.550f64,
-        };
-        init
+    paper {
+        name: b"a3\x00" as *const u8 as *const i8,
+        pswidth: 841.890,
+        psheight: 1190.550,
     },
-    {
-        let mut init = paper {
-            name: b"b6\x00" as *const u8 as *const i8,
-            pswidth: 364.25f64,
-            psheight: 515.91f64,
-        };
-        init
+    paper {
+        name: b"b6\x00" as *const u8 as *const i8,
+        pswidth: 364.25,
+        psheight: 515.91,
     },
-    {
-        let mut init = paper {
-            name: b"b5\x00" as *const u8 as *const i8,
-            pswidth: 515.91f64,
-            psheight: 728.50f64,
-        };
-        init
+    paper {
+        name: b"b5\x00" as *const u8 as *const i8,
+        pswidth: 515.91,
+        psheight: 728.50,
     },
-    {
-        let mut init = paper {
-            name: b"b4\x00" as *const u8 as *const i8,
-            pswidth: 728.50f64,
-            psheight: 1031.81f64,
-        };
-        init
+    paper {
+        name: b"b4\x00" as *const u8 as *const i8,
+        pswidth: 728.50,
+        psheight: 1031.81,
     },
-    {
-        let mut init = paper {
-            name: b"b3\x00" as *const u8 as *const i8,
-            pswidth: 1031.81f64,
-            psheight: 1457.00f64,
-        };
-        init
+    paper {
+        name: b"b3\x00" as *const u8 as *const i8,
+        pswidth: 1031.81,
+        psheight: 1457.00,
     },
-    {
-        let mut init = paper {
-            name: b"b5var\x00" as *const u8 as *const i8,
-            pswidth: 515.91f64,
-            psheight: 651.97f64,
-        };
-        init
+    paper {
+        name: b"b5var\x00" as *const u8 as *const i8,
+        pswidth: 515.91,
+        psheight: 651.97,
     },
-    {
-        let mut init = paper {
-            name: b"jisb6\x00" as *const u8 as *const i8,
-            pswidth: 364.25f64,
-            psheight: 515.91f64,
-        };
-        init
+    paper {
+        name: b"jisb6\x00" as *const u8 as *const i8,
+        pswidth: 364.25,
+        psheight: 515.91,
     },
-    {
-        let mut init = paper {
-            name: b"jisb5\x00" as *const u8 as *const i8,
-            pswidth: 515.91f64,
-            psheight: 728.50f64,
-        };
-        init
+    paper {
+        name: b"jisb5\x00" as *const u8 as *const i8,
+        pswidth: 515.91,
+        psheight: 728.50,
     },
-    {
-        let mut init = paper {
-            name: b"jisb4\x00" as *const u8 as *const i8,
-            pswidth: 728.50f64,
-            psheight: 1031.81f64,
-        };
-        init
+    paper {
+        name: b"jisb4\x00" as *const u8 as *const i8,
+        pswidth: 728.50,
+        psheight: 1031.81,
     },
-    {
-        let mut init = paper {
-            name: b"jisb3\x00" as *const u8 as *const i8,
-            pswidth: 1031.81f64,
-            psheight: 1457.00f64,
-        };
-        init
+    paper {
+        name: b"jisb3\x00" as *const u8 as *const i8,
+        pswidth: 1031.81,
+        psheight: 1457.00,
     },
-    {
-        let mut init = paper {
-            name: b"isob6\x00" as *const u8 as *const i8,
-            pswidth: 354.331f64,
-            psheight: 498.898f64,
-        };
-        init
+    paper {
+        name: b"isob6\x00" as *const u8 as *const i8,
+        pswidth: 354.331,
+        psheight: 498.898,
     },
-    {
-        let mut init = paper {
-            name: b"isob5\x00" as *const u8 as *const i8,
-            pswidth: 498.898f64,
-            psheight: 708.661f64,
-        };
-        init
+    paper {
+        name: b"isob5\x00" as *const u8 as *const i8,
+        pswidth: 498.898,
+        psheight: 708.661,
     },
-    {
-        let mut init = paper {
-            name: b"isob4\x00" as *const u8 as *const i8,
-            pswidth: 708.661f64,
-            psheight: 1000.630f64,
-        };
-        init
+    paper {
+        name: b"isob4\x00" as *const u8 as *const i8,
+        pswidth: 708.661,
+        psheight: 1000.630,
     },
-    {
-        let mut init = paper {
-            name: b"isob3\x00" as *const u8 as *const i8,
-            pswidth: 1000.630f64,
-            psheight: 1417.320f64,
-        };
-        init
+    paper {
+        name: b"isob3\x00" as *const u8 as *const i8,
+        pswidth: 1000.630,
+        psheight: 1417.320,
     },
-    {
-        let mut init = paper {
-            name: 0 as *const i8,
-            pswidth: 0i32 as f64,
-            psheight: 0i32 as f64,
-        };
-        init
+    paper {
+        name: 0 as *const i8,
+        pswidth: 0.0,
+        psheight: 0.0,
     },
 ];
 #[no_mangle]

--- a/dpx/src/dpx_dvi.rs
+++ b/dpx/src/dpx_dvi.rs
@@ -209,17 +209,14 @@ static mut linear: i8 = 0_i8;
 static mut page_loc: *mut u32 = 0 as *const u32 as *mut u32;
 static mut num_pages: u32 = 0_u32;
 static mut dvi_file_size: u32 = 0_u32;
-static mut DVI_INFO: dvi_header = {
-    let mut init = dvi_header {
-        unit_num: 25400000_u32,
-        unit_den: 473628672_u32,
-        mag: 1000_u32,
-        media_width: 0_u32,
-        media_height: 0_u32,
-        stackdepth: 0_u32,
-        comment: [0; 257],
-    };
-    init
+static mut DVI_INFO: dvi_header = dvi_header {
+    unit_num: 25400000_u32,
+    unit_den: 473628672_u32,
+    mag: 1000_u32,
+    media_width: 0_u32,
+    media_height: 0_u32,
+    stackdepth: 0_u32,
+    comment: [0; 257],
 };
 static mut dev_origin_x: f64 = 72.0f64;
 static mut dev_origin_y: f64 = 770.0f64;

--- a/dpx/src/dpx_mpost.rs
+++ b/dpx/src/dpx_mpost.rs
@@ -108,1803 +108,26 @@ pub struct operators {
  */
 static mut Xorigin: f64 = 0.;
 static mut Yorigin: f64 = 0.;
-static mut font_stack: [mp_font; 256] = [
-    {
-        let mut init = mp_font {
-            font_name: 0 as *const i8 as *mut i8,
-            font_id: -1i32,
-            tfm_id: -1i32,
-            subfont_id: -1i32,
-            pt_size: 0i32 as f64,
-        }; /* No currentfont */
-        init
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-    mp_font {
-        font_name: 0 as *const i8 as *mut i8,
-        font_id: 0,
-        tfm_id: 0,
-        subfont_id: 0,
-        pt_size: 0.,
-    },
-];
+static mut font_stack: [mp_font; 256] = {
+    let mut init: [mp_font; 256] = [
+        mp_font {
+            font_name: std::ptr::null_mut(),
+            font_id: 0,
+            tfm_id: 0,
+            subfont_id: 0,
+            pt_size: 0.0,
+        }; 
+        256
+    ];
+    init[0] = mp_font {
+        font_name: std::ptr::null_mut(),
+        font_id: -1,
+        tfm_id: -1,
+        subfont_id: -1,
+        pt_size: 0.0,
+    }; /* No currentfont */
+    init
+};
 static mut currentfont: i32 = -1i32;
 static mut mp_cmode: i32 = 0i32;
 unsafe fn mp_setfont(mut font_name: *const i8, mut pt_size: f64) -> i32 {
@@ -2089,539 +312,311 @@ unsafe fn skip_prolog(mut start: *mut *const i8, mut end: *const i8) {
     };
 }
 static mut ps_operators: [operators; 48] = [
-    {
-        let mut init = operators {
-            token: b"add\x00" as *const u8 as *const i8,
-            opcode: 1i32,
-        };
-        init
+    operators {
+        token: b"add\x00" as *const u8 as *const i8,
+        opcode: 1,
     },
-    {
-        let mut init = operators {
-            token: b"mul\x00" as *const u8 as *const i8,
-            opcode: 3i32,
-        };
-        init
+    operators {
+        token: b"mul\x00" as *const u8 as *const i8,
+        opcode: 3,
     },
-    {
-        let mut init = operators {
-            token: b"div\x00" as *const u8 as *const i8,
-            opcode: 4i32,
-        };
-        init
+    operators {
+        token: b"div\x00" as *const u8 as *const i8,
+        opcode: 4,
     },
-    {
-        let mut init = operators {
-            token: b"neg\x00" as *const u8 as *const i8,
-            opcode: 5i32,
-        };
-        init
+    operators {
+        token: b"neg\x00" as *const u8 as *const i8,
+        opcode: 5,
     },
-    {
-        let mut init = operators {
-            token: b"sub\x00" as *const u8 as *const i8,
-            opcode: 2i32,
-        };
-        init
+    operators {
+        token: b"sub\x00" as *const u8 as *const i8,
+        opcode: 2,
     },
-    {
-        let mut init = operators {
-            token: b"truncate\x00" as *const u8 as *const i8,
-            opcode: 6i32,
-        };
-        init
+    operators {
+        token: b"truncate\x00" as *const u8 as *const i8,
+        opcode: 6,
     },
-    {
-        let mut init = operators {
-            token: b"clear\x00" as *const u8 as *const i8,
-            opcode: 10i32,
-        };
-        init
+    operators {
+        token: b"clear\x00" as *const u8 as *const i8,
+        opcode: 10,
     },
-    {
-        let mut init = operators {
-            token: b"exch\x00" as *const u8 as *const i8,
-            opcode: 11i32,
-        };
-        init
+    operators {
+        token: b"exch\x00" as *const u8 as *const i8,
+        opcode: 11,
     },
-    {
-        let mut init = operators {
-            token: b"pop\x00" as *const u8 as *const i8,
-            opcode: 12i32,
-        };
-        init
+    operators {
+        token: b"pop\x00" as *const u8 as *const i8,
+        opcode: 12,
     },
-    {
-        let mut init = operators {
-            token: b"clip\x00" as *const u8 as *const i8,
-            opcode: 44i32,
-        };
-        init
+    operators {
+        token: b"clip\x00" as *const u8 as *const i8,
+        opcode: 44,
     },
-    {
-        let mut init = operators {
-            token: b"eoclip\x00" as *const u8 as *const i8,
-            opcode: 45i32,
-        };
-        init
+    operators {
+        token: b"eoclip\x00" as *const u8 as *const i8,
+        opcode: 45,
     },
-    {
-        let mut init = operators {
-            token: b"closepath\x00" as *const u8 as *const i8,
-            opcode: 32i32,
-        };
-        init
+    operators {
+        token: b"closepath\x00" as *const u8 as *const i8,
+        opcode: 32,
     },
-    {
-        let mut init = operators {
-            token: b"concat\x00" as *const u8 as *const i8,
-            opcode: 52i32,
-        };
-        init
+    operators {
+        token: b"concat\x00" as *const u8 as *const i8,
+        opcode: 52,
     },
-    {
-        let mut init = operators {
-            token: b"newpath\x00" as *const u8 as *const i8,
-            opcode: 31i32,
-        };
-        init
+    operators {
+        token: b"newpath\x00" as *const u8 as *const i8,
+        opcode: 31,
     },
-    {
-        let mut init = operators {
-            token: b"moveto\x00" as *const u8 as *const i8,
-            opcode: 33i32,
-        };
-        init
+    operators {
+        token: b"moveto\x00" as *const u8 as *const i8,
+        opcode: 33,
     },
-    {
-        let mut init = operators {
-            token: b"rmoveto\x00" as *const u8 as *const i8,
-            opcode: 34i32,
-        };
-        init
+    operators {
+        token: b"rmoveto\x00" as *const u8 as *const i8,
+        opcode: 34,
     },
-    {
-        let mut init = operators {
-            token: b"lineto\x00" as *const u8 as *const i8,
-            opcode: 37i32,
-        };
-        init
+    operators {
+        token: b"lineto\x00" as *const u8 as *const i8,
+        opcode: 37,
     },
-    {
-        let mut init = operators {
-            token: b"rlineto\x00" as *const u8 as *const i8,
-            opcode: 38i32,
-        };
-        init
+    operators {
+        token: b"rlineto\x00" as *const u8 as *const i8,
+        opcode: 38,
     },
-    {
-        let mut init = operators {
-            token: b"curveto\x00" as *const u8 as *const i8,
-            opcode: 35i32,
-        };
-        init
+    operators {
+        token: b"curveto\x00" as *const u8 as *const i8,
+        opcode: 35,
     },
-    {
-        let mut init = operators {
-            token: b"rcurveto\x00" as *const u8 as *const i8,
-            opcode: 36i32,
-        };
-        init
+    operators {
+        token: b"rcurveto\x00" as *const u8 as *const i8,
+        opcode: 36,
     },
-    {
-        let mut init = operators {
-            token: b"arc\x00" as *const u8 as *const i8,
-            opcode: 39i32,
-        };
-        init
+    operators {
+        token: b"arc\x00" as *const u8 as *const i8,
+        opcode: 39,
     },
-    {
-        let mut init = operators {
-            token: b"arcn\x00" as *const u8 as *const i8,
-            opcode: 40i32,
-        };
-        init
+    operators {
+        token: b"arcn\x00" as *const u8 as *const i8,
+        opcode: 40,
     },
-    {
-        let mut init = operators {
-            token: b"stroke\x00" as *const u8 as *const i8,
-            opcode: 42i32,
-        };
-        init
+    operators {
+        token: b"stroke\x00" as *const u8 as *const i8,
+        opcode: 42,
     },
-    {
-        let mut init = operators {
-            token: b"fill\x00" as *const u8 as *const i8,
-            opcode: 41i32,
-        };
-        init
+    operators {
+        token: b"fill\x00" as *const u8 as *const i8,
+        opcode: 41,
     },
-    {
-        let mut init = operators {
-            token: b"show\x00" as *const u8 as *const i8,
-            opcode: 43i32,
-        };
-        init
+    operators {
+        token: b"show\x00" as *const u8 as *const i8,
+        opcode: 43,
     },
-    {
-        let mut init = operators {
-            token: b"showpage\x00" as *const u8 as *const i8,
-            opcode: 49i32,
-        };
-        init
+    operators {
+        token: b"showpage\x00" as *const u8 as *const i8,
+        opcode: 49,
     },
-    {
-        let mut init = operators {
-            token: b"gsave\x00" as *const u8 as *const i8,
-            opcode: 50i32,
-        };
-        init
+    operators {
+        token: b"gsave\x00" as *const u8 as *const i8,
+        opcode: 50,
     },
-    {
-        let mut init = operators {
-            token: b"grestore\x00" as *const u8 as *const i8,
-            opcode: 51i32,
-        };
-        init
+    operators {
+        token: b"grestore\x00" as *const u8 as *const i8,
+        opcode: 51,
     },
-    {
-        let mut init = operators {
-            token: b"translate\x00" as *const u8 as *const i8,
-            opcode: 54i32,
-        };
-        init
+    operators {
+        token: b"translate\x00" as *const u8 as *const i8,
+        opcode: 54,
     },
-    {
-        let mut init = operators {
-            token: b"rotate\x00" as *const u8 as *const i8,
-            opcode: 55i32,
-        };
-        init
+    operators {
+        token: b"rotate\x00" as *const u8 as *const i8,
+        opcode: 55,
     },
-    {
-        let mut init = operators {
-            token: b"scale\x00" as *const u8 as *const i8,
-            opcode: 53i32,
-        };
-        init
+    operators {
+        token: b"scale\x00" as *const u8 as *const i8,
+        opcode: 53,
     },
-    {
-        let mut init = operators {
-            token: b"setlinecap\x00" as *const u8 as *const i8,
-            opcode: 62i32,
-        };
-        init
+    operators {
+        token: b"setlinecap\x00" as *const u8 as *const i8,
+        opcode: 62,
     },
-    {
-        let mut init = operators {
-            token: b"setlinejoin\x00" as *const u8 as *const i8,
-            opcode: 63i32,
-        };
-        init
+    operators {
+        token: b"setlinejoin\x00" as *const u8 as *const i8,
+        opcode: 63,
     },
-    {
-        let mut init = operators {
-            token: b"setlinewidth\x00" as *const u8 as *const i8,
-            opcode: 60i32,
-        };
-        init
+    operators {
+        token: b"setlinewidth\x00" as *const u8 as *const i8,
+        opcode: 60,
     },
-    {
-        let mut init = operators {
-            token: b"setmiterlimit\x00" as *const u8 as *const i8,
-            opcode: 64i32,
-        };
-        init
+    operators {
+        token: b"setmiterlimit\x00" as *const u8 as *const i8,
+        opcode: 64,
     },
-    {
-        let mut init = operators {
-            token: b"setdash\x00" as *const u8 as *const i8,
-            opcode: 61i32,
-        };
-        init
+    operators {
+        token: b"setdash\x00" as *const u8 as *const i8,
+        opcode: 61,
     },
-    {
-        let mut init = operators {
-            token: b"setgray\x00" as *const u8 as *const i8,
-            opcode: 70i32,
-        };
-        init
+    operators {
+        token: b"setgray\x00" as *const u8 as *const i8,
+        opcode: 70,
     },
-    {
-        let mut init = operators {
-            token: b"setrgbcolor\x00" as *const u8 as *const i8,
-            opcode: 71i32,
-        };
-        init
+    operators {
+        token: b"setrgbcolor\x00" as *const u8 as *const i8,
+        opcode: 71,
     },
-    {
-        let mut init = operators {
-            token: b"setcmykcolor\x00" as *const u8 as *const i8,
-            opcode: 72i32,
-        };
-        init
+    operators {
+        token: b"setcmykcolor\x00" as *const u8 as *const i8,
+        opcode: 72,
     },
-    {
-        let mut init = operators {
-            token: b"currentpoint\x00" as *const u8 as *const i8,
-            opcode: 80i32,
-        };
-        init
+    operators {
+        token: b"currentpoint\x00" as *const u8 as *const i8,
+        opcode: 80,
     },
-    {
-        let mut init = operators {
-            token: b"dtransform\x00" as *const u8 as *const i8,
-            opcode: 82i32,
-        };
-        init
+    operators {
+        token: b"dtransform\x00" as *const u8 as *const i8,
+        opcode: 82,
     },
-    {
-        let mut init = operators {
-            token: b"idtransform\x00" as *const u8 as *const i8,
-            opcode: 81i32,
-        };
-        init
+    operators {
+        token: b"idtransform\x00" as *const u8 as *const i8,
+        opcode: 81,
     },
-    {
-        let mut init = operators {
-            token: b"findfont\x00" as *const u8 as *const i8,
-            opcode: 201i32,
-        };
-        init
+    operators {
+        token: b"findfont\x00" as *const u8 as *const i8,
+        opcode: 201,
     },
-    {
-        let mut init = operators {
-            token: b"scalefont\x00" as *const u8 as *const i8,
-            opcode: 202i32,
-        };
-        init
+    operators {
+        token: b"scalefont\x00" as *const u8 as *const i8,
+        opcode: 202,
     },
-    {
-        let mut init = operators {
-            token: b"setfont\x00" as *const u8 as *const i8,
-            opcode: 203i32,
-        };
-        init
+    operators {
+        token: b"setfont\x00" as *const u8 as *const i8,
+        opcode: 203,
     },
-    {
-        let mut init = operators {
-            token: b"currentfont\x00" as *const u8 as *const i8,
-            opcode: 204i32,
-        };
-        init
+    operators {
+        token: b"currentfont\x00" as *const u8 as *const i8,
+        opcode: 204,
     },
-    {
-        let mut init = operators {
-            token: b"stringwidth\x00" as *const u8 as *const i8,
-            opcode: 210i32,
-        };
-        init
+    operators {
+        token: b"stringwidth\x00" as *const u8 as *const i8,
+        opcode: 210,
     },
-    {
-        let mut init = operators {
-            token: b"def\x00" as *const u8 as *const i8,
-            opcode: 999i32,
-        };
-        init
+    operators {
+        token: b"def\x00" as *const u8 as *const i8,
+        opcode: 999,
     },
 ];
 static mut mps_operators: [operators; 28] = [
-    {
-        let mut init = operators {
-            token: b"fshow\x00" as *const u8 as *const i8,
-            opcode: 1001i32,
-        };
-        init
+    operators {
+        token: b"fshow\x00" as *const u8 as *const i8,
+        opcode: 1001,
     },
-    {
-        let mut init = operators {
-            token: b"startTexFig\x00" as *const u8 as *const i8,
-            opcode: 1002i32,
-        };
-        init
+    operators {
+        token: b"startTexFig\x00" as *const u8 as *const i8,
+        opcode: 1002,
     },
-    {
-        let mut init = operators {
-            token: b"endTexFig\x00" as *const u8 as *const i8,
-            opcode: 1003i32,
-        };
-        init
+    operators {
+        token: b"endTexFig\x00" as *const u8 as *const i8,
+        opcode: 1003,
     },
-    {
-        let mut init = operators {
-            token: b"hlw\x00" as *const u8 as *const i8,
-            opcode: 1004i32,
-        };
-        init
+    operators {
+        token: b"hlw\x00" as *const u8 as *const i8,
+        opcode: 1004,
     },
-    {
-        let mut init = operators {
-            token: b"vlw\x00" as *const u8 as *const i8,
-            opcode: 1005i32,
-        };
-        init
+    operators {
+        token: b"vlw\x00" as *const u8 as *const i8,
+        opcode: 1005,
     },
-    {
-        let mut init = operators {
-            token: b"l\x00" as *const u8 as *const i8,
-            opcode: 37i32,
-        };
-        init
+    operators {
+        token: b"l\x00" as *const u8 as *const i8,
+        opcode: 37,
     },
-    {
-        let mut init = operators {
-            token: b"r\x00" as *const u8 as *const i8,
-            opcode: 38i32,
-        };
-        init
+    operators {
+        token: b"r\x00" as *const u8 as *const i8,
+        opcode: 38,
     },
-    {
-        let mut init = operators {
-            token: b"c\x00" as *const u8 as *const i8,
-            opcode: 35i32,
-        };
-        init
+    operators {
+        token: b"c\x00" as *const u8 as *const i8,
+        opcode: 35,
     },
-    {
-        let mut init = operators {
-            token: b"m\x00" as *const u8 as *const i8,
-            opcode: 33i32,
-        };
-        init
+    operators {
+        token: b"m\x00" as *const u8 as *const i8,
+        opcode: 33,
     },
-    {
-        let mut init = operators {
-            token: b"p\x00" as *const u8 as *const i8,
-            opcode: 32i32,
-        };
-        init
+    operators {
+        token: b"p\x00" as *const u8 as *const i8,
+        opcode: 32,
     },
-    {
-        let mut init = operators {
-            token: b"n\x00" as *const u8 as *const i8,
-            opcode: 31i32,
-        };
-        init
+    operators {
+        token: b"n\x00" as *const u8 as *const i8,
+        opcode: 31,
     },
-    {
-        let mut init = operators {
-            token: b"C\x00" as *const u8 as *const i8,
-            opcode: 72i32,
-        };
-        init
+    operators {
+        token: b"C\x00" as *const u8 as *const i8,
+        opcode: 72,
     },
-    {
-        let mut init = operators {
-            token: b"G\x00" as *const u8 as *const i8,
-            opcode: 70i32,
-        };
-        init
+    operators {
+        token: b"G\x00" as *const u8 as *const i8,
+        opcode: 70,
     },
-    {
-        let mut init = operators {
-            token: b"R\x00" as *const u8 as *const i8,
-            opcode: 71i32,
-        };
-        init
+    operators {
+        token: b"R\x00" as *const u8 as *const i8,
+        opcode: 71,
     },
-    {
-        let mut init = operators {
-            token: b"lj\x00" as *const u8 as *const i8,
-            opcode: 63i32,
-        };
-        init
+    operators {
+        token: b"lj\x00" as *const u8 as *const i8,
+        opcode: 63,
     },
-    {
-        let mut init = operators {
-            token: b"ml\x00" as *const u8 as *const i8,
-            opcode: 64i32,
-        };
-        init
+    operators {
+        token: b"ml\x00" as *const u8 as *const i8,
+        opcode: 64,
     },
-    {
-        let mut init = operators {
-            token: b"lc\x00" as *const u8 as *const i8,
-            opcode: 62i32,
-        };
-        init
+    operators {
+        token: b"lc\x00" as *const u8 as *const i8,
+        opcode: 62,
     },
-    {
-        let mut init = operators {
-            token: b"S\x00" as *const u8 as *const i8,
-            opcode: 42i32,
-        };
-        init
+    operators {
+        token: b"S\x00" as *const u8 as *const i8,
+        opcode: 42,
     },
-    {
-        let mut init = operators {
-            token: b"F\x00" as *const u8 as *const i8,
-            opcode: 41i32,
-        };
-        init
+    operators {
+        token: b"F\x00" as *const u8 as *const i8,
+        opcode: 41,
     },
-    {
-        let mut init = operators {
-            token: b"q\x00" as *const u8 as *const i8,
-            opcode: 50i32,
-        };
-        init
+    operators {
+        token: b"q\x00" as *const u8 as *const i8,
+        opcode: 50,
     },
-    {
-        let mut init = operators {
-            token: b"Q\x00" as *const u8 as *const i8,
-            opcode: 51i32,
-        };
-        init
+    operators {
+        token: b"Q\x00" as *const u8 as *const i8,
+        opcode: 51,
     },
-    {
-        let mut init = operators {
-            token: b"s\x00" as *const u8 as *const i8,
-            opcode: 53i32,
-        };
-        init
+    operators {
+        token: b"s\x00" as *const u8 as *const i8,
+        opcode: 53,
     },
-    {
-        let mut init = operators {
-            token: b"t\x00" as *const u8 as *const i8,
-            opcode: 52i32,
-        };
-        init
+    operators {
+        token: b"t\x00" as *const u8 as *const i8,
+        opcode: 52,
     },
-    {
-        let mut init = operators {
-            token: b"sd\x00" as *const u8 as *const i8,
-            opcode: 61i32,
-        };
-        init
+    operators {
+        token: b"sd\x00" as *const u8 as *const i8,
+        opcode: 61,
     },
-    {
-        let mut init = operators {
-            token: b"rd\x00" as *const u8 as *const i8,
-            opcode: 1006i32,
-        };
-        init
+    operators {
+        token: b"rd\x00" as *const u8 as *const i8,
+        opcode: 1006,
     },
-    {
-        let mut init = operators {
-            token: b"P\x00" as *const u8 as *const i8,
-            opcode: 49i32,
-        };
-        init
+    operators {
+        token: b"P\x00" as *const u8 as *const i8,
+        opcode: 49,
     },
-    {
-        let mut init = operators {
-            token: b"B\x00" as *const u8 as *const i8,
-            opcode: 1007i32,
-        };
-        init
+    operators {
+        token: b"B\x00" as *const u8 as *const i8,
+        opcode: 1007,
     },
-    {
-        let mut init = operators {
-            token: b"W\x00" as *const u8 as *const i8,
-            opcode: 44i32,
-        };
-        init
+    operators {
+        token: b"W\x00" as *const u8 as *const i8,
+        opcode: 44,
     },
 ];
 unsafe fn get_opcode(mut token: *const i8) -> i32 {

--- a/dpx/src/dpx_pdfcolor.rs
+++ b/dpx/src/dpx_pdfcolor.rs
@@ -1045,13 +1045,10 @@ pub unsafe extern "C" fn iccp_load_profile(
     cspc_id = pdf_colorspace_defineresource(ident, 4i32, cdata, resource);
     cspc_id
 }
-static mut CSPC_CACHE: CspcCache = {
-    let mut init = CspcCache {
-        count: 0_u32,
-        capacity: 0_u32,
-        colorspaces: 0 as *const pdf_colorspace as *mut pdf_colorspace,
-    };
-    init
+static mut CSPC_CACHE: CspcCache = CspcCache {
+    count: 0_u32,
+    capacity: 0_u32,
+    colorspaces: 0 as *const pdf_colorspace as *mut pdf_colorspace,
 };
 unsafe fn pdf_colorspace_findresource(
     mut ident: *const i8,

--- a/dpx/src/dpx_pdfdev.rs
+++ b/dpx/src/dpx_pdfdev.rs
@@ -273,13 +273,10 @@ pub unsafe extern "C" fn pdf_dev_set_verbose(mut level: i32) {
 pub unsafe extern "C" fn pdf_dev_scale() -> f64 {
     1.0f64
 }
-static mut dev_unit: DevUnit = {
-    let mut init = DevUnit {
-        dvi2pts: 0.0f64,
-        min_bp_val: 658i32,
-        precision: 2i32,
-    };
-    init
+static mut dev_unit: DevUnit = DevUnit {
+    dvi2pts: 0.0f64,
+    min_bp_val: 658i32,
+    precision: 2i32,
 };
 #[no_mangle]
 pub unsafe extern "C" fn dev_unit_dviunit() -> f64 {
@@ -473,12 +470,9 @@ pub unsafe extern "C" fn pdf_sprint_number(buf: &mut [u8], mut value: f64) -> us
     buf[len] = 0;
     len
 }
-static mut dev_param: DevParam = {
-    let mut init = DevParam {
-        autorotate: 1i32,
-        colormode: 1i32,
-    };
-    init
+static mut dev_param: DevParam = DevParam {
+    autorotate: 1i32,
+    colormode: 1i32,
 };
 static mut motion_state: MotionState = MotionState::GRAPHICS_MODE;
 static mut format_buffer: [u8; 4096] = [0; 4096];

--- a/dpx/src/dpx_pdfdoc.rs
+++ b/dpx/src/dpx_pdfdoc.rs
@@ -2766,14 +2766,11 @@ pub unsafe extern "C" fn pdf_doc_end_grabbing(mut attrib: *mut pdf_obj) {
     pdf_dev_reset_color(0i32);
     free(fnode as *mut libc::c_void);
 }
-static mut breaking_state: C2RustUnnamed_4 = {
-    let mut init = C2RustUnnamed_4 {
-        dirty: 0i32,
-        broken: 0i32,
-        annot_dict: 0 as *const pdf_obj as *mut pdf_obj,
-        rect: pdf_rect::new(),
-    };
-    init
+static mut breaking_state: C2RustUnnamed_4 = C2RustUnnamed_4 {
+    dirty: 0i32,
+    broken: 0i32,
+    annot_dict: 0 as *const pdf_obj as *mut pdf_obj,
+    rect: pdf_rect::new(),
 };
 unsafe fn reset_box() {
     breaking_state.rect.lly = ::std::f64::INFINITY;

--- a/dpx/src/dpx_pdfencoding.rs
+++ b/dpx/src/dpx_pdfencoding.rs
@@ -325,13 +325,10 @@ unsafe fn load_encoding_file(mut filename: *const i8) -> i32 {
     }
     enc_id
 }
-static mut enc_cache: C2RustUnnamed = {
-    let mut init = C2RustUnnamed {
-        count: 0i32,
-        capacity: 0i32,
-        encodings: 0 as *const pdf_encoding as *mut pdf_encoding,
-    };
-    init
+static mut enc_cache: C2RustUnnamed = C2RustUnnamed {
+    count: 0i32,
+    capacity: 0i32,
+    encodings: 0 as *const pdf_encoding as *mut pdf_encoding,
 };
 #[no_mangle]
 pub unsafe extern "C" fn pdf_init_encodings() {

--- a/dpx/src/dpx_pdffont.rs
+++ b/dpx/src/dpx_pdffont.rs
@@ -303,13 +303,10 @@ unsafe fn pdf_clean_font_struct(mut font: *mut pdf_font) {
         (*font).usedchars = 0 as *mut i8
     };
 }
-static mut font_cache: C2RustUnnamed_0 = {
-    let mut init = C2RustUnnamed_0 {
-        count: 0i32,
-        capacity: 0i32,
-        fonts: 0 as *const pdf_font as *mut pdf_font,
-    };
-    init
+static mut font_cache: C2RustUnnamed_0 = C2RustUnnamed_0 {
+    count: 0i32,
+    capacity: 0i32,
+    fonts: 0 as *const pdf_font as *mut pdf_font,
 };
 #[no_mangle]
 pub unsafe extern "C" fn pdf_init_fonts() {

--- a/dpx/src/dpx_pdfobj.rs
+++ b/dpx/src/dpx_pdfobj.rs
@@ -4142,16 +4142,13 @@ unsafe extern "C" fn import_dict(
     pdf_add_dict(copy, pdf_name_value(&*key).to_bytes(), tmp); // TODO: check
     0i32
 }
-static mut loop_marker: pdf_obj = {
-    let mut init = pdf_obj {
-        typ: 0i32,
-        label: 0_u32,
-        generation: 0_u16,
-        refcount: 0_u32,
-        flags: 0i32,
-        data: 0 as *const libc::c_void as *mut libc::c_void,
-    };
-    init
+static mut loop_marker: pdf_obj = pdf_obj {
+    typ: 0i32,
+    label: 0_u32,
+    generation: 0_u16,
+    refcount: 0_u32,
+    flags: 0i32,
+    data: 0 as *const libc::c_void as *mut libc::c_void,
 };
 unsafe fn pdf_import_indirect(mut object: *mut pdf_obj) -> *mut pdf_obj {
     let mut pf: *mut pdf_file = (*((*object).data as *mut pdf_indirect)).pf;

--- a/dpx/src/dpx_pdfresource.rs
+++ b/dpx/src/dpx_pdfresource.rs
@@ -68,68 +68,41 @@ pub struct C2RustUnnamed {
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
 static mut pdf_resource_categories: [C2RustUnnamed; 9] = [
-    {
-        let mut init = C2RustUnnamed {
-            name: b"Font\x00" as *const u8 as *const i8,
-            cat_id: 0i32,
-        };
-        init
+    C2RustUnnamed {
+        name: b"Font\x00" as *const u8 as *const i8,
+        cat_id: 0,
     },
-    {
-        let mut init = C2RustUnnamed {
-            name: b"CIDFont\x00" as *const u8 as *const i8,
-            cat_id: 1i32,
-        };
-        init
+    C2RustUnnamed {
+        name: b"CIDFont\x00" as *const u8 as *const i8,
+        cat_id: 1,
     },
-    {
-        let mut init = C2RustUnnamed {
-            name: b"Encoding\x00" as *const u8 as *const i8,
-            cat_id: 2i32,
-        };
-        init
+    C2RustUnnamed {
+        name: b"Encoding\x00" as *const u8 as *const i8,
+        cat_id: 2,
     },
-    {
-        let mut init = C2RustUnnamed {
-            name: b"CMap\x00" as *const u8 as *const i8,
-            cat_id: 3i32,
-        };
-        init
+    C2RustUnnamed {
+        name: b"CMap\x00" as *const u8 as *const i8,
+        cat_id: 3,
     },
-    {
-        let mut init = C2RustUnnamed {
-            name: b"XObject\x00" as *const u8 as *const i8,
-            cat_id: 4i32,
-        };
-        init
+    C2RustUnnamed {
+        name: b"XObject\x00" as *const u8 as *const i8,
+        cat_id: 4,
     },
-    {
-        let mut init = C2RustUnnamed {
-            name: b"ColorSpace\x00" as *const u8 as *const i8,
-            cat_id: 5i32,
-        };
-        init
+    C2RustUnnamed {
+        name: b"ColorSpace\x00" as *const u8 as *const i8,
+        cat_id: 5,
     },
-    {
-        let mut init = C2RustUnnamed {
-            name: b"Shading\x00" as *const u8 as *const i8,
-            cat_id: 6i32,
-        };
-        init
+    C2RustUnnamed {
+        name: b"Shading\x00" as *const u8 as *const i8,
+        cat_id: 6,
     },
-    {
-        let mut init = C2RustUnnamed {
-            name: b"Pattern\x00" as *const u8 as *const i8,
-            cat_id: 7i32,
-        };
-        init
+    C2RustUnnamed {
+        name: b"Pattern\x00" as *const u8 as *const i8,
+        cat_id: 7,
     },
-    {
-        let mut init = C2RustUnnamed {
-            name: b"ExtGState\x00" as *const u8 as *const i8,
-            cat_id: 8i32,
-        };
-        init
+    C2RustUnnamed {
+        name: b"ExtGState\x00" as *const u8 as *const i8,
+        cat_id: 8,
     },
 ];
 static mut resources: [res_cache; 9] = [res_cache {

--- a/dpx/src/dpx_pdfximage.rs
+++ b/dpx/src/dpx_pdfximage.rs
@@ -132,24 +132,18 @@ pub struct ic_ {
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-static mut _opts: opt_ = {
-    let mut init = opt_ {
-        verbose: 0i32,
-        cmdtmpl: 0 as *const i8 as *mut i8,
-    };
-    init
+static mut _opts: opt_ = opt_ {
+    verbose: 0i32,
+    cmdtmpl: 0 as *const i8 as *mut i8,
 };
 #[no_mangle]
 pub unsafe extern "C" fn pdf_ximage_set_verbose(mut level: i32) {
     _opts.verbose = level;
 }
-static mut _ic: ic_ = {
-    let mut init = ic_ {
-        count: 0i32,
-        capacity: 0i32,
-        ximages: 0 as *const pdf_ximage as *mut pdf_ximage,
-    };
-    init
+static mut _ic: ic_ = ic_ {
+    count: 0i32,
+    capacity: 0i32,
+    ximages: 0 as *const pdf_ximage as *mut pdf_ximage,
 };
 unsafe fn pdf_init_ximage_struct(mut I: *mut pdf_ximage) {
     (*I).ident = 0 as *mut i8;

--- a/dpx/src/dpx_tt_cmap.rs
+++ b/dpx/src/dpx_tt_cmap.rs
@@ -1218,40 +1218,25 @@ unsafe fn create_ToUnicode_cmap(
     stream
 }
 static mut cmap_plat_encs: [cmap_plat_enc_rec; 5] = [
-    {
-        let mut init = cmap_plat_enc_rec {
-            platform: 3_i16,
-            encoding: 10_i16,
-        };
-        init
+    cmap_plat_enc_rec {
+        platform: 3,
+        encoding: 10,
     },
-    {
-        let mut init = cmap_plat_enc_rec {
-            platform: 0_i16,
-            encoding: 3_i16,
-        };
-        init
+    cmap_plat_enc_rec {
+        platform: 0,
+        encoding: 3,
     },
-    {
-        let mut init = cmap_plat_enc_rec {
-            platform: 0_i16,
-            encoding: 0_i16,
-        };
-        init
+    cmap_plat_enc_rec {
+        platform: 0,
+        encoding: 0,
     },
-    {
-        let mut init = cmap_plat_enc_rec {
-            platform: 3_i16,
-            encoding: 1_i16,
-        };
-        init
+    cmap_plat_enc_rec {
+        platform: 3,
+        encoding: 1,
     },
-    {
-        let mut init = cmap_plat_enc_rec {
-            platform: 0_i16,
-            encoding: 1_i16,
-        };
-        init
+    cmap_plat_enc_rec {
+        platform: 0,
+        encoding: 1,
     },
 ];
 #[no_mangle]

--- a/dpx/src/dpx_type0.rs
+++ b/dpx/src/dpx_type0.rs
@@ -301,13 +301,10 @@ pub unsafe extern "C" fn Type0Font_get_resource(mut font: *mut Type0Font) -> *mu
     }
     pdf_link_obj((*font).indirect)
 }
-static mut __cache: font_cache = {
-    let mut init = font_cache {
-        count: 0i32,
-        capacity: 0i32,
-        fonts: 0 as *const Type0Font as *mut Type0Font,
-    };
-    init
+static mut __cache: font_cache = font_cache {
+    count: 0i32,
+    capacity: 0i32,
+    fonts: 0 as *const Type0Font as *mut Type0Font,
 };
 #[no_mangle]
 pub unsafe extern "C" fn Type0Font_cache_init() {

--- a/dpx/src/specials/html.rs
+++ b/dpx/src/specials/html.rs
@@ -86,17 +86,11 @@ use crate::dpx_pdfdev::pdf_coord;
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-static mut _HTML_STATE: spc_html_ = {
-    let mut init = spc_html_ {
-        opts: {
-            let mut init = C2RustUnnamed_0 { extensions: 0i32 };
-            init
-        },
-        link_dict: 0 as *const pdf_obj as *mut pdf_obj,
-        baseurl: 0 as *const i8 as *mut i8,
-        pending_type: -1i32,
-    };
-    init
+static mut _HTML_STATE: spc_html_ = spc_html_ {
+    opts: C2RustUnnamed_0 { extensions: 0 },
+    link_dict: 0 as *const pdf_obj as *mut pdf_obj,
+    baseurl: 0 as *const i8 as *mut i8,
+    pending_type: -1,
 };
 /* ENABLE_HTML_SVG_TRANSFORM */
 unsafe fn parse_key_val(

--- a/dpx/src/specials/pdfm.rs
+++ b/dpx/src/specials/pdfm.rs
@@ -133,21 +133,18 @@ use crate::dpx_pdfdev::pdf_coord;
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-static mut _PDF_STAT: spc_pdf_ = {
-    let mut init = spc_pdf_ {
-        annot_dict: 0 as *const pdf_obj as *mut pdf_obj,
-        lowest_level: 255i32,
-        resourcemap: 0 as *const ht_table as *mut ht_table,
-        cd: {
-            let mut init = tounicode {
-                cmap_id: -1i32,
-                unescape_backslash: 0i32,
-                taintkeys: 0 as *const pdf_obj as *mut pdf_obj,
-            };
-            init
-        },
-    };
-    init
+static mut _PDF_STAT: spc_pdf_ = spc_pdf_ {
+    annot_dict: 0 as *const pdf_obj as *mut pdf_obj,
+    lowest_level: 255i32,
+    resourcemap: 0 as *const ht_table as *mut ht_table,
+    cd: {
+        let mut init = tounicode {
+            cmap_id: -1i32,
+            unescape_backslash: 0i32,
+            taintkeys: 0 as *const pdf_obj as *mut pdf_obj,
+        };
+        init
+    },
 };
 /* PLEASE REMOVE THIS */
 unsafe extern "C" fn hval_free(mut vp: *mut libc::c_void) {


### PR DESCRIPTION
The repeat in `dpx/src/dpx_mpost.rs` is tiring.
A lot of code have pattern 
```rust
static STATIC: Struct = {
    let mut init = Struct {...};
    init
};
```
It should be simplified.