### PR TITLE
Overhaul pdfobj

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,7 +491,7 @@ dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "indexmap 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -632,8 +632,11 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "iovec"
@@ -1493,6 +1496,7 @@ version = "0.0.1-dev"
 dependencies = [
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "libpng-sys 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2038,7 +2042,7 @@ dependencies = [
 "checksum hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
-"checksum indexmap 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a61202fbe46c4a951e9404a720a0180bcf3212c750d735cb5c4ba4dc551299f3"
+"checksum indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d7b3ea5827fcb9d4fda14bf4da5f136f0db2ae9c8f4bd4e2d1c6fde4e6db2"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,6 +299,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,6 +648,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "inflate"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "iovec"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,6 +985,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "pkg-config"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "png"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "deflate 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "inflate 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "podio"
@@ -1501,6 +1529,7 @@ dependencies = [
  "libpng-sys 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "md-5 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "png 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tectonic_bridge 0.0.1-dev",
@@ -2006,6 +2035,7 @@ dependencies = [
 "checksum crossbeam-epoch 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fedcd6772e37f3da2a9af9bf12ebe046c0dfe657992377b4df982a2b54cd37a9"
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
+"checksum deflate 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)" = "707b6a7b384888a70c8d2e8650b3e60170dfc6a67bb4aa67b6dfca57af4bedb4"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
 "checksum dunce 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0ad6bf6a88548d1126045c413548df1453d9be094a8ab9fd59bf1fdd338da4f"
@@ -2043,6 +2073,7 @@ dependencies = [
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d7b3ea5827fcb9d4fda14bf4da5f136f0db2ae9c8f4bd4e2d1c6fde4e6db2"
+"checksum inflate 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1cdb29978cc5797bd8dcc8e5bf7de604891df2a8dc576973d71a281e916db2ff"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
@@ -2082,6 +2113,7 @@ dependencies = [
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 "checksum pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "72d5370d90f49f70bd033c3d75e87fc529fbfff9d6f7cccef07d6170079d91ea"
+"checksum png 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8422b27bb2c013dd97b9aef69e161ce262236f49aaf46a0489011c8ff0264602"
 "checksum podio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "780fb4b6698bbf9cf2444ea5d22411cef2953f0824b98f33cf454ec5615645bd"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
 "checksum proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aeccfe4d5d8ea175d5f0e4a2ad0637e0f4121d63bd99d356fb1f39ab2e7c6097"

--- a/dpx/Cargo.toml
+++ b/dpx/Cargo.toml
@@ -15,6 +15,7 @@ md-5 = "0.8.0"
 sha2 = "0.8.0"
 rand = "0.7.2"
 chrono = "0.4.9"
+indexmap = "1.3.0"
 
 [features]
 default = ['libz-sys']

--- a/dpx/Cargo.toml
+++ b/dpx/Cargo.toml
@@ -16,6 +16,7 @@ sha2 = "0.8.0"
 rand = "0.7.2"
 chrono = "0.4.9"
 indexmap = "1.3.0"
+png = "0.15.0"
 
 [features]
 default = ['libz-sys']

--- a/dpx/src/dpx_cid.rs
+++ b/dpx/src/dpx_cid.rs
@@ -29,6 +29,7 @@
 
 use crate::DisplayExt;
 use std::ffi::CStr;
+use crate::dpx_pdfobj::PdfObjRef;
 
 use crate::dpx_pdfparse::ParsePdfObj;
 use crate::mfree;
@@ -69,9 +70,9 @@ pub struct CIDFont {
     pub parent: [i32; 2],
     pub csi: *mut CIDSysInfo,
     pub options: *mut cid_opt,
-    pub indirect: *mut pdf_obj,
-    pub fontdict: *mut pdf_obj,
-    pub descriptor: *mut pdf_obj,
+    pub indirect: PdfObjRef,
+    pub fontdict: PdfObjRef,
+    pub descriptor: PdfObjRef,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -411,20 +412,20 @@ unsafe fn CIDFont_new() -> *mut CIDFont {
     /*
      * PDF Font Resource
      */
-    (*font).indirect = 0 as *mut pdf_obj;
-    (*font).fontdict = 0 as *mut pdf_obj;
-    (*font).descriptor = 0 as *mut pdf_obj;
+    (*font).indirect = 0 as PdfObjRef;
+    (*font).fontdict = 0 as PdfObjRef;
+    (*font).descriptor = 0 as PdfObjRef;
     font
 }
 /* It does write PDF objects. */
 unsafe fn CIDFont_flush(mut font: *mut CIDFont) {
     if !font.is_null() {
         pdf_release_obj((*font).indirect);
-        (*font).indirect = 0 as *mut pdf_obj;
+        (*font).indirect = 0 as PdfObjRef;
         pdf_release_obj((*font).fontdict);
-        (*font).fontdict = 0 as *mut pdf_obj;
+        (*font).fontdict = 0 as PdfObjRef;
         pdf_release_obj((*font).descriptor);
-        (*font).descriptor = 0 as *mut pdf_obj
+        (*font).descriptor = 0 as PdfObjRef
     };
 }
 unsafe fn CIDFont_release(mut font: *mut CIDFont) {
@@ -498,7 +499,7 @@ pub unsafe extern "C" fn CIDFont_get_parent_id(mut font: *mut CIDFont, mut wmode
     (*font).parent[wmode as usize]
 }
 #[no_mangle]
-pub unsafe extern "C" fn CIDFont_get_resource(mut font: *mut CIDFont) -> *mut pdf_obj {
+pub unsafe extern "C" fn CIDFont_get_resource(mut font: *mut CIDFont) -> PdfObjRef {
     assert!(!font.is_null());
     if (*font).indirect.is_null() {
         (*font).indirect = pdf_ref_obj((*font).fontdict)

--- a/dpx/src/dpx_cidtype0.rs
+++ b/dpx/src/dpx_cidtype0.rs
@@ -29,6 +29,7 @@
 
 use crate::DisplayExt;
 use std::ffi::CStr;
+use crate::dpx_pdfobj::PdfObjRef;
 
 use super::dpx_sfnt::{
     sfnt_close, sfnt_find_table_pos, sfnt_locate_table, sfnt_open, sfnt_read_table_directory,
@@ -165,14 +166,14 @@ pub unsafe extern "C" fn CIDFont_type0_set_flags(mut flags: i32) {
  * PDF Reference 3rd. ed., p.340, "Glyph Metrics in CID Fonts".
  */
 unsafe fn add_CIDHMetrics(
-    mut fontdict: *mut pdf_obj,
+    mut fontdict: PdfObjRef,
     mut CIDToGIDMap: *mut u8,
     mut last_cid: u16,
     mut maxp: *mut tt_maxp_table,
     mut head: *mut tt_head_table,
     mut hmtx: *mut tt_longMetrics,
 ) {
-    let mut an_array: *mut pdf_obj = 0 as *mut pdf_obj;
+    let mut an_array: PdfObjRef = 0 as PdfObjRef;
     let mut start: i32 = 0i32;
     let mut prev: i32 = 0i32;
     let mut empty: i32 = 1i32;
@@ -205,14 +206,14 @@ unsafe fn add_CIDHMetrics(
                 if !an_array.is_null() {
                     pdf_add_array(&mut *w_array, pdf_new_number(start as f64));
                     pdf_add_array(&mut *w_array, an_array);
-                    an_array = 0 as *mut pdf_obj;
+                    an_array = 0 as PdfObjRef;
                     empty = 0i32
                 }
             } else {
                 if cid != prev + 1i32 && !an_array.is_null() {
                     pdf_add_array(&mut *w_array, pdf_new_number(start as f64));
                     pdf_add_array(&mut *w_array, an_array);
-                    an_array = 0 as *mut pdf_obj;
+                    an_array = 0 as PdfObjRef;
                     empty = 0i32
                 }
                 if an_array.is_null() {
@@ -242,7 +243,7 @@ unsafe fn add_CIDHMetrics(
 }
 unsafe fn add_CIDVMetrics(
     mut sfont: *mut sfnt,
-    mut fontdict: *mut pdf_obj,
+    mut fontdict: PdfObjRef,
     mut CIDToGIDMap: *mut u8,
     mut last_cid: u16,
     mut maxp: *mut tt_maxp_table,
@@ -376,7 +377,7 @@ unsafe fn add_CIDVMetrics(
 }
 unsafe fn add_CIDMetrics(
     mut sfont: *mut sfnt,
-    mut fontdict: *mut pdf_obj,
+    mut fontdict: PdfObjRef,
     mut CIDToGIDMap: *mut u8,
     mut last_cid: u16,
     mut need_vmetrics: i32,
@@ -1147,7 +1148,7 @@ pub unsafe extern "C" fn CIDFont_type0_open(
     }
     pdf_add_dict(&mut *(*font).descriptor, "FontName", pdf_copy_name(fontname));
     pdf_add_dict(&mut *(*font).fontdict, "BaseFont", pdf_copy_name(fontname));
-    let mut csi_dict: *mut pdf_obj = pdf_new_dict();
+    let mut csi_dict: PdfObjRef = pdf_new_dict();
     pdf_add_dict(
         &mut *csi_dict,
         "Registry",
@@ -1609,13 +1610,13 @@ unsafe fn create_ToUnicode_stream(
     cffont: &cff_font,
     mut font_name: *const i8,
     mut used_glyphs: *const i8,
-) -> *mut pdf_obj {
-    let mut stream: *mut pdf_obj = 0 as *mut pdf_obj;
+) -> PdfObjRef {
+    let mut stream: PdfObjRef = 0 as PdfObjRef;
     let mut wbuf: [u8; 1024] = [0; 1024];
     static mut range_min: [u8; 2] = [0; 2];
     static mut range_max: [u8; 2] = [0xff, 0xff];
     if font_name.is_null() || used_glyphs.is_null() {
-        return 0 as *mut pdf_obj;
+        return 0 as PdfObjRef;
     }
     let cmap = CMap_new();
     let cmap_name = new((strlen(font_name)

--- a/dpx/src/dpx_cidtype2.rs
+++ b/dpx/src/dpx_cidtype2.rs
@@ -29,6 +29,7 @@
 
 use crate::DisplayExt;
 use std::ffi::CStr;
+use crate::dpx_pdfobj::PdfObjRef;
 
 use super::dpx_sfnt::{
     dfont_open, sfnt_close, sfnt_create_FontFile_stream, sfnt_find_table_pos, sfnt_open,
@@ -416,7 +417,7 @@ unsafe fn find_tocode_cmap(mut reg: *const i8, mut ord: *const i8, mut select: i
  * Mostly same as add_CID[HV]Metrics in cidtype0.c.
  */
 unsafe fn add_TTCIDHMetrics(
-    mut fontdict: *mut pdf_obj,
+    mut fontdict: PdfObjRef,
     mut g: *mut tt_glyphs,
     mut used_chars: *mut i8,
     mut cidtogidmap: *mut u8,
@@ -424,7 +425,7 @@ unsafe fn add_TTCIDHMetrics(
 ) {
     let mut start: i32 = 0i32;
     let mut prev: i32 = 0i32;
-    let mut an_array: *mut pdf_obj = 0 as *mut pdf_obj;
+    let mut an_array: PdfObjRef = 0 as PdfObjRef;
     let mut empty: i32 = 1i32;
     let w_array = pdf_new_array();
     let dw = if (*g).dw as i32 != 0i32 && (*g).dw as i32 <= (*g).emsize as i32 {
@@ -459,7 +460,7 @@ unsafe fn add_TTCIDHMetrics(
                     if !an_array.is_null() {
                         pdf_add_array(&mut *w_array, pdf_new_number(start as f64));
                         pdf_add_array(&mut *w_array, an_array);
-                        an_array = 0 as *mut pdf_obj;
+                        an_array = 0 as PdfObjRef;
                         empty = 0i32
                     }
                 } else {
@@ -467,7 +468,7 @@ unsafe fn add_TTCIDHMetrics(
                         if !an_array.is_null() {
                             pdf_add_array(&mut *w_array, pdf_new_number(start as f64));
                             pdf_add_array(&mut *w_array, an_array);
-                            an_array = 0 as *mut pdf_obj;
+                            an_array = 0 as PdfObjRef;
                             empty = 0i32
                         }
                     }
@@ -493,7 +494,7 @@ unsafe fn add_TTCIDHMetrics(
     pdf_release_obj(w_array);
 }
 unsafe fn add_TTCIDVMetrics(
-    mut fontdict: *mut pdf_obj,
+    mut fontdict: PdfObjRef,
     mut g: *mut tt_glyphs,
     mut used_chars: *mut i8,
     mut last_cid: u16,

--- a/dpx/src/dpx_cmap_write.rs
+++ b/dpx/src/dpx_cmap_write.rs
@@ -29,6 +29,7 @@
 
 use crate::warn;
 
+use crate::dpx_pdfobj::PdfObjRef;
 use super::dpx_cid::{CSI_IDENTITY, CSI_UNICODE};
 use super::dpx_cmap::{CMap_get_CIDSysInfo, CMap_is_valid};
 use super::dpx_mem::new;
@@ -129,7 +130,7 @@ unsafe fn write_map(
     mut codestr: *mut u8,
     mut depth: size_t,
     mut wbuf: *mut sbuf,
-    mut stream: *mut pdf_obj,
+    mut stream: PdfObjRef,
 ) -> i32 {
     /* Must be greater than 1 */
     let mut blocks: [C2RustUnnamed_1; 129] = [C2RustUnnamed_1 { start: 0, count: 0 }; 129];
@@ -349,7 +350,7 @@ unsafe fn write_map(
     count as i32
 }
 #[no_mangle]
-pub unsafe extern "C" fn CMap_create_stream(mut cmap: *mut CMap) -> *mut pdf_obj {
+pub unsafe extern "C" fn CMap_create_stream(mut cmap: *mut CMap) -> PdfObjRef {
     let mut wbuf: sbuf = sbuf {
         buf: 0 as *mut i8,
         curptr: 0 as *mut i8,
@@ -357,10 +358,10 @@ pub unsafe extern "C" fn CMap_create_stream(mut cmap: *mut CMap) -> *mut pdf_obj
     };
     if cmap.is_null() || !CMap_is_valid(cmap) {
         warn!("Invalid CMap");
-        return 0 as *mut pdf_obj;
+        return 0 as PdfObjRef;
     }
     if (*cmap).type_0 == 0i32 {
-        return 0 as *mut pdf_obj;
+        return 0 as PdfObjRef;
     }
     let stream = pdf_new_stream(1i32 << 0i32);
     let stream_dict = pdf_stream_dict(&mut *stream);

--- a/dpx/src/dpx_epdf.rs
+++ b/dpx/src/dpx_epdf.rs
@@ -27,6 +27,7 @@
     unused_mut
 )]
 
+use crate::dpx_pdfobj::PdfObjRef;
 use crate::warn;
 
 //use super::dpx_mem::xmalloc;
@@ -149,7 +150,7 @@ pub const OP_UNKNOWN: C2RustUnnamed_0 = 16;
  * The number of degrees by which the page should be rotated clockwise when
  * displayed or printed. The value must be a multiple of 90. Default value: 0.
  */
-/*unsafe fn rect_equal(mut rect1: *mut pdf_obj, mut rect2: *mut pdf_obj) -> i32 {
+/*unsafe fn rect_equal(mut rect1: PdfObjRef, mut rect2: PdfObjRef) -> i32 {
     if rect1.is_null() || rect2.is_null() {
         return 0i32;
     }
@@ -163,33 +164,33 @@ pub const OP_UNKNOWN: C2RustUnnamed_0 = 16;
 /*unsafe fn pdf_get_page_obj(
     mut pf: *mut pdf_file,
     mut page_no: i32,
-    mut ret_bbox: *mut *mut pdf_obj,
-    mut ret_resources: *mut *mut pdf_obj,
-) -> *mut pdf_obj {
-    let mut page_tree: *mut pdf_obj = 0 as *mut pdf_obj;
-    let mut bbox: *mut pdf_obj = 0 as *mut pdf_obj;
-    let mut resources: *mut pdf_obj = 0 as *mut pdf_obj;
-    let mut rotate: *mut pdf_obj = 0 as *mut pdf_obj;
+    mut ret_bbox: *mut PdfObjRef,
+    mut ret_resources: *mut PdfObjRef,
+) -> PdfObjRef {
+    let mut page_tree: PdfObjRef = 0 as PdfObjRef;
+    let mut bbox: PdfObjRef = 0 as PdfObjRef;
+    let mut resources: PdfObjRef = 0 as PdfObjRef;
+    let mut rotate: PdfObjRef = 0 as PdfObjRef;
     let mut page_idx: i32 = 0;
     /*
      * Get Page Tree.
      */
-    page_tree = 0 as *mut pdf_obj;
-    let mut trailer: *mut pdf_obj = 0 as *mut pdf_obj;
-    let mut catalog: *mut pdf_obj = 0 as *mut pdf_obj;
-    let mut markinfo: *mut pdf_obj = 0 as *mut pdf_obj;
+    page_tree = 0 as PdfObjRef;
+    let mut trailer: PdfObjRef = 0 as PdfObjRef;
+    let mut catalog: PdfObjRef = 0 as PdfObjRef;
+    let mut markinfo: PdfObjRef = 0 as PdfObjRef;
     trailer = pdf_file_get_trailer(pf);
     if pdf_lookup_dict(trailer, "Encrypt").is_some() {
         warn!("This PDF document is encrypted.");
         pdf_release_obj(trailer);
-        return 0 as *mut pdf_obj;
+        return 0 as PdfObjRef;
     }
     catalog = pdf_deref_obj(pdf_lookup_dict(trailer, "Root"));
     if !(!catalog.is_null() && pdf_obj_typeof(catalog) == PdfObjType::DICT) {
         warn!("Can\'t read document catalog.");
         pdf_release_obj(trailer);
         pdf_release_obj(catalog);
-        return 0 as *mut pdf_obj;
+        return 0 as PdfObjRef;
     }
     pdf_release_obj(trailer);
     markinfo = pdf_deref_obj(pdf_lookup_dict(catalog, "MarkInfo"));
@@ -206,7 +207,7 @@ pub const OP_UNKNOWN: C2RustUnnamed_0 = 16;
     pdf_release_obj(catalog);
     if page_tree.is_null() {
         warn!("Page tree not found.");
-        return 0 as *mut pdf_obj;
+        return 0 as PdfObjRef;
     }
     /*
      * Negative page numbers are counted from the back.
@@ -216,15 +217,15 @@ pub const OP_UNKNOWN: C2RustUnnamed_0 = 16;
     if page_idx < 0i32 || page_idx >= count {
         warn!("Page {} does not exist.", page_no);
         pdf_release_obj(page_tree);
-        return 0 as *mut pdf_obj;
+        return 0 as PdfObjRef;
     }
     page_no = page_idx + 1i32;
     /*
      * Seek correct page. Get Media/Crop Box.
      * Media box and resources can be inherited.
      */
-    let mut kids: *mut pdf_obj = 0 as *mut pdf_obj;
-    let mut crop_box: *mut pdf_obj = 0 as *mut pdf_obj;
+    let mut kids: PdfObjRef = 0 as PdfObjRef;
+    let mut crop_box: PdfObjRef = 0 as PdfObjRef;
     let tmp = pdf_lookup_dict(page_tree, "Resources");
     if tmp.is_some() {
         pdf_deref_obj(tmp)
@@ -315,7 +316,7 @@ pub const OP_UNKNOWN: C2RustUnnamed_0 = 16;
             pdf_release_obj(rotate);
             pdf_release_obj(resources);
             pdf_release_obj(page_tree);
-            return 0 as *mut pdf_obj;
+            return 0 as PdfObjRef;
         }
     }
     if !crop_box.is_null() {
@@ -327,11 +328,11 @@ pub const OP_UNKNOWN: C2RustUnnamed_0 = 16;
         pdf_release_obj(page_tree);
         pdf_release_obj(resources);
         pdf_release_obj(rotate);
-        return 0 as *mut pdf_obj;
+        return 0 as PdfObjRef;
     }
     if !rotate.is_null() {
         pdf_release_obj(rotate);
-        rotate = 0 as *mut pdf_obj
+        rotate = 0 as PdfObjRef
     }
     if !ret_bbox.is_null() {
         *ret_bbox = bbox
@@ -341,12 +342,12 @@ pub const OP_UNKNOWN: C2RustUnnamed_0 = 16;
     }
     page_tree
 }
-unsafe fn pdf_get_page_content(mut page: *mut pdf_obj) -> *mut pdf_obj {
-    let mut contents: *mut pdf_obj = 0 as *mut pdf_obj;
-    let mut content_new: *mut pdf_obj = 0 as *mut pdf_obj;
+unsafe fn pdf_get_page_content(mut page: PdfObjRef) -> PdfObjRef {
+    let mut contents: PdfObjRef = 0 as PdfObjRef;
+    let mut content_new: PdfObjRef = 0 as PdfObjRef;
     contents = pdf_deref_obj(pdf_lookup_dict(page, "Contents"));
     if contents.is_null() {
-        return 0 as *mut pdf_obj;
+        return 0 as PdfObjRef;
     }
     if pdf_obj_typeof(contents) == PdfObjType::NULL {
         /* empty page */
@@ -357,7 +358,7 @@ unsafe fn pdf_get_page_content(mut page: *mut pdf_obj) -> *mut pdf_obj {
         /*
          * Concatenate all content streams.
          */
-        let mut content_seg: *mut pdf_obj = 0 as *mut pdf_obj;
+        let mut content_seg: PdfObjRef = 0 as PdfObjRef;
         let mut idx: i32 = 0i32;
         content_new = pdf_new_stream(1i32 << 0i32);
         loop {
@@ -371,14 +372,14 @@ unsafe fn pdf_get_page_content(mut page: *mut pdf_obj) -> *mut pdf_obj {
                     pdf_release_obj(content_seg);
                     pdf_release_obj(content_new);
                     pdf_release_obj(contents);
-                    return 0 as *mut pdf_obj;
+                    return 0 as PdfObjRef;
                 } else {
                     if pdf_concat_stream(content_new, content_seg) < 0i32 {
                         warn!("Could not handle content stream with multiple segments.");
                         pdf_release_obj(content_seg);
                         pdf_release_obj(content_new);
                         pdf_release_obj(contents);
-                        return 0 as *mut pdf_obj;
+                        return 0 as PdfObjRef;
                     }
                 }
             }
@@ -391,7 +392,7 @@ unsafe fn pdf_get_page_content(mut page: *mut pdf_obj) -> *mut pdf_obj {
         if !(!contents.is_null() && pdf_obj_typeof(contents) == PdfObjType::STREAM) {
             warn!("Page content not a stream object. Broken PDF file?");
             pdf_release_obj(contents);
-            return 0 as *mut pdf_obj;
+            return 0 as PdfObjRef;
         }
         /* Flate the contents if necessary. */
         content_new = pdf_new_stream(1i32 << 0i32);
@@ -399,7 +400,7 @@ unsafe fn pdf_get_page_content(mut page: *mut pdf_obj) -> *mut pdf_obj {
             warn!("Could not handle a content stream.");
             pdf_release_obj(contents);
             pdf_release_obj(content_new);
-            return 0 as *mut pdf_obj;
+            return 0 as PdfObjRef;
         }
         pdf_release_obj(contents);
         contents = content_new
@@ -415,9 +416,9 @@ pub unsafe extern "C" fn pdf_include_page(
     mut options: load_options,
 ) -> i32 {
     let mut info = xform_info::default();
-    let mut contents: *mut pdf_obj = 0 as *mut pdf_obj;
-    let mut resources: *mut pdf_obj = 0 as *mut pdf_obj;
-    let mut markinfo: *mut pdf_obj = 0 as *mut pdf_obj;
+    let mut contents: PdfObjRef = 0 as PdfObjRef;
+    let mut resources: PdfObjRef = 0 as PdfObjRef;
+    let mut markinfo: PdfObjRef = 0 as PdfObjRef;
     let pf = pdf_open(ident, handle);
     if pf.is_null() {
         return -1;
@@ -461,7 +462,7 @@ pub unsafe extern "C" fn pdf_include_page(
     let catalog = pdf_file_get_catalog(pf);
     markinfo = pdf_deref_obj(pdf_lookup_dict(&mut *catalog, "MarkInfo"));
     if !markinfo.is_null() {
-        let mut tmp: *mut pdf_obj = pdf_deref_obj(pdf_lookup_dict(&mut *markinfo, "Marked"));
+        let mut tmp: PdfObjRef = pdf_deref_obj(pdf_lookup_dict(&mut *markinfo, "Marked"));
         pdf_release_obj(markinfo);
         if tmp.is_null() || !(*tmp).is_boolean() {
             pdf_release_obj(tmp);
@@ -478,7 +479,7 @@ pub unsafe extern "C" fn pdf_include_page(
     /*
      * Handle page content stream.
      */
-    let mut content_new: *mut pdf_obj;
+    let mut content_new: PdfObjRef;
     if contents.is_null() {
         /*
          * Empty page
@@ -498,7 +499,7 @@ pub unsafe extern "C" fn pdf_include_page(
         let mut len: i32 = pdf_array_length(&*contents) as i32;
         content_new = pdf_new_stream(1i32 << 0i32);
         for idx in 0..len {
-            let mut content_seg: *mut pdf_obj =
+            let mut content_seg: PdfObjRef =
                 pdf_deref_obj(Some(pdf_get_array(&mut *contents, idx)));
             if content_seg.is_null()
             || !(*content_seg).is_stream()
@@ -832,8 +833,8 @@ pub unsafe extern "C" fn pdf_copy_clip(
     mut x_user: f64,
     mut y_user: f64,
 ) -> i32 {
-    let mut page_tree: *mut pdf_obj = 0 as *mut pdf_obj; /* silence uninitialized warning */
-    let mut contents: *mut pdf_obj = 0 as *mut pdf_obj;
+    let mut page_tree: PdfObjRef = 0 as PdfObjRef; /* silence uninitialized warning */
+    let mut contents: PdfObjRef = 0 as PdfObjRef;
     let mut depth: i32 = 0i32;
     let mut top: i32 = -1i32;
     let mut clip_path: *const i8 = 0 as *const i8;
@@ -851,7 +852,7 @@ pub unsafe extern "C" fn pdf_copy_clip(
     pdf_invertmatrix(&mut M);
     M.e += x_user;
     M.f += y_user;
-    page_tree = pdf_get_page_obj(pf, pageNo, 0 as *mut *mut pdf_obj, 0 as *mut *mut pdf_obj);
+    page_tree = pdf_get_page_obj(pf, pageNo, 0 as *mut PdfObjRef, 0 as *mut PdfObjRef);
     if page_tree.is_null() {
         pdf_close(pf);
         return -1i32;

--- a/dpx/src/dpx_pdfdev.rs
+++ b/dpx/src/dpx_pdfdev.rs
@@ -30,6 +30,7 @@
 use crate::DisplayExt;
 use crate::{info, warn};
 use std::ffi::CStr;
+use crate::dpx_pdfobj::PdfObjRef;
 
 use super::dpx_cff::cff_charsets_lookup_cid;
 use super::dpx_cmap::{CMap_cache_get, CMap_decode};
@@ -271,7 +272,7 @@ pub struct dev_font {
     pub font_id: i32,
     pub enc_id: i32,
     pub real_font_index: i32,
-    pub resource: *mut pdf_obj,
+    pub resource: PdfObjRef,
     pub used_chars: *mut i8,
     pub format: i32,
     pub wmode: i32,
@@ -1440,7 +1441,7 @@ pub unsafe extern "C" fn pdf_close_device() {
             let ref mut fresh43 = (*dev_fonts.offset(i as isize)).tex_name;
             *fresh43 = 0 as *mut i8;
             let ref mut fresh44 = (*dev_fonts.offset(i as isize)).resource;
-            *fresh44 = 0 as *mut pdf_obj;
+            *fresh44 = 0 as PdfObjRef;
             let ref mut fresh45 = (*dev_fonts.offset(i as isize)).cff_charsets;
             *fresh45 = 0 as *mut cff_charsets;
         }
@@ -1624,7 +1625,7 @@ pub unsafe extern "C" fn pdf_dev_locate_font(mut font_name: *const i8, mut ptsiz
     }
     (*font).wmode = pdf_get_font_wmode((*font).font_id);
     (*font).enc_id = pdf_get_font_encoding((*font).font_id);
-    (*font).resource = 0 as *mut pdf_obj;
+    (*font).resource = 0 as PdfObjRef;
     (*font).used_chars = 0 as *mut i8;
     (*font).extend = 1.0f64;
     (*font).slant = 0.0f64;

--- a/dpx/src/dpx_pdfencrypt.rs
+++ b/dpx/src/dpx_pdfencrypt.rs
@@ -28,6 +28,7 @@
 )]
 
 use std::slice::from_raw_parts;
+use crate::dpx_pdfobj::PdfObjRef;
 
 use super::dpx_dpxcrypt::ARC4_CONTEXT;
 use super::dpx_dpxcrypt::{AES_cbc_encrypt_tectonic, AES_ecb_encrypt, ARC4_set_key, ARC4};
@@ -761,7 +762,7 @@ pub unsafe extern "C" fn pdf_encrypt_data(
     };
 }
 #[no_mangle]
-pub unsafe extern "C" fn pdf_encrypt_obj() -> *mut pdf_obj {
+pub unsafe extern "C" fn pdf_encrypt_obj() -> PdfObjRef {
     let p = &mut sec_data;
     let mut doc_encrypt = pdf_new_dict();
     pdf_add_dict(&mut *doc_encrypt, "Filter", pdf_new_name("Standard"));
@@ -861,7 +862,7 @@ pub unsafe extern "C" fn pdf_encrypt_obj() -> *mut pdf_obj {
         free(cipher as *mut libc::c_void);
     }
     if p.R > 5i32 {
-        let mut catalog: *mut pdf_obj =
+        let mut catalog: PdfObjRef =
             pdf_doc_get_dictionary("Catalog");
         let mut ext = pdf_new_dict();
         let mut adbe = pdf_new_dict();
@@ -877,9 +878,9 @@ pub unsafe extern "C" fn pdf_encrypt_obj() -> *mut pdf_obj {
     doc_encrypt
 }
 #[no_mangle]
-pub unsafe extern "C" fn pdf_enc_id_array() -> *mut pdf_obj {
+pub unsafe extern "C" fn pdf_enc_id_array() -> PdfObjRef {
     let p = &mut sec_data;
-    let mut id: *mut pdf_obj = pdf_new_array();
+    let mut id: PdfObjRef = pdf_new_array();
     pdf_add_array(
         &mut *id,
         pdf_new_string(p.ID.as_mut_ptr() as *const libc::c_void, 16i32 as size_t),

--- a/dpx/src/dpx_pdfobj.rs
+++ b/dpx/src/dpx_pdfobj.rs
@@ -1267,6 +1267,9 @@ pub unsafe extern "C" fn pdf_dict_keys(dict: &pdf_obj) -> PdfObjRef {
     let keys = pdf_new_array();
     let array = (&mut *keys).get_array_mut();
     for (k, v) in dict.inner.iter() {
+        /* We duplicate name object rather than linking keys.
+         * If we forget to free keys, broken PDF is generated.
+         */
         array.values.push(pdf_new_name(k.name.as_bytes()))
     }
     keys

--- a/dpx/src/dpx_pdfobj.rs
+++ b/dpx/src/dpx_pdfobj.rs
@@ -1247,10 +1247,12 @@ pub unsafe extern "C" fn pdf_foreach_dict(
 ) -> i32 {
     let proc = proc_0.expect("non-null function pointer");
     let dict = dict.get_dict_mut();
-    let mut make_key_ptr = |key: &PdfName| safe_new_obj(PdfObjType::NAME, |object| {
-        object.data = Box::into_raw(Box::new(key.clone())) as *mut libc::c_void;
-    });
-    dict.foreach_dict(|k, v, pdata| proc(make_key_ptr(k), v, pdata), pdata)
+    dict.foreach_dict(|k, v, pdata| {
+        let tmp_key_ptr = pdf_new_name(k.name.as_bytes());
+        let e = proc(tmp_key_ptr, v, pdata);
+        pdf_release_obj(tmp_key_ptr);
+        e
+    }, pdata)
 }
 
 pub unsafe fn pdf_lookup_dict<K>(dict: &mut pdf_obj, name: K) -> Option<PdfObjRef>

--- a/dpx/src/dpx_pdfobj.rs
+++ b/dpx/src/dpx_pdfobj.rs
@@ -2193,8 +2193,9 @@ unsafe fn filter_decoded(
             }
         }
     } else {
-        let mut prev = vec![0u8; len_usize];
-        let mut current = vec![0u8; len_usize];
+        let mut rowlen = len_usize + 1;
+        let mut prev = vec![0u8; rowlen];
+        let mut current = vec![0u8; rowlen];
         match parms.predictor {
             // PNG can improve its compression ratios by applying filters to each scanline of the image.
             // FlateDecode incorporates these filtering methods.
@@ -2207,7 +2208,6 @@ unsafe fn filter_decoded(
                  // The prediction algorithm can change from line to line
             => {
                 let mut typ = (parms.predictor - 10) as u8;
-                let mut rowlen = len_usize + 1;
                 let mut chunks = src_stream.stream.chunks_exact(rowlen);
                 let bytes_per_pixel = bytes_per_pixel as usize;
                 while let Some(p) = chunks.next() {

--- a/dpx/src/dpx_pdfobj.rs
+++ b/dpx/src/dpx_pdfobj.rs
@@ -222,12 +222,12 @@ pub struct xref_entry {
     pub indirect: PdfObjRef,
 }
 
-use std::collections::HashMap;
+use indexmap::IndexMap;
 
 #[derive(Clone)]
 #[repr(C)]
 pub struct pdf_dict {
-    inner: HashMap<PdfName, PdfObjRef>,
+    inner: IndexMap<PdfName, PdfObjRef>,
 }
 
 impl pdf_dict {
@@ -1186,7 +1186,7 @@ unsafe fn write_dict(dict: &pdf_dict, handle: &mut OutputHandleWrapper) {
 pub fn pdf_new_dict() -> PdfObjRef {
     safe_new_obj(PdfObjType::DICT, |object| {
         let boxed = Box::new(pdf_dict {
-            inner: HashMap::new(),
+            inner: IndexMap::new(),
         });
         object.data = Box::into_raw(boxed) as *mut libc::c_void;
     })
@@ -1194,7 +1194,7 @@ pub fn pdf_new_dict() -> PdfObjRef {
 
 unsafe fn release_dict(mut data: *mut pdf_dict) {
     let mut boxed = Box::from_raw(data);
-    for (_k, v) in boxed.inner.drain() {
+    for (_k, v) in boxed.inner.drain(..) {
         unsafe {
             pdf_release_obj(v);
         }

--- a/dpx/src/dpx_pkfont.rs
+++ b/dpx/src/dpx_pkfont.rs
@@ -30,6 +30,7 @@
 use crate::warn;
 use crate::DisplayExt;
 use std::ffi::CStr;
+use crate::dpx_pdfobj::PdfObjRef;
 
 use super::dpx_mem::new;
 use super::dpx_mfileio::work_buffer_u8 as work_buffer;
@@ -239,11 +240,11 @@ unsafe fn pk_packed_num(mut np: *mut u32, mut dyn_f: i32, mut dp: *mut u8, mut p
     *np = i;
     nmbr
 }
-unsafe fn send_out(mut rowptr: *mut u8, mut rowbytes: u32, mut stream: *mut pdf_obj) {
+unsafe fn send_out(mut rowptr: *mut u8, mut rowbytes: u32, mut stream: PdfObjRef) {
     pdf_add_stream(&mut *stream, rowptr as *mut libc::c_void, rowbytes as i32);
 }
 unsafe fn pk_decode_packed(
-    mut stream: *mut pdf_obj,
+    mut stream: PdfObjRef,
     mut wd: u32,
     mut ht: u32,
     mut dyn_f: i32,
@@ -347,7 +348,7 @@ unsafe fn pk_decode_packed(
     0i32
 }
 unsafe fn pk_decode_bitmap(
-    mut stream: *mut pdf_obj,
+    mut stream: PdfObjRef,
     mut wd: u32,
     mut ht: u32,
     mut dyn_f: i32,
@@ -482,7 +483,7 @@ unsafe fn create_pk_CharProc_stream(
     mut chrwid: f64,
     mut pkt_ptr: *mut u8,
     mut pkt_len: u32,
-) -> *mut pdf_obj {
+) -> PdfObjRef {
     let llx = -(*pkh).bm_hoff;
     let lly = ((*pkh).bm_voff as u32).wrapping_sub((*pkh).bm_ht) as i32;
     let urx = (*pkh).bm_wd.wrapping_sub((*pkh).bm_hoff as u32) as i32;

--- a/dpx/src/dpx_sfnt.rs
+++ b/dpx/src/dpx_sfnt.rs
@@ -28,6 +28,7 @@
 )]
 
 use tectonic_bridge::ttstub_input_close;
+use crate::dpx_pdfobj::PdfObjRef;
 
 use super::dpx_mem::{new, renew};
 use super::dpx_numbers::{tt_get_unsigned_pair, tt_get_unsigned_quad};
@@ -366,7 +367,7 @@ static mut padbytes: [u8; 4] = [0; 4];
 /* get_***_*** from numbers.h */
 /* table directory */
 #[no_mangle]
-pub unsafe extern "C" fn sfnt_create_FontFile_stream(mut sfont: *mut sfnt) -> *mut pdf_obj {
+pub unsafe extern "C" fn sfnt_create_FontFile_stream(mut sfont: *mut sfnt) -> PdfObjRef {
     let mut length;
     assert!(!sfont.is_null() && !(*sfont).directory.is_null());
     let stream = pdf_new_stream(1i32 << 0i32);

--- a/dpx/src/dpx_truetype.rs
+++ b/dpx/src/dpx_truetype.rs
@@ -27,6 +27,7 @@
     unused_mut
 )]
 
+use crate::dpx_pdfobj::PdfObjRef;
 use super::dpx_sfnt::{
     dfont_open, sfnt_close, sfnt_create_FontFile_stream, sfnt_open, sfnt_read_table_directory,
     sfnt_require_table, sfnt_set_table,
@@ -1033,7 +1034,7 @@ unsafe fn do_custom_encoding(
 }
 #[no_mangle]
 pub unsafe extern "C" fn pdf_font_load_truetype(mut font: *mut pdf_font) -> i32 {
-    let mut descriptor: *mut pdf_obj = pdf_font_get_descriptor(font);
+    let mut descriptor: PdfObjRef = pdf_font_get_descriptor(font);
     let mut ident: *mut i8 = pdf_font_get_ident(font);
     let mut encoding_id: i32 = pdf_font_get_encoding(font);
     let mut usedchars: *mut i8 = pdf_font_get_usedchars(font);

--- a/dpx/src/dpx_tt_aux.rs
+++ b/dpx/src/dpx_tt_aux.rs
@@ -27,6 +27,7 @@
     unused_mut
 )]
 
+use crate::dpx_pdfobj::PdfObjRef;
 use crate::DisplayExt;
 use std::ffi::CStr;
 
@@ -82,7 +83,7 @@ pub unsafe extern "C" fn tt_get_fontdesc(
     mut stemv: i32,
     mut type_0: i32,
     mut fontname: *const i8,
-) -> *mut pdf_obj {
+) -> PdfObjRef {
     let mut flag: i32 = 1i32 << 2i32;
     if sfont.is_null() {
         panic!("font file not opened");
@@ -94,7 +95,7 @@ pub unsafe extern "C" fn tt_get_fontdesc(
     if post.is_null() {
         free(os2 as *mut libc::c_void);
         free(head as *mut libc::c_void);
-        return 0 as *mut pdf_obj;
+        return 0 as PdfObjRef;
     }
     let descriptor = pdf_new_dict();
     pdf_add_dict(&mut *descriptor, "Type", pdf_new_name("FontDescriptor"));

--- a/dpx/src/dpx_tt_cmap.rs
+++ b/dpx/src/dpx_tt_cmap.rs
@@ -27,6 +27,7 @@
     unused_mut
 )]
 
+use crate::dpx_pdfobj::PdfObjRef;
 use super::dpx_sfnt::{
     dfont_open, sfnt_close, sfnt_find_table_pos, sfnt_locate_table, sfnt_open,
     sfnt_read_table_directory,
@@ -1091,7 +1092,7 @@ unsafe fn create_ToUnicode_cmap(
     mut used_chars: *const i8,
     mut sfont: *mut sfnt,
     mut code_to_cid_cmap: *mut CMap,
-) -> *mut pdf_obj {
+) -> PdfObjRef {
     let mut count: u16 = 0_u16;
     let mut cffont = prepare_CIDFont_from_sfnt(&mut *sfont);
     let mut is_cidfont = if let Some(cffont) = &cffont {
@@ -1207,7 +1208,7 @@ unsafe fn create_ToUnicode_cmap(
             ) as i32) as u16
     }
     let stream = if (count as i32) < 1i32 {
-        0 as *mut pdf_obj
+        0 as PdfObjRef
     } else {
         CMap_create_stream(cmap)
     };
@@ -1260,8 +1261,8 @@ pub unsafe extern "C" fn otf_create_ToUnicode_stream(
     mut ttc_index: i32,
     mut used_chars: *const i8,
     mut cmap_id: i32,
-) -> *mut pdf_obj {
-    let mut cmap_obj: *mut pdf_obj = 0 as *mut pdf_obj;
+) -> PdfObjRef {
+    let mut cmap_obj: PdfObjRef = 0 as PdfObjRef;
     let mut ttcmap: *mut tt_cmap = 0 as *mut tt_cmap;
     let offset;
     /* replace slash in map name with dash to make the output cmap name valid,
@@ -1309,7 +1310,7 @@ pub unsafe extern "C" fn otf_create_ToUnicode_stream(
         dfont_open(handle, ttc_index)
     } else {
         free(cmap_name as *mut libc::c_void);
-        return 0 as *mut pdf_obj;
+        return 0 as PdfObjRef;
     };
     if sfont.is_null() {
         panic!(
@@ -1389,7 +1390,7 @@ pub unsafe extern "C" fn otf_create_ToUnicode_stream(
         );
         pdf_get_resource_reference(res_id)
     } else {
-        0 as *mut pdf_obj
+        0 as PdfObjRef
     };
     free(cmap_name as *mut libc::c_void);
     sfnt_close(sfont);

--- a/dpx/src/dpx_type1.rs
+++ b/dpx/src/dpx_type1.rs
@@ -32,6 +32,7 @@ use crate::streq_ptr;
 use crate::DisplayExt;
 use crate::{info, warn};
 use std::ffi::CStr;
+use crate::dpx_pdfobj::PdfObjRef;
 
 use super::dpx_cff::{
     cff_add_string, cff_close, cff_get_seac_sid, cff_glyph_lookup, cff_index_size, cff_new_index,
@@ -514,7 +515,7 @@ unsafe fn add_metrics(
 unsafe fn write_fontfile(
     mut font: *mut pdf_font,
     cffont: &cff_font,
-    mut pdfcharset: *mut pdf_obj,
+    mut pdfcharset: PdfObjRef,
 ) -> i32 {
     let mut wbuf: [u8; 1024] = [0; 1024];
     let descriptor = pdf_font_get_descriptor(font);

--- a/dpx/src/specials.rs
+++ b/dpx/src/specials.rs
@@ -34,6 +34,7 @@ pub mod xtx;
 use crate::warn;
 use crate::DisplayExt;
 use std::ffi::{CStr, CString};
+use crate::dpx_pdfobj::PdfObjRef;
 
 use self::color::{spc_color_check_special, spc_color_setup_handler};
 use self::dvipdfmx::{spc_dvipdfmx_check_special, spc_dvipdfmx_setup_handler};
@@ -115,7 +116,7 @@ pub unsafe fn spc_set_verbose(mut level: i32) {
 /* This is currently just to make other spc_xxx to not directly
  * call dvi_xxx.
  */
-pub unsafe extern "C" fn spc_begin_annot(mut _spe: *mut spc_env, mut dict: *mut pdf_obj) -> i32 {
+pub unsafe extern "C" fn spc_begin_annot(mut _spe: *mut spc_env, mut dict: PdfObjRef) -> i32 {
     pdf_doc_begin_annot(dict); /* Tell dvi interpreter to handle line-break. */
     dvi_tag_depth();
     0i32
@@ -173,7 +174,7 @@ unsafe fn ispageref(mut key: *const i8) -> i32 {
     1i32
 }
 
-pub unsafe fn spc_lookup_reference(mut key: &CString) -> Option<*mut pdf_obj> {
+pub unsafe fn spc_lookup_reference(mut key: &CString) -> Option<PdfObjRef> {
     assert!(!NAMED_OBJECTS.is_null());
     let value = match key.to_bytes() {
         b"xpos" => {
@@ -220,10 +221,10 @@ pub unsafe fn spc_lookup_reference(mut key: &CString) -> Option<*mut pdf_obj> {
         Some(value)
     }
 }
-pub unsafe extern "C" fn spc_lookup_object(mut key: *const i8) -> *mut pdf_obj {
+pub unsafe extern "C" fn spc_lookup_object(mut key: *const i8) -> PdfObjRef {
     assert!(!NAMED_OBJECTS.is_null());
     if key.is_null() {
-        return 0 as *mut pdf_obj;
+        return 0 as PdfObjRef;
     }
     let mut k = 0i32;
     while !_RKEYS[k as usize].is_null() && strcmp(key, _RKEYS[k as usize]) != 0 {
@@ -262,7 +263,7 @@ pub unsafe extern "C" fn spc_lookup_object(mut key: *const i8) -> *mut pdf_obj {
     */
     return value; /* _FIXME_ */
 }
-pub unsafe extern "C" fn spc_push_object(mut key: *const i8, mut value: *mut pdf_obj) {
+pub unsafe extern "C" fn spc_push_object(mut key: *const i8, mut value: PdfObjRef) {
     assert!(!NAMED_OBJECTS.is_null());
     if key.is_null() || value.is_null() {
         return;

--- a/dpx/src/specials/dvips.rs
+++ b/dpx/src/specials/dvips.rs
@@ -27,6 +27,7 @@
 
 use crate::DisplayExt;
 use std::ffi::{CStr, CString};
+use crate::dpx_pdfobj::PdfObjRef;
 
 use crate::mfree;
 use crate::warn;
@@ -144,7 +145,7 @@ unsafe fn spc_handler_ps_file(mut spe: *mut spc_env, mut args: *mut spc_arg) -> 
         let mut init = load_options {
             page_no: 1i32,
             bbox_type: 0i32,
-            dict: 0 as *mut pdf_obj,
+            dict: 0 as PdfObjRef,
         };
         init
     };
@@ -184,7 +185,7 @@ unsafe fn spc_handler_ps_plotfile(mut spe: *mut spc_env, mut args: *mut spc_arg)
         let mut init = load_options {
             page_no: 1i32,
             bbox_type: 0i32,
-            dict: 0 as *mut pdf_obj,
+            dict: 0 as PdfObjRef,
         };
         init
     };

--- a/dpx/src/specials/html.rs
+++ b/dpx/src/specials/html.rs
@@ -28,6 +28,7 @@ unused_mut
 use crate::dpx_error::dpx_warning;
 use crate::DisplayExt;
 use std::ffi::{CStr, CString};
+use crate::dpx_pdfobj::PdfObjRef;
 
 use crate::dpx_pdfdraw::{pdf_dev_concat, pdf_dev_transform};
 use crate::dpx_pdfximage::{
@@ -62,7 +63,7 @@ use super::SpcHandler;
 #[repr(C)]
 pub struct spc_html_ {
     pub opts: C2RustUnnamed_0,
-    pub link_dict: *mut pdf_obj,
+    pub link_dict: PdfObjRef,
     pub baseurl: *mut i8,
     pub pending_type: i32,
 }
@@ -90,7 +91,7 @@ static mut _HTML_STATE: spc_html_ = {
             let mut init = C2RustUnnamed_0 { extensions: 0i32 };
             init
         },
-        link_dict: 0 as *const pdf_obj as *mut pdf_obj,
+        link_dict: 0 as *const pdf_obj as PdfObjRef,
         baseurl: 0 as *const i8 as *mut i8,
         pending_type: -1i32,
     };
@@ -151,7 +152,7 @@ unsafe fn parse_key_val(
 }
 
 unsafe fn read_html_tag(
-    mut attr: *mut pdf_obj,
+    mut attr: PdfObjRef,
     type_0: &mut i32,
     pp: &mut &[u8],
 ) -> Result<Vec<u8>, ()> {
@@ -232,7 +233,7 @@ unsafe fn read_html_tag(
 
 unsafe fn spc_handler_html__init(mut dp: *mut libc::c_void) -> i32 {
     let mut sd: *mut spc_html_ = dp as *mut spc_html_;
-    (*sd).link_dict = 0 as *mut pdf_obj;
+    (*sd).link_dict = 0 as PdfObjRef;
     (*sd).baseurl = 0 as *mut i8;
     (*sd).pending_type = -1i32;
     0i32
@@ -247,7 +248,7 @@ unsafe fn spc_handler_html__clean(mut spe: *mut spc_env, mut dp: *mut libc::c_vo
     pdf_release_obj((*sd).link_dict);
     (*sd).pending_type = -1i32;
     (*sd).baseurl = 0 as *mut i8;
-    (*sd).link_dict = 0 as *mut pdf_obj;
+    (*sd).link_dict = 0 as PdfObjRef;
     0i32
 }
 
@@ -320,7 +321,7 @@ unsafe fn html_open_link(
             ),
         ); /* Otherwise must be bug */
     } else {
-        let mut action: *mut pdf_obj = pdf_new_dict();
+        let mut action: PdfObjRef = pdf_new_dict();
         pdf_add_dict(&mut *action, "Type", pdf_new_name("Action"));
         pdf_add_dict(&mut *action, "S", pdf_new_name("URI"));
         pdf_add_dict(
@@ -371,7 +372,7 @@ unsafe fn html_open_dest(
 
 unsafe fn spc_html__anchor_open(
     mut spe: *mut spc_env,
-    mut attr: *mut pdf_obj,
+    mut attr: PdfObjRef,
     mut sd: *mut spc_html_,
 ) -> i32 {
     if (*sd).pending_type >= 0i32 || !(*sd).link_dict.is_null() {
@@ -407,7 +408,7 @@ unsafe fn spc_html__anchor_close(mut spe: *mut spc_env, mut sd: *mut spc_html_) 
             if !(*sd).link_dict.is_null() {
                 spc_end_annot(spe);
                 pdf_release_obj((*sd).link_dict);
-                (*sd).link_dict = 0 as *mut pdf_obj;
+                (*sd).link_dict = 0 as PdfObjRef;
                 (*sd).pending_type = -1i32
             } else {
                 spc_warn!(spe, "Closing html anchor (link) without starting!");
@@ -425,7 +426,7 @@ unsafe fn spc_html__anchor_close(mut spe: *mut spc_env, mut sd: *mut spc_html_) 
 
 unsafe fn spc_html__base_empty(
     mut spe: *mut spc_env,
-    mut attr: *mut pdf_obj,
+    mut attr: PdfObjRef,
     mut sd: *mut spc_html_,
 ) -> i32 {
     let href = pdf_lookup_dict(&mut *attr, "href");
@@ -506,7 +507,7 @@ unsafe fn atopt(mut a: *const i8) -> f64 {
     v * u
 }
 /* Replicated from spc_tpic */
-unsafe fn create_xgstate(mut a: f64, mut f_ais: i32) -> *mut pdf_obj
+unsafe fn create_xgstate(mut a: f64, mut f_ais: i32) -> PdfObjRef
 /* alpha is shape */ {
     let dict = pdf_new_dict();
     pdf_add_dict(&mut *dict, "Type", pdf_new_name("ExtGState"));
@@ -535,7 +536,7 @@ unsafe fn spc_html__img_empty(mut spe: *mut spc_env, attr: &mut pdf_obj) -> i32 
         let mut init = load_options {
             page_no: 1i32,
             bbox_type: 0i32,
-            dict: 0 as *mut pdf_obj,
+            dict: 0 as PdfObjRef,
         };
         init
     };

--- a/dpx/src/specials/misc.rs
+++ b/dpx/src/specials/misc.rs
@@ -34,8 +34,9 @@ use crate::spc_warn;
 use crate::DisplayExt;
 use crate::TTInputFormat;
 use crate::{ttstub_input_close, ttstub_input_open};
-use libc::{strlen};
+use libc::strlen;
 use std::ffi::CStr;
+use crate::dpx_pdfobj::PdfObjRef;
 
 use super::{spc_arg, spc_env};
 
@@ -50,7 +51,7 @@ unsafe fn spc_handler_postscriptbox(mut spe: *mut spc_env, mut ap: *mut spc_arg)
         let mut init = load_options {
             page_no: 1i32,
             bbox_type: 0i32,
-            dict: 0 as *mut pdf_obj,
+            dict: 0 as PdfObjRef,
         };
         init
     };

--- a/dpx/src/specials/tpic.rs
+++ b/dpx/src/specials/tpic.rs
@@ -31,6 +31,7 @@ use crate::warn;
 use crate::DisplayExt;
 use crate::SkipBlank;
 use std::ffi::{CString, CStr};
+use crate::dpx_pdfobj::PdfObjRef;
 
 use super::{spc_arg, spc_env};
 use crate::spc_warn;
@@ -97,7 +98,7 @@ unsafe fn tpic__clear(mut tp: *mut spc_tpic_) {
     (*tp).fill_shape = false;
     (*tp).fill_color = 0.0f64;
 }
-unsafe fn create_xgstate(mut a: f64, mut f_ais: i32) -> *mut pdf_obj
+unsafe fn create_xgstate(mut a: f64, mut f_ais: i32) -> PdfObjRef
 /* alpha is shape */ {
     let dict = pdf_new_dict(); /* dash pattern */
     pdf_add_dict(&mut *dict, "Type", pdf_new_name("ExtGState"));
@@ -665,7 +666,7 @@ pub unsafe extern "C" fn spc_tpic_at_end_document() -> i32 {
     let mut tp: *mut spc_tpic_ = &mut _TPIC_STATE;
     spc_handler_tpic__clean(0 as *mut spc_env, tp as *mut libc::c_void)
 }
-unsafe fn spc_parse_kvpairs(mut ap: *mut spc_arg) -> *mut pdf_obj {
+unsafe fn spc_parse_kvpairs(mut ap: *mut spc_arg) -> PdfObjRef {
     let mut error: i32 = 0i32;
     let mut dict = pdf_new_dict();
     (*ap).cur.skip_blank();
@@ -702,13 +703,13 @@ unsafe fn spc_parse_kvpairs(mut ap: *mut spc_arg) -> *mut pdf_obj {
     }
     if error != 0 {
         pdf_release_obj(dict);
-        dict = 0 as *mut pdf_obj
+        dict = 0 as PdfObjRef
     }
     dict
 }
 unsafe extern "C" fn tpic_filter_getopts(
-    mut kp: *mut pdf_obj,
-    mut vp: *mut pdf_obj,
+    mut kp: PdfObjRef,
+    mut vp: PdfObjRef,
     mut dp: *mut libc::c_void,
 ) -> i32 {
     let mut tp: *mut spc_tpic_ = dp as *mut spc_tpic_;
@@ -752,8 +753,8 @@ unsafe fn spc_handler_tpic__setopts(mut spe: *mut spc_env, mut ap: *mut spc_arg)
         Some(
             tpic_filter_getopts
                 as unsafe extern "C" fn(
-                    _: *mut pdf_obj,
-                    _: *mut pdf_obj,
+                    _: PdfObjRef,
+                    _: PdfObjRef,
                     _: *mut libc::c_void,
                 ) -> i32,
         ),

--- a/engine/src/xetex_pic.rs
+++ b/engine/src/xetex_pic.rs
@@ -8,6 +8,7 @@
     unused_mut
 )]
 
+use dpx::dpx_pdfobj::PdfObjRef;
 use crate::core_memory::xstrdup;
 use crate::xetex_errors::error;
 use crate::xetex_ext::{D2Fix, Fix2D};
@@ -113,7 +114,7 @@ unsafe extern "C" fn pdf_get_rect(
     let mut pages: i32 = 0;
     let mut dpx_options: i32 = 0;
     let mut pf: *mut pdf_file = 0 as *mut pdf_file;
-    let mut page: *mut pdf_obj = 0 as *mut pdf_obj;
+    let mut page: PdfObjRef = 0 as PdfObjRef;
     let mut bbox = Rect::zero();
     let mut matrix = TMatrix::new();
     pf = pdf_open(filename, handle);
@@ -147,7 +148,7 @@ unsafe extern "C" fn pdf_get_rect(
         dpx_options,
         &mut bbox,
         &mut matrix,
-        0 as *mut *mut pdf_obj,
+        0 as *mut PdfObjRef,
     );
     pdf_close(pf);
     if page.is_null() {


### PR DESCRIPTION
Depends on #175

- :tada: PdfDict uses an insertion-order-preserving hash map, from `indexmap` :tada:
- PdfName uses CString under the hood
- Streams and arrays get a much more convenient API, and more things
  operate directly on streams
- Rustified filter_decoded

Note that review is a bit annoying as I abstracted away `*mut pdf_obj` behing a type alias, `PdfObjRef`. You can basically click 'viewed' on every file except `dpx_pdfobj.rs`.