### PR TITLE
Replace all libz-sys code with flate2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,7 +371,6 @@ dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "miniz_oxide 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1497,7 +1497,6 @@ dependencies = [
  "flate2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "libpng-sys 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "md-5 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,9 +365,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "flate2"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1210,7 +1211,7 @@ dependencies = [
  "cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie_store 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding_rs 0.8.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "flate2 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1458,7 +1459,7 @@ version = "0.1.12-dev"
 dependencies = [
  "app_dirs2 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "flate2 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "headers 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1493,6 +1494,7 @@ version = "0.0.1-dev"
 dependencies = [
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "libpng-sys 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1962,7 +1964,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "flate2 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "podio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2011,7 +2013,7 @@ dependencies = [
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
-"checksum flate2 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "2adaffba6388640136149e18ed080b77a78611c1e1d6de75aedcdf78df5d4682"
+"checksum flate2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ad3c5233c9a940c8719031b423d7e6c16af66e031cb0420b0896f5245bf181d3"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ crate-type = ["rlib"]
 app_dirs2 = "^2"
 structopt = "0.3"
 error-chain = "^0.12"
-flate2 = { version = "^1.0", default-features = false, features = ["zlib"] }
+flate2 = "1.0.12"
 fs2 = "^0.4"
 headers = "^0.2"
 lazy_static = "^1.4"

--- a/dpx/Cargo.toml
+++ b/dpx/Cargo.toml
@@ -10,16 +10,12 @@ license = "GPL"
 tectonic_bridge = { version = "0.0.1-dev", path = "../bridge" }
 libc = "0.2"
 libpng-sys = "1.1.8"
-libz-sys = { version = "1", optional = true}
 md-5 = "0.8.0"
 sha2 = "0.8.0"
 rand = "0.7.2"
 chrono = "0.4.9"
-flate2 = "1.0.12"
-
-[features]
-default = ['libz-sys']
-legacy-libz = ['libz-sys']
+# to ensure binaries are not different, we link to libz-sys
+flate2 = { version = "1.0.12", default-features = false, features = ["zlib"] }
 
 [build-dependencies]
 cc = "^1.0"

--- a/dpx/Cargo.toml
+++ b/dpx/Cargo.toml
@@ -15,7 +15,7 @@ sha2 = "0.8.0"
 rand = "0.7.2"
 chrono = "0.4.9"
 # to ensure binaries are not different, we link to libz-sys
-flate2 = { version = "1.0.12", default-features = false, features = ["zlib"] }
+flate2 = "1.0.12"
 
 [build-dependencies]
 cc = "^1.0"

--- a/dpx/Cargo.toml
+++ b/dpx/Cargo.toml
@@ -15,6 +15,7 @@ md-5 = "0.8.0"
 sha2 = "0.8.0"
 rand = "0.7.2"
 chrono = "0.4.9"
+flate2 = "1.0.12"
 
 [features]
 default = ['libz-sys']

--- a/dpx/src/dpx_pdfobj.rs
+++ b/dpx/src/dpx_pdfobj.rs
@@ -52,8 +52,6 @@ use crate::{
 use bridge::_tt_abort;
 use libc::{atof, atoi, free, memcmp, memset, strlen, strtoul};
 
-use libz_sys as libz;
-
 pub type __ssize_t = i64;
 pub type size_t = u64;
 use bridge::{InputHandleWrapper, OutputHandleWrapper};
@@ -260,14 +258,6 @@ static mut compression_level: i8 = 9_i8;
 static mut compression_use_predictor: i8 = 1_i8;
 #[no_mangle]
 pub unsafe extern "C" fn pdf_set_compression(mut level: i32) {
-    if cfg!(not(feature = "libz-sys")) {
-        panic!(
-            "You don\'t have compression compiled in. Possibly libz wasn\'t found by configure."
-        );
-    }
-    if cfg!(feature = "legacy-libz") && level != 0i32 {
-        warn!("Unable to set compression level -- your zlib doesn\'t have compress2().");
-    }
     if level >= 0i32 && level <= 9i32 {
         compression_level = level as i8
     } else {
@@ -1542,7 +1532,6 @@ pub unsafe extern "C" fn pdf_stream_set_predictor(
  *   absolute differences heuristic and was first proposed by Lee Daniel
  *   Crocker in February 1995.
  */
-#[cfg(feature = "libz-sys")]
 unsafe fn filter_PNG15_apply_filter(
     mut raster: *mut libc::c_uchar,
     mut columns: i32,
@@ -1749,7 +1738,6 @@ unsafe fn filter_PNG15_apply_filter(
  *  Evince(poppler)    2.32.0.145      NG (1bit and 4bit broken)
  */
 /* This modifies "raster" itself! */
-#[cfg(feature = "libz-sys")]
 unsafe fn apply_filter_TIFF2_1_2_4(
     mut raster: *mut libc::c_uchar,
     mut width: i32,
@@ -1818,7 +1806,6 @@ unsafe fn apply_filter_TIFF2_1_2_4(
     }
     free(prev as *mut libc::c_void);
 }
-#[cfg(feature = "libz-sys")]
 unsafe fn filter_TIFF2_apply_filter(
     mut raster: *mut libc::c_uchar,
     mut columns: i32,
@@ -1899,7 +1886,6 @@ unsafe fn filter_TIFF2_apply_filter(
     }
     return dst;
 }
-#[cfg(feature = "libz-sys")]
 unsafe fn filter_create_predictor_dict(
     mut predictor: libc::c_int,
     mut columns: i32,
@@ -1933,128 +1919,109 @@ unsafe fn write_stream(mut stream: *mut pdf_stream, handle: &mut OutputHandleWra
         (*stream)._flags &= !(1i32 << 0i32)
     }
     /* Apply compression filter if requested */
-    #[cfg(feature = "libz-sys")]
-    {
-        if (*stream).stream.len() > 0
-            && (*stream)._flags & 1i32 << 0i32 != 0
+    if (*stream).stream.len() > 0
+        && (*stream)._flags & 1i32 << 0i32 != 0
             && compression_level as libc::c_int > 0i32
-        {
-            /* First apply predictor filter if requested. */
-            if compression_use_predictor as libc::c_int != 0
-                && (*stream)._flags & 1i32 << 1i32 != 0
+    {
+        /* First apply predictor filter if requested. */
+        if compression_use_predictor as libc::c_int != 0
+            && (*stream)._flags & 1i32 << 1i32 != 0
                 && pdf_lookup_dict((*stream).dict, "DecodeParms").is_none()
-            {
-                let mut bits_per_pixel: libc::c_int =
-                    (*stream).decodeparms.colors * (*stream).decodeparms.bits_per_component;
-                let mut len: i32 = ((*stream).decodeparms.columns * bits_per_pixel + 7i32) / 8i32;
-                let mut rows: i32 =
-                    ((*stream).stream.len() as i32) / len;
-                let mut filtered2: *mut libc::c_uchar = 0 as *mut libc::c_uchar;
-                let mut length2: i32 = (*stream).stream.len() as i32;
-                let parms = filter_create_predictor_dict(
-                    (*stream).decodeparms.predictor,
-                    (*stream).decodeparms.columns,
-                    (*stream).decodeparms.bits_per_component,
-                    (*stream).decodeparms.colors,
-                );
-                match (*stream).decodeparms.predictor {
-                    2 => {
-                        /* TIFF2 */
-                        filtered2 = filter_TIFF2_apply_filter(
-                            filtered,
-                            (*stream).decodeparms.columns,
-                            rows,
-                            (*stream).decodeparms.bits_per_component as i8,
-                            (*stream).decodeparms.colors as i8,
-                            &mut length2,
-                        )
-                    }
-                    15 => {
-                        /* PNG optimun */
-                        filtered2 = filter_PNG15_apply_filter(
-                            filtered,
-                            (*stream).decodeparms.columns,
-                            rows,
-                            (*stream).decodeparms.bits_per_component as i8,
-                            (*stream).decodeparms.colors as i8,
-                            &mut length2,
-                        )
-                    }
-                    _ => {
-                        warn!(
-                            "Unknown/unsupported Predictor function {}.",
-                            (*stream).decodeparms.predictor
-                        );
-                    }
+        {
+            let mut bits_per_pixel: libc::c_int =
+                (*stream).decodeparms.colors * (*stream).decodeparms.bits_per_component;
+            let mut len: i32 = ((*stream).decodeparms.columns * bits_per_pixel + 7i32) / 8i32;
+            let mut rows: i32 =
+                ((*stream).stream.len() as i32) / len;
+            let mut filtered2: *mut libc::c_uchar = 0 as *mut libc::c_uchar;
+            let mut length2: i32 = (*stream).stream.len() as i32;
+            let parms = filter_create_predictor_dict(
+                (*stream).decodeparms.predictor,
+                (*stream).decodeparms.columns,
+                (*stream).decodeparms.bits_per_component,
+                (*stream).decodeparms.colors,
+            );
+            match (*stream).decodeparms.predictor {
+                2 => {
+                    /* TIFF2 */
+                    filtered2 = filter_TIFF2_apply_filter(
+                        filtered,
+                        (*stream).decodeparms.columns,
+                        rows,
+                        (*stream).decodeparms.bits_per_component as i8,
+                        (*stream).decodeparms.colors as i8,
+                        &mut length2,
+                    )
                 }
-                if !parms.is_null() && !filtered2.is_null() {
-                    free(filtered as *mut libc::c_void);
-                    filtered = filtered2;
-                    filtered_length = length2 as libc::c_uint;
-                    pdf_add_dict((*stream).dict, "DecodeParms", parms);
+                15 => {
+                    /* PNG optimun */
+                    filtered2 = filter_PNG15_apply_filter(
+                        filtered,
+                        (*stream).decodeparms.columns,
+                        rows,
+                        (*stream).decodeparms.bits_per_component as i8,
+                        (*stream).decodeparms.colors as i8,
+                        &mut length2,
+                    )
+                }
+                _ => {
+                    warn!(
+                        "Unknown/unsupported Predictor function {}.",
+                        (*stream).decodeparms.predictor
+                    );
                 }
             }
-            let filters = pdf_lookup_dict((*stream).dict, "Filter");
-            let mut buffer_length: libz::uLong;
-            buffer_length = filtered_length
-                .wrapping_add(filtered_length.wrapping_div(1000i32 as libc::c_uint))
-                .wrapping_add(14i32 as libc::c_uint) as libz::uLong;
-            let buffer = new((buffer_length as u32 as u64)
-                .wrapping_mul(::std::mem::size_of::<libc::c_uchar>() as u64)
-                as u32) as *mut libc::c_uchar;
-            let mut filter_name: *mut pdf_obj = pdf_new_name("FlateDecode");
-            if let Some(filters) = filters {
-                /*
-                 * FlateDecode is the first filter to be applied to the stream.
-                 */
-                pdf_unshift_array(filters, filter_name);
-            } else {
-                /*
-                 * Adding the filter as a name instead of a one-element array
-                 * is crucial because otherwise Adobe Reader cannot read the
-                 * cross-reference stream any more, cf. the PDF v1.5 Errata.
-                 */
-                pdf_add_dict((*stream).dict, "Filter", filter_name);
+            if !parms.is_null() && !filtered2.is_null() {
+                free(filtered as *mut libc::c_void);
+                filtered = filtered2;
+                filtered_length = length2 as libc::c_uint;
+                pdf_add_dict((*stream).dict, "DecodeParms", parms);
             }
-
-            #[cfg(not(feature = "legacy-libz"))]
-            {
-                if libz::compress2(
-                    buffer,
-                    &mut buffer_length,
-                    filtered,
-                    filtered_length as libz::uLong,
-                    compression_level as libc::c_int,
-                ) != 0
-                {
-                    panic!("Zlib error");
-                }
-            }
-            #[cfg(feature = "legacy-libz")]
-            {
-                if libz::compress(
-                    buffer,
-                    &mut buffer_length,
-                    filtered,
-                    filtered_length as libz::uLong,
-                ) != 0
-                {
-                    panic!("Zlib error");
-                }
-            }
-            free(filtered as *mut libc::c_void);
-            compression_saved = (compression_saved as u64).wrapping_add(
-                (filtered_length as u64)
-                    .wrapping_sub(buffer_length as u64)
-                    .wrapping_sub(if filters.is_some() {
-                        strlen(b"/FlateDecode \x00" as *const u8 as *const i8)
-                    } else {
-                        strlen(b"/Filter/FlateDecode\n\x00" as *const u8 as *const i8)
-                    } as u64),
-            ) as libc::c_int as libc::c_int;
-            filtered = buffer;
-            filtered_length = buffer_length as libc::c_uint
         }
+        let filters = pdf_lookup_dict((*stream).dict, "Filter");
+        let mut filter_name: *mut pdf_obj = pdf_new_name("FlateDecode");
+        if let Some(filters) = filters {
+            /*
+             * FlateDecode is the first filter to be applied to the stream.
+             */
+            pdf_unshift_array(filters, filter_name);
+        } else {
+            /*
+             * Adding the filter as a name instead of a one-element array
+             * is crucial because otherwise Adobe Reader cannot read the
+             * cross-reference stream any more, cf. the PDF v1.5 Errata.
+             */
+            pdf_add_dict((*stream).dict, "Filter", filter_name);
+        }
+
+        use flate2::Compression;
+        use flate2::bufread::ZlibEncoder;
+        let slice = std::slice::from_raw_parts(filtered, filtered_length as usize);
+        let mut z = ZlibEncoder::new(slice, Compression::new(compression_level as u32));
+        let mut destination = Vec::new();
+        z.read_to_end(&mut destination).expect("Zlib error");
+        let buffer_length = destination.len();
+        let mut destination = destination.into_boxed_slice();
+
+        // Free filtered once slice no longer has a reference to it
+        drop(slice);
+        free(filtered as *mut libc::c_void);
+
+        // compute how much we saved, for posterity
+        compression_saved = (compression_saved as u64).wrapping_add(
+            (filtered_length as u64)
+            .wrapping_sub(buffer_length as u64)
+            .wrapping_sub(if filters.is_some() {
+                strlen(b"/FlateDecode \x00" as *const u8 as *const i8)
+            } else {
+                strlen(b"/Filter/FlateDecode\n\x00" as *const u8 as *const i8)
+            } as u64),
+        ) as libc::c_int as libc::c_int;
+
+        // TODO: keep infecting the code with Vec
+        filtered = destination.as_mut_ptr();
+        filtered_length = buffer_length as libc::c_uint;
+        std::mem::forget(destination);
     }
     /* HAVE_ZLIB */
     /* AES will change the size of data! */
@@ -2188,28 +2155,13 @@ pub unsafe extern "C" fn pdf_add_stream(
     stream_data: *const libc::c_void,
     length: i32,
 ) {
-    if stream.is_null() || !(*stream).is_stream() {
-        panic!(
-            "typecheck: Invalid object type: {} {} (line {})",
-            if !stream.is_null() {
-                (*stream).typ
-            } else {
-                -1i32
-            },
-            7i32,
-            2011i32,
-        );
-    }
-    if length < 1i32 {
-        return;
-    }
     let payload = std::slice::from_raw_parts(stream_data as *const u8, length as usize);
-    let data = (*stream).data as *mut pdf_stream;
-    // We only want this pointer until the end of the function, it's fine
-    let data = unsafe { &mut *data as &mut pdf_stream };
-    data.append(payload)
+    with_stream(stream, move |stream| {
+        stream.append(payload);
+    });
 }
 
+/// Ensure a pdf_obj is a stream, and run a closure with it
 unsafe fn with_stream<T>(obj: *mut pdf_obj, f: impl FnOnce(&mut pdf_stream) -> T + 'static) -> T {
     if obj.is_null() || !(*obj).is_stream() {
         panic!(
@@ -2225,7 +2177,6 @@ unsafe fn with_stream<T>(obj: *mut pdf_obj, f: impl FnOnce(&mut pdf_stream) -> T
     let data = (*obj).data as *mut pdf_stream;
     // We only want this pointer until the end of the function.
     // It's fine because FnOnce and T: 'static cannot hold a reference to it.
-    
     let data = unsafe { &mut *data as &mut pdf_stream };
     f(data)
 }
@@ -2257,7 +2208,6 @@ pub unsafe extern "C" fn pdf_add_stream_flate(
     }
 }
 
-#[cfg(feature = "libz-sys")]
 unsafe fn get_decode_parms(parms: &mut decode_parms, mut dict: *mut pdf_obj) -> libc::c_int {
     assert!(!dict.is_null() && (*dict).is_dict());
     /* Fill with default values */
@@ -2302,7 +2252,6 @@ unsafe fn get_decode_parms(parms: &mut decode_parms, mut dict: *mut pdf_obj) -> 
 /* From Xpdf version 3.04
  * I'm not sure if I properly ported... Untested.
  */
-#[cfg(feature = "libz-sys")]
 unsafe fn filter_row_TIFF2(
     mut dst: *mut libc::c_uchar,
     mut src: *const libc::c_uchar,
@@ -2358,7 +2307,6 @@ unsafe fn filter_row_TIFF2(
  * Especially, calling pdf_add_stream() for each 4 bytes append is highly
  * inefficient.
  */
-#[cfg(feature = "libz-sys")]
 unsafe fn filter_decoded(
     mut dst: *mut pdf_obj,
     mut src: *const libc::c_void,
@@ -2635,66 +2583,63 @@ pub unsafe extern "C" fn pdf_concat_stream(mut dst: *mut pdf_obj, mut src: *mut 
     if filter.is_null() {
         pdf_add_stream(dst, stream_data as *const libc::c_void, stream_length);
     } else {
-        #[cfg(feature = "libz-sys")]
-        {
-            let mut parms = decode_parms {
-                predictor: 0,
-                colors: 0,
-                bits_per_component: 0,
-                columns: 0,
-            };
-            let mut have_parms: libc::c_int = 0i32;
-            if pdf_lookup_dict(stream_dict, "DecodeParms").is_some() {
-                /* Dictionary or array */
-                let mut tmp = pdf_deref_obj(pdf_lookup_dict(stream_dict, "DecodeParms"));
-                if !tmp.is_null() && (*tmp).is_array() {
-                    if pdf_array_length(tmp) > 1i32 as libc::c_uint {
-                        warn!("Unexpected size for DecodeParms array.");
-                        return -1i32;
-                    }
-                    tmp = pdf_deref_obj(Some(pdf_get_array(tmp, 0i32)))
-                }
-                if !(!tmp.is_null() && (*tmp).is_dict()) {
-                    warn!("PDF dict expected for DecodeParms...");
+        let mut parms = decode_parms {
+            predictor: 0,
+            colors: 0,
+            bits_per_component: 0,
+            columns: 0,
+        };
+        let mut have_parms: libc::c_int = 0i32;
+        if pdf_lookup_dict(stream_dict, "DecodeParms").is_some() {
+            /* Dictionary or array */
+            let mut tmp = pdf_deref_obj(pdf_lookup_dict(stream_dict, "DecodeParms"));
+            if !tmp.is_null() && (*tmp).is_array() {
+                if pdf_array_length(tmp) > 1i32 as libc::c_uint {
+                    warn!("Unexpected size for DecodeParms array.");
                     return -1i32;
                 }
-                error = get_decode_parms(&mut parms, tmp);
-                if error != 0 {
-                    panic!("Invalid value(s) in DecodeParms dictionary.");
-                }
-                have_parms = 1i32
+                tmp = pdf_deref_obj(Some(pdf_get_array(tmp, 0i32)))
             }
-            if !filter.is_null() && (*filter).is_array() {
-                if pdf_array_length(filter) > 1i32 as libc::c_uint {
-                    warn!("Multiple DecodeFilter not supported.");
-                    return -1i32;
-                }
-                filter = pdf_get_array(filter, 0i32)
+            if !(!tmp.is_null() && (*tmp).is_dict()) {
+                warn!("PDF dict expected for DecodeParms...");
+                return -1i32;
             }
-            if !filter.is_null() && (*filter).is_name() {
-                let filter_name = pdf_name_value(&*filter).to_string_lossy();
-                if filter_name == "FlateDecode" {
-                    if have_parms != 0 {
-                        error = pdf_add_stream_flate_filtered(
-                            dst,
-                            stream_data as *const libc::c_void,
-                            stream_length,
-                            &mut parms,
-                        )
-                    } else {
-                        error = pdf_add_stream_flate(
-                            dst,
-                            stream_data as *const libc::c_void,
-                            stream_length,
-                        )
-                    }
+            error = get_decode_parms(&mut parms, tmp);
+            if error != 0 {
+                panic!("Invalid value(s) in DecodeParms dictionary.");
+            }
+            have_parms = 1i32
+        }
+        if !filter.is_null() && (*filter).is_array() {
+            if pdf_array_length(filter) > 1i32 as libc::c_uint {
+                warn!("Multiple DecodeFilter not supported.");
+                return -1i32;
+            }
+            filter = pdf_get_array(filter, 0i32)
+        }
+        if !filter.is_null() && (*filter).is_name() {
+            let filter_name = pdf_name_value(&*filter).to_string_lossy();
+            if filter_name == "FlateDecode" {
+                if have_parms != 0 {
+                    error = pdf_add_stream_flate_filtered(
+                        dst,
+                        stream_data as *const libc::c_void,
+                        stream_length,
+                        &mut parms,
+                    )
                 } else {
-                    warn!("DecodeFilter \"{}\" not supported.", filter_name,);
-                    error = -1i32
+                    error = pdf_add_stream_flate(
+                        dst,
+                        stream_data as *const libc::c_void,
+                        stream_length,
+                    )
                 }
             } else {
-                panic!("Broken PDF file?");
+                warn!("DecodeFilter \"{}\" not supported.", filter_name,);
+                error = -1i32
             }
+        } else {
+            panic!("Broken PDF file?");
         }
     }
     /* HAVE_ZLIB */

--- a/engine/build.rs
+++ b/engine/build.rs
@@ -16,12 +16,12 @@ use std::path::{Path, PathBuf};
 
 #[cfg(not(target_os = "macos"))]
 const PKGCONFIG_LIBS: &'static str =
-    "fontconfig harfbuzz >= 1.4 harfbuzz-icu icu-uc freetype2 graphite2 libpng zlib";
+    "fontconfig harfbuzz >= 1.4 harfbuzz-icu icu-uc freetype2 graphite2 libpng";
 
 // No fontconfig on MacOS:
 #[cfg(target_os = "macos")]
 const PKGCONFIG_LIBS: &'static str =
-    "harfbuzz >= 1.4 harfbuzz-icu icu-uc freetype2 graphite2 libpng zlib";
+    "harfbuzz >= 1.4 harfbuzz-icu icu-uc freetype2 graphite2 libpng";
 
 /// Build-script state when using pkg-config as the backend.
 #[derive(Debug)]
@@ -202,10 +202,7 @@ fn main() {
         ccfg.flag_if_supported(flag);
     }
 
-    ccfg.define("HAVE_ZLIB", "1")
-        .define("HAVE_ZLIB_COMPRESS2", "1")
-        .define("ZLIB_CONST", "1")
-        .include(".");
+    ccfg.include(".");
 
     let cppflags = [
         "-std=c++14",


### PR DESCRIPTION
Much less prone to errors; reads directly into pdf_stream `Vec<u8>`.

Relevant: #171