### PR TITLE
xetex get_date_and_time: pull from SOURCE_DATE_EPOCH

### DIFF
--- a/dpx/src/dpx_pdffont.rs
+++ b/dpx/src/dpx_pdffont.rs
@@ -185,17 +185,7 @@ pub unsafe extern "C" fn pdf_font_make_uniqueTag(mut tag: *mut i8) {
         return;
     }
     if unique_tag_state != 0 {
-        let current_time = match get_unique_time_if_given() {
-            Some(x) => x,
-            None => SystemTime::now(),
-        };
-
-        let seconds_since_epoch = current_time
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap_or_else(|x| x.duration())
-            .as_secs();
-
-        srand(seconds_since_epoch as _);
+        srand(0);
         unique_tag_state = 0i32
     }
     for i in 0..6 {

--- a/engine/src/xetex_texmfmp.rs
+++ b/engine/src/xetex_texmfmp.rs
@@ -16,6 +16,8 @@ use crate::xetex_stringpool::make_string;
 use crate::{ttstub_get_data_md5, ttstub_get_file_md5};
 use libc::{free, strlen};
 
+use std::env;
+
 pub type size_t = u64;
 pub type str_number = i32;
 pub type packed_UTF16_code = u16;
@@ -33,7 +35,16 @@ static mut last_lineno: i32 = 0;
 pub fn get_date_and_time() -> (i32, i32, i32, i32) {
     use chrono::prelude::*;
 
-    let tm = Local::now();
+    let tm = match env::var("SOURCE_DATE_EPOCH").ok() {
+        Some(s) => {
+            let epoch = u64::from_str_radix(&s, 10).expect("invalid build date (not a number)");
+            std::time::SystemTime::UNIX_EPOCH
+                .checked_add(std::time::Duration::from_secs(epoch))
+                .expect("time overflow")
+                .into()
+        }
+        None => Local::now(),
+    };
 
     let year = tm.year();
     let month = tm.month();


### PR DESCRIPTION
This replicates the change in https://github.com/tectonic-typesetting/tectonic/pull/486 with a minimal diff
and is necessary to be able to compare outputs of this fork and tectonic@master.