### PR TITLE
pdf_dict, array, stream has/get/get_mut 

### DIFF
--- a/dpx/src/dpx_bmpimage.rs
+++ b/dpx/src/dpx_bmpimage.rs
@@ -32,7 +32,7 @@ use super::dpx_numbers::tt_get_unsigned_byte;
 use super::dpx_pdfximage::{pdf_ximage_init_image_info, pdf_ximage_set_image};
 use crate::dpx_pdfobj::{
     pdf_add_array, pdf_add_dict, pdf_add_stream, pdf_new_array, pdf_new_name, pdf_new_number,
-    pdf_new_stream, pdf_new_string, pdf_release_obj, pdf_stream_dict,
+    pdf_new_stream, pdf_new_string, pdf_release_obj,
     pdf_stream_set_predictor, STREAM_COMPRESS,
 };
 use crate::warn;
@@ -191,7 +191,7 @@ pub unsafe extern "C" fn bmp_include_image(
     }
     /* Start reading raster data */
     let stream = pdf_new_stream(STREAM_COMPRESS);
-    let stream_dict = pdf_stream_dict(&mut *stream);
+    let stream_dict = (*stream).as_stream_mut().get_dict_mut();
     /* Color space: Indexed or DeviceRGB */
     if (hdr.bit_count as i32) < 24i32 {
         let mut bgrq: [u8; 4] = [0; 4];

--- a/dpx/src/dpx_cid.rs
+++ b/dpx/src/dpx_cid.rs
@@ -45,7 +45,7 @@ use super::dpx_cidtype2::{
 };
 use super::dpx_mem::{new, renew};
 use crate::dpx_pdfobj::{
-    pdf_add_dict, pdf_copy_name, pdf_file, pdf_get_version, pdf_link_obj, pdf_lookup_dict,
+    pdf_add_dict, pdf_copy_name, pdf_file, pdf_get_version, pdf_link_obj,
     pdf_name_value, pdf_new_name, pdf_number_value, pdf_obj, pdf_ref_obj,
     pdf_release_obj, pdf_remove_dict, pdf_string_value,
 };
@@ -938,12 +938,12 @@ unsafe fn CIDFont_base_open(
     let descriptor = start.parse_pdf_dict(0 as *mut pdf_file).unwrap();
     (*font).fontname = fontname;
     (*font).flags |= 1i32 << 0i32;
-    let tmp = pdf_lookup_dict(&mut *fontdict, "CIDSystemInfo")
+    let tmp = (*fontdict).as_dict().get("CIDSystemInfo")
         .filter(|&tmp| (*tmp).is_dict())
         .unwrap();
-    let registry = pdf_string_value(&*pdf_lookup_dict(&mut *tmp, "Registry").unwrap()) as *mut i8;
-    let ordering = pdf_string_value(&*pdf_lookup_dict(&mut *tmp, "Ordering").unwrap()) as *mut i8;
-    let supplement = pdf_number_value(&*pdf_lookup_dict(&mut *tmp, "Supplement").unwrap()) as i32;
+    let registry = pdf_string_value(tmp.as_dict().get("Registry").unwrap()) as *mut i8;
+    let ordering = pdf_string_value(tmp.as_dict().get("Ordering").unwrap()) as *mut i8;
+    let supplement = pdf_number_value(tmp.as_dict().get("Supplement").unwrap()) as i32;
     if !cmap_csi.is_null() {
         /* NULL for accept any */
         if strcmp(registry, (*cmap_csi).registry) != 0
@@ -974,7 +974,7 @@ unsafe fn CIDFont_base_open(
     strcpy((*(*font).csi).registry, registry);
     strcpy((*(*font).csi).ordering, ordering);
     (*(*font).csi).supplement = supplement;
-    let tmp = pdf_lookup_dict(&mut *fontdict, "Subtype")
+    let tmp = (*fontdict).as_dict().get("Subtype")
         .filter(|&tmp| (*tmp).is_name())
         .unwrap();
     let typ = pdf_name_value(&*tmp).to_string_lossy();
@@ -986,10 +986,10 @@ unsafe fn CIDFont_base_open(
         panic!("Unknown CIDFontType \"{}\"", typ);
     }
     if cidoptflags & 1i32 << 1i32 != 0 {
-        if pdf_lookup_dict(&mut *fontdict, "W").is_some() {
+        if (*fontdict).as_dict().has("W") {
             pdf_remove_dict(&mut *fontdict, "W");
         }
-        if pdf_lookup_dict(&mut *fontdict, "W2").is_some() {
+        if (*fontdict).as_dict().has("W2") {
             pdf_remove_dict(&mut *fontdict, "W2");
         }
     }

--- a/dpx/src/dpx_cidtype0.rs
+++ b/dpx/src/dpx_cidtype0.rs
@@ -81,7 +81,7 @@ use super::dpx_type0::{
 use crate::dpx_pdfobj::{
     pdf_add_array, pdf_add_dict, pdf_add_stream, pdf_array_length, pdf_copy_name, pdf_new_array,
     pdf_new_dict, pdf_new_name, pdf_new_number, pdf_new_stream, pdf_new_string, pdf_obj,
-    pdf_ref_obj, pdf_release_obj, pdf_stream_dict, STREAM_COMPRESS,
+    pdf_ref_obj, pdf_release_obj, STREAM_COMPRESS,
 };
 use crate::dpx_truetype::sfnt_table_info;
 use crate::shims::sprintf;
@@ -540,7 +540,7 @@ unsafe fn write_fontfile(mut font: *mut CIDFont, cffont: &mut cff_font) -> i32 {
      * FontFile
      */
     let fontfile = pdf_new_stream(STREAM_COMPRESS);
-    let stream_dict = pdf_stream_dict(&mut *fontfile);
+    let stream_dict = (*fontfile).as_stream_mut().get_dict_mut();
     pdf_add_dict(&mut *(*font).descriptor, "FontFile3", pdf_ref_obj(fontfile));
     pdf_add_dict(stream_dict, "Subtype", pdf_new_name("CIDFontType0C"));
     pdf_add_stream(
@@ -1988,7 +1988,7 @@ unsafe fn add_metrics(
         }
     }
     pdf_add_dict(&mut *(*font).fontdict, "DW", pdf_new_number(default_width));
-    if pdf_array_length(&*tmp) > 0_u32 {
+    if pdf_array_length(&*tmp) > 0 {
         pdf_add_dict(&mut *(*font).fontdict, "W", pdf_ref_obj(tmp));
     }
     pdf_release_obj(tmp);

--- a/dpx/src/dpx_cmap_write.rs
+++ b/dpx/src/dpx_cmap_write.rs
@@ -34,7 +34,7 @@ use super::dpx_cmap::{CMap_get_CIDSysInfo, CMap_is_valid};
 use super::dpx_mem::new;
 use crate::dpx_pdfobj::{
     pdf_add_dict, pdf_add_stream, pdf_copy_name, pdf_new_dict, pdf_new_name, pdf_new_number,
-    pdf_new_stream, pdf_new_string, pdf_obj, pdf_stream_dict, STREAM_COMPRESS,
+    pdf_new_stream, pdf_new_string, pdf_obj, STREAM_COMPRESS,
 };
 use crate::shims::sprintf;
 use libc::{free, memcmp, memset, strlen};
@@ -363,7 +363,7 @@ pub unsafe extern "C" fn CMap_create_stream(mut cmap: *mut CMap) -> *mut pdf_obj
         return 0 as *mut pdf_obj;
     }
     let stream = pdf_new_stream(STREAM_COMPRESS);
-    let stream_dict = pdf_stream_dict(&mut *stream);
+    let stream_dict = (*stream).as_stream_mut().get_dict_mut();
     let mut csi = CMap_get_CIDSysInfo(cmap);
     if csi.is_null() {
         csi = if (*cmap).type_0 != 2i32 {

--- a/dpx/src/dpx_epdf.rs
+++ b/dpx/src/dpx_epdf.rs
@@ -44,9 +44,9 @@ use super::dpx_pdfximage::{pdf_ximage_init_form_info, pdf_ximage_set_form};
 use crate::dpx_pdfobj::{
     pdf_add_array, pdf_add_dict, pdf_array_length, pdf_boolean_value, pdf_close, pdf_concat_stream,
     pdf_deref_obj, pdf_file_get_catalog, /*pdf_file_get_trailer, */pdf_file_get_version,
-    pdf_get_array, pdf_get_version, pdf_import_object, pdf_lookup_dict, pdf_new_array,
+    pdf_get_version, pdf_import_object, pdf_new_array,
     /*pdf_new_dict, */pdf_new_name, pdf_new_number, pdf_new_stream,/* pdf_number_value, */pdf_obj,
-    /*pdf_obj_typeof, */pdf_open, pdf_release_obj,/* pdf_stream_dataptr,*/ pdf_stream_dict,
+    /*pdf_obj_typeof, */pdf_open, pdf_release_obj,/* pdf_stream_dataptr,*/
    /* pdf_stream_length, PdfObjType,*/ STREAM_COMPRESS,
 };
 /*use crate::dpx_pdfparse::{parse_ident, parse_pdf_array};
@@ -459,9 +459,9 @@ pub unsafe extern "C" fn pdf_include_page(
     }
 
     let catalog = pdf_file_get_catalog(pf);
-    markinfo = pdf_deref_obj(pdf_lookup_dict(&mut *catalog, "MarkInfo"));
+    markinfo = pdf_deref_obj((*catalog).as_dict_mut().get_mut("MarkInfo"));
     if !markinfo.is_null() {
-        let mut tmp: *mut pdf_obj = pdf_deref_obj(pdf_lookup_dict(&mut *markinfo, "Marked"));
+        let mut tmp: *mut pdf_obj = pdf_deref_obj((*markinfo).as_dict_mut().get_mut("Marked"));
         pdf_release_obj(markinfo);
         if tmp.is_null() || !(*tmp).is_boolean() {
             pdf_release_obj(tmp);
@@ -473,7 +473,7 @@ pub unsafe extern "C" fn pdf_include_page(
         pdf_release_obj(tmp);
     }
 
-    contents = pdf_deref_obj(pdf_lookup_dict(&mut *page, "Contents"));
+    contents = pdf_deref_obj((*page).as_dict_mut().get_mut("Contents"));
     pdf_release_obj(page);
     /*
      * Handle page content stream.
@@ -499,7 +499,7 @@ pub unsafe extern "C" fn pdf_include_page(
         content_new = pdf_new_stream(STREAM_COMPRESS);
         for idx in 0..len {
             let mut content_seg: *mut pdf_obj =
-                pdf_deref_obj(Some(pdf_get_array(&mut *contents, idx)));
+                pdf_deref_obj((*contents).as_array_mut().get_mut(idx));
             if content_seg.is_null()
             || !(*content_seg).is_stream()
             || pdf_concat_stream(content_new, content_seg) < 0
@@ -522,7 +522,7 @@ pub unsafe extern "C" fn pdf_include_page(
     /*
      * Add entries to contents stream dictionary.
      */
-    let contents_dict = pdf_stream_dict(&mut *contents);
+    let contents_dict = (*contents).as_stream_mut().get_dict_mut();
     pdf_add_dict(contents_dict, "Type", pdf_new_name("XObject"));
     pdf_add_dict(contents_dict, "Subtype", pdf_new_name("Form"));
     pdf_add_dict(contents_dict, "FormType", pdf_new_number(1.0f64));

--- a/dpx/src/dpx_jp2image.rs
+++ b/dpx/src/dpx_jp2image.rs
@@ -34,7 +34,6 @@ use super::dpx_numbers::{get_unsigned_byte, get_unsigned_pair, get_unsigned_quad
 use super::dpx_pdfximage::{pdf_ximage_init_image_info, pdf_ximage_set_image};
 use crate::dpx_pdfobj::{
     pdf_add_dict, pdf_add_stream, pdf_get_version, pdf_new_name, pdf_new_number, pdf_new_stream,
-    pdf_stream_dict,
 };
 use libc::{fread, rewind, FILE};
 
@@ -342,7 +341,7 @@ pub unsafe extern "C" fn jp2_include_image(mut ximage: *mut pdf_ximage, mut fp: 
         return -1i32;
     }
     let stream = pdf_new_stream(0i32);
-    let stream_dict = pdf_stream_dict(&mut *stream);
+    let stream_dict = (*stream).as_stream_mut().get_dict_mut();
     pdf_add_dict(stream_dict, "Filter", pdf_new_name("JPXDecode"));
     if smask != 0 {
         pdf_add_dict(stream_dict, "SMaskInData", pdf_new_number(1i32 as f64));

--- a/dpx/src/dpx_jpegimage.rs
+++ b/dpx/src/dpx_jpegimage.rs
@@ -41,7 +41,7 @@ use super::dpx_pdfximage::{pdf_ximage_init_image_info, pdf_ximage_set_image};
 use crate::dpx_pdfobj::{
     pdf_add_array, pdf_add_dict, pdf_add_stream, pdf_get_version, pdf_new_array, pdf_new_name,
     pdf_new_number, pdf_new_stream, pdf_obj, pdf_ref_obj, pdf_release_obj, pdf_stream_dataptr,
-    pdf_stream_dict, pdf_stream_length, STREAM_COMPRESS,
+    pdf_stream_length, STREAM_COMPRESS,
 };
 use crate::{ttstub_input_get_size, ttstub_input_getc, ttstub_input_read};
 use libc::{free, memcmp, memset};
@@ -217,7 +217,7 @@ pub unsafe extern "C" fn jpeg_include_image(
     };
     /* JPEG image use DCTDecode. */
     let stream = pdf_new_stream(0i32);
-    let stream_dict = pdf_stream_dict(&mut *stream);
+    let stream_dict = (*stream).as_stream_mut().get_dict_mut();
     pdf_add_dict(stream_dict, "Filter", pdf_new_name("DCTDecode"));
     /* XMP Metadata */
     if pdf_get_version() >= 4_u32 {
@@ -413,7 +413,7 @@ unsafe fn JPEG_get_XMP(mut j_info: *mut JPEG_info) -> *mut pdf_obj {
     let mut count: i32 = 0i32;
     /* I don't know if XMP Metadata should be compressed here.*/
     let XMP_stream = pdf_new_stream(STREAM_COMPRESS);
-    let stream_dict = pdf_stream_dict(&mut *XMP_stream);
+    let stream_dict = (*XMP_stream).as_stream_mut().get_dict_mut();
     pdf_add_dict(stream_dict, "Type", pdf_new_name("Metadata"));
     pdf_add_dict(stream_dict, "Subtype", pdf_new_name("XML"));
     for i in 0..(*j_info).num_appn {

--- a/dpx/src/dpx_otl_conf.rs
+++ b/dpx/src/dpx_otl_conf.rs
@@ -27,7 +27,7 @@
     non_upper_case_globals,
     unused_mut
 )]
-
+/*
 use crate::DisplayExt;
 use std::ffi::CStr;
 
@@ -38,8 +38,8 @@ use super::dpx_dpxutil::parse_c_ident;
 use super::dpx_mem::new;
 use super::dpx_pdfparse::skip_white;
 use crate::dpx_pdfobj::{
-    pdf_add_array, pdf_add_dict, pdf_array_length, pdf_copy_name, pdf_get_array, pdf_link_obj,
-    pdf_lookup_dict, pdf_new_array, pdf_new_dict, pdf_new_null, pdf_new_number, pdf_new_string,
+    pdf_add_array, pdf_add_dict, pdf_array_length, pdf_copy_name, pdf_link_obj,
+    pdf_new_array, pdf_new_dict, pdf_new_null, pdf_new_number, pdf_new_string,
     pdf_obj, pdf_ref_obj, pdf_release_obj, pdf_string_value,
 };
 use crate::streq_ptr;
@@ -51,7 +51,7 @@ pub type size_t = u64;
 pub type ssize_t = __ssize_t;
 
 use crate::TTInputFormat;
-
+*/
 /* quasi-hack to get the primary input */
 /* tectonic/core-strutils.h: miscellaneous C string utilities
    Copyright 2016-2018 the Tectonic Project
@@ -61,11 +61,11 @@ use crate::TTInputFormat;
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
 static mut verbose: i32 = 0i32;
-#[no_mangle]
+/*#[no_mangle]
 pub unsafe extern "C" fn otl_conf_set_verbose(mut level: i32) {
     verbose = level;
-}
-unsafe fn parse_uc_coverage(
+}*/
+/*unsafe fn parse_uc_coverage(
     mut gclass: *mut pdf_obj,
     mut pp: *mut *const i8,
     mut endptr: *const i8,
@@ -472,8 +472,8 @@ unsafe fn parse_block(
         *pp = (*pp).offset(1)
     }
     rule
-}
-unsafe fn otl_read_conf(mut conf_name: *const i8) -> *mut pdf_obj {
+}*/
+/*unsafe fn otl_read_conf(mut conf_name: *const i8) -> *mut pdf_obj {
     let mut filename = new((strlen(conf_name)
         .wrapping_add(strlen(b".otl\x00" as *const u8 as *const i8))
         .wrapping_add(1))
@@ -542,13 +542,13 @@ pub unsafe extern "C" fn otl_conf_get_script(mut conf: *mut pdf_obj) -> *mut i8 
 #[no_mangle]
 pub unsafe extern "C" fn otl_conf_get_language(mut conf: *mut pdf_obj) -> *mut i8 {
     assert!(!conf.is_null());
-    let language = pdf_lookup_dict(&mut *conf, "language").unwrap_or(0 as *mut pdf_obj);
-    pdf_string_value(&*language) as *mut i8
+    let language = pdf_dict_get(&*conf, "language").unwrap_or(0 as *mut pdf_obj);
+    pdf_string_value(language) as *mut i8
 }
 #[no_mangle]
 pub unsafe extern "C" fn otl_conf_get_rule(mut conf: *mut pdf_obj) -> *mut pdf_obj {
     assert!(!conf.is_null());
-    pdf_lookup_dict(&mut *conf, "rule").unwrap_or(0 as *mut pdf_obj)
+    pdf_dict_get_mut(&mut *conf, "rule").unwrap_or(0 as *mut pdf_obj)
 }
 #[no_mangle]
 pub unsafe extern "C" fn otl_conf_find_opt(
@@ -556,8 +556,8 @@ pub unsafe extern "C" fn otl_conf_find_opt(
     mut opt_tag: *const i8,
 ) -> *mut pdf_obj {
     assert!(!conf.is_null());
-    if let Some(options) = pdf_lookup_dict(&mut *conf, "option").filter(|_| !opt_tag.is_null()) {
-        pdf_lookup_dict(&mut *options, CStr::from_ptr(opt_tag).to_bytes()).unwrap_or(0 as *mut pdf_obj)
+    if let Some(options) = pdf_dict_get_mut(&mut *conf, "option").filter(|_| !opt_tag.is_null()) {
+        pdf_dict_get_mut(&mut *options, CStr::from_ptr(opt_tag).to_bytes()).unwrap_or(0 as *mut pdf_obj)
     } else {
         0 as *mut pdf_obj
     }
@@ -574,4 +574,4 @@ pub unsafe extern "C" fn otl_init_conf() {
 pub unsafe extern "C" fn otl_close_conf() {
     pdf_release_obj(otl_confs);
     otl_confs = 0 as *mut pdf_obj;
-}
+}*/

--- a/dpx/src/dpx_pdfcolor.rs
+++ b/dpx/src/dpx_pdfcolor.rs
@@ -29,7 +29,7 @@ use super::dpx_pdfdev::{pdf_dev_get_param, pdf_dev_reset_color};
 use crate::dpx_pdfobj::{
     pdf_add_array, pdf_add_dict, pdf_add_stream, pdf_get_version, pdf_link_obj, pdf_new_array,
     pdf_new_name, pdf_new_number, pdf_new_stream, pdf_obj, pdf_ref_obj, pdf_release_obj,
-    pdf_stream_dict, STREAM_COMPRESS,
+    STREAM_COMPRESS,
 };
 use crate::mfree;
 use crate::shims::sprintf;
@@ -1034,7 +1034,7 @@ pub unsafe extern "C" fn iccp_load_profile(
     let stream = pdf_new_stream(STREAM_COMPRESS);
     pdf_add_array(&mut *resource, pdf_new_name("ICCBased"));
     pdf_add_array(&mut *resource, pdf_ref_obj(stream));
-    let stream_dict = pdf_stream_dict(&mut *stream);
+    let stream_dict = (*stream).as_stream_mut().get_dict_mut();
     pdf_add_dict(
         stream_dict,
         "N",

--- a/dpx/src/dpx_pdfencoding.rs
+++ b/dpx/src/dpx_pdfencoding.rs
@@ -43,7 +43,7 @@ use super::dpx_cmap_write::CMap_create_stream;
 use super::dpx_dpxfile::dpx_tt_open;
 use super::dpx_mem::{new, renew};
 use crate::dpx_pdfobj::{
-    pdf_add_array, pdf_add_dict, pdf_copy_name, pdf_file, pdf_get_array, pdf_get_version,
+    pdf_add_array, pdf_add_dict, pdf_copy_name, pdf_file, pdf_get_version,
     pdf_link_obj, pdf_name_value, pdf_new_array, pdf_new_dict, pdf_new_number, pdf_obj,
     pdf_release_obj,
 };
@@ -296,7 +296,7 @@ unsafe fn load_encoding_file(mut filename: *const i8) -> i32 {
     }
     let encoding_array = encoding_array.unwrap();
     for code in 0..256 {
-        enc_vec[code as usize] = pdf_name_value(&*pdf_get_array(&mut *encoding_array, code)).as_ptr();
+        enc_vec[code as usize] = pdf_name_value((*encoding_array).as_array().get(code).unwrap()).as_ptr();
     }
     let enc_id = pdf_encoding_new_encoding(
         if let Some(enc_name) = enc_name {

--- a/dpx/src/dpx_pdffont.rs
+++ b/dpx/src/dpx_pdffont.rs
@@ -55,7 +55,7 @@ use super::dpx_type0::{
 use super::dpx_type1::{pdf_font_load_type1, pdf_font_open_type1};
 use super::dpx_type1c::{pdf_font_load_type1c, pdf_font_open_type1c};
 use crate::dpx_pdfobj::{
-    pdf_add_dict, pdf_copy_name, pdf_link_obj, pdf_lookup_dict, pdf_new_dict, pdf_new_name,
+    pdf_add_dict, pdf_copy_name, pdf_link_obj, pdf_new_dict, pdf_new_name,
     pdf_obj, pdf_ref_obj, pdf_release_obj, pdf_stream_length,
 };
 use crate::mfree;
@@ -530,7 +530,7 @@ pub unsafe extern "C" fn pdf_close_fonts() {
                     },
                 );
             }
-            if pdf_lookup_dict(&mut *(*font_0).resource, "ToUnicode").is_none() && {
+            if !(*(*font_0).resource).as_dict().has("ToUnicode") && {
                 tounicode = pdf_encoding_get_tounicode((*font_0).encoding_id);
                 !tounicode.is_null()
             } {

--- a/dpx/src/dpx_pdfximage.rs
+++ b/dpx/src/dpx_pdfximage.rs
@@ -43,7 +43,7 @@ use super::dpx_pngimage::{check_for_png, png_include_image};
 use crate::dpx_epdf::pdf_include_page;
 use crate::dpx_pdfobj::{
     check_for_pdf, pdf_add_dict, pdf_link_obj, pdf_merge_dict, pdf_new_name, pdf_new_number,
-    pdf_obj, pdf_ref_obj, pdf_release_obj, pdf_stream_dict,
+    pdf_obj, pdf_ref_obj, pdf_release_obj,
 };
 use crate::shims::sprintf;
 use crate::{ttstub_input_close, ttstub_input_open};
@@ -510,7 +510,7 @@ pub unsafe extern "C" fn pdf_ximage_set_image(
     (*I).attr.xdensity = info.xdensity;
     (*I).attr.ydensity = info.ydensity;
     (*I).reference = pdf_ref_obj(resource);
-    let dict = pdf_stream_dict(&mut *resource);
+    let dict = (*resource).as_stream_mut().get_dict_mut();
     pdf_add_dict(dict, "Type", pdf_new_name("XObject"));
     pdf_add_dict(dict, "Subtype", pdf_new_name("Image"));
     pdf_add_dict(dict, "Width", pdf_new_number((*info).width as f64));

--- a/dpx/src/dpx_pngimage.rs
+++ b/dpx/src/dpx_pngimage.rs
@@ -38,7 +38,7 @@ use super::dpx_pdfximage::{pdf_ximage_init_image_info, pdf_ximage_set_image};
 use crate::dpx_pdfobj::{
     pdf_add_array, pdf_add_dict, pdf_add_stream, pdf_get_version, pdf_new_array, pdf_new_dict,
     pdf_new_name, pdf_new_number, pdf_new_stream, pdf_new_string, pdf_obj, pdf_ref_obj,
-    pdf_release_obj, pdf_stream_dict, pdf_stream_set_predictor, STREAM_COMPRESS,
+    pdf_release_obj, pdf_stream_set_predictor, STREAM_COMPRESS,
 };
 use crate::{ttstub_input_read};
 use libc::free;
@@ -190,7 +190,7 @@ pub unsafe extern "C" fn png_include_image(
         info.ydensity = 72.0f64 / 0.0254f64 / yppm as f64
     }
     let stream = pdf_new_stream(STREAM_COMPRESS);
-    let stream_dict = pdf_stream_dict(&mut *stream);
+    let stream_dict = (*stream).as_stream_mut().get_dict_mut();
     let stream_data_ptr = new((rowbytes.wrapping_mul(height) as u64)
         .wrapping_mul(::std::mem::size_of::<png_byte>() as u64)
         as u32) as *mut png_byte;
@@ -336,7 +336,7 @@ pub unsafe extern "C" fn png_include_image(
                      * and scan for that.
                      */
                     let XMP_stream = pdf_new_stream(STREAM_COMPRESS);
-                    let XMP_stream_dict = pdf_stream_dict(&mut *XMP_stream);
+                    let XMP_stream_dict = (*XMP_stream).as_stream_mut().get_dict_mut();
                     pdf_add_dict(XMP_stream_dict, "Type", pdf_new_name("Metadata"));
                     pdf_add_dict(XMP_stream_dict, "Subtype", pdf_new_name("XML"));
                     pdf_add_stream(
@@ -985,16 +985,16 @@ unsafe fn create_soft_mask(
         return 0 as *mut pdf_obj;
     }
     let smask = pdf_new_stream(STREAM_COMPRESS);
-    let dict = pdf_stream_dict(&mut *smask);
+    let dict = (*smask).as_stream_mut().get_dict_mut();
     let smask_data_ptr = new((width.wrapping_mul(height) as u64)
         .wrapping_mul(::std::mem::size_of::<png_byte>() as u64) as u32)
         as *mut png_byte;
-    pdf_add_dict(&mut *dict, "Type", pdf_new_name("XObject"));
-    pdf_add_dict(&mut *dict, "Subtype", pdf_new_name("Image"));
-    pdf_add_dict(&mut *dict, "Width", pdf_new_number(width as f64));
-    pdf_add_dict(&mut *dict, "Height", pdf_new_number(height as f64));
-    pdf_add_dict(&mut *dict, "ColorSpace", pdf_new_name("DeviceGray"));
-    pdf_add_dict(&mut *dict, "BitsPerComponent", pdf_new_number(8i32 as f64));
+    pdf_add_dict(dict, "Type", pdf_new_name("XObject"));
+    pdf_add_dict(dict, "Subtype", pdf_new_name("Image"));
+    pdf_add_dict(dict, "Width", pdf_new_number(width as f64));
+    pdf_add_dict(dict, "Height", pdf_new_number(height as f64));
+    pdf_add_dict(dict, "ColorSpace", pdf_new_name("DeviceGray"));
+    pdf_add_dict(dict, "BitsPerComponent", pdf_new_number(8i32 as f64));
     for i in 0..width.wrapping_mul(height) {
         let mut idx: png_byte = *image_data_ptr.offset(i as isize);
         *smask_data_ptr.offset(i as isize) = (if (idx as i32) < num_trans {
@@ -1048,7 +1048,7 @@ unsafe fn strip_soft_mask(
         }
     }
     let smask = pdf_new_stream(STREAM_COMPRESS);
-    let dict = pdf_stream_dict(&mut *smask);
+    let dict = (*smask).as_stream_mut().get_dict_mut();
     pdf_add_dict(dict, "Type", pdf_new_name("XObject"));
     pdf_add_dict(dict, "Subtype", pdf_new_name("Image"));
     pdf_add_dict(dict, "Width", pdf_new_number(width as f64));

--- a/dpx/src/dpx_sfnt.rs
+++ b/dpx/src/dpx_sfnt.rs
@@ -33,7 +33,7 @@ use super::dpx_mem::{new, renew};
 use super::dpx_numbers::{tt_get_unsigned_pair, tt_get_unsigned_quad};
 use crate::dpx_pdfobj::{
     pdf_add_dict, pdf_add_stream, pdf_new_number, pdf_new_stream, pdf_obj, pdf_release_obj,
-    pdf_stream_dict, STREAM_COMPRESS,
+    STREAM_COMPRESS,
 };
 use crate::dpx_truetype::SfntTableInfo;
 use crate::mfree;
@@ -473,7 +473,7 @@ pub unsafe extern "C" fn sfnt_create_FontFile_stream(mut sfont: *mut sfnt) -> *m
                 as i32
         }
     }
-    let stream_dict = pdf_stream_dict(&mut *stream);
+    let stream_dict = (*stream).as_stream_mut().get_dict_mut();
     pdf_add_dict(stream_dict, "Length1", pdf_new_number(offset as f64));
     stream
 }

--- a/dpx/src/dpx_type0.rs
+++ b/dpx/src/dpx_type0.rs
@@ -43,7 +43,7 @@ use super::dpx_pdfresource::{pdf_defineresource, pdf_findresource, pdf_get_resou
 use super::dpx_tt_cmap::otf_create_ToUnicode_stream;
 use crate::dpx_pdfobj::{
     pdf_add_array, pdf_add_dict, pdf_add_stream, pdf_copy_name, pdf_get_version, pdf_link_obj,
-    pdf_lookup_dict, pdf_new_array, pdf_new_dict, pdf_new_name, pdf_new_stream, pdf_obj,
+    pdf_new_array, pdf_new_dict, pdf_new_name, pdf_new_stream, pdf_obj,
     pdf_ref_obj, pdf_release_obj, STREAM_COMPRESS,
 };
 use crate::shims::sprintf;
@@ -260,7 +260,7 @@ unsafe fn Type0Font_dofont(mut font: *mut Type0Font) {
     if font.is_null() || (*font).indirect.is_null() {
         return;
     }
-    if pdf_lookup_dict(&mut *(*font).fontdict, "ToUnicode").is_none() {
+    if !(*(*font).fontdict).as_dict().has("ToUnicode") {
         /* FIXME */
         add_ToUnicode(font);
     };

--- a/dpx/src/dpx_type1.rs
+++ b/dpx/src/dpx_type1.rs
@@ -53,9 +53,9 @@ use super::dpx_t1_char::{t1char_convert_charstring, t1char_get_metrics};
 use super::dpx_t1_load::{is_pfb, t1_get_fontname, t1_get_standard_glyph, t1_load_font};
 use super::dpx_tfm::{tfm_get_width, tfm_open};
 use crate::dpx_pdfobj::{
-    pdf_add_array, pdf_add_dict, pdf_add_stream, pdf_array_length, pdf_lookup_dict, pdf_new_array,
+    pdf_add_array, pdf_add_dict, pdf_add_stream, pdf_array_length, pdf_new_array,
     pdf_new_name, pdf_new_number, pdf_new_stream, pdf_new_string, pdf_obj, pdf_ref_obj,
-    pdf_release_obj, pdf_stream_dataptr, pdf_stream_dict, pdf_stream_length, STREAM_COMPRESS,
+    pdf_release_obj, pdf_stream_dataptr, pdf_stream_length, STREAM_COMPRESS,
 };
 use crate::shims::sprintf;
 use crate::{ttstub_input_close, ttstub_input_open};
@@ -650,7 +650,7 @@ unsafe fn write_fontfile(
     /* Copyright and Trademark Notice ommited. */
     /* Flush Font File */
     let fontfile = pdf_new_stream(STREAM_COMPRESS);
-    let stream_dict = pdf_stream_dict(&mut *fontfile);
+    let stream_dict = (*fontfile).as_stream_mut().get_dict_mut();
     pdf_add_dict(&mut *descriptor, "FontFile3", pdf_ref_obj(fontfile));
     pdf_add_dict(stream_dict, "Subtype", pdf_new_name("Type1C"));
     pdf_add_stream(
@@ -727,7 +727,7 @@ pub unsafe extern "C" fn pdf_font_load_type1(mut font: *mut pdf_font) -> i32 {
         enc_vec = pdf_encoding_get_encoding(encoding_id)
     } else {
         /* Create enc_vec and ToUnicode CMap for built-in encoding. */
-        if pdf_lookup_dict(fontdict, "ToUnicode").is_none() {
+        if !(*fontdict).as_dict().has("ToUnicode") {
             let tounicode = pdf_create_ToUnicode_CMap(fullname, enc_vec, usedchars);
             if !tounicode.is_null() {
                 pdf_add_dict(fontdict, "ToUnicode", pdf_ref_obj(tounicode));

--- a/dpx/src/dpx_type1c.rs
+++ b/dpx/src/dpx_type1c.rs
@@ -59,9 +59,9 @@ use super::dpx_pdffont::{
 use super::dpx_tfm::{tfm_get_width, tfm_open};
 use super::dpx_tt_aux::tt_get_fontdesc;
 use crate::dpx_pdfobj::{
-    pdf_add_array, pdf_add_dict, pdf_add_stream, pdf_array_length, pdf_lookup_dict, pdf_merge_dict,
+    pdf_add_array, pdf_add_dict, pdf_add_stream, pdf_array_length, pdf_merge_dict,
     pdf_new_array, pdf_new_name, pdf_new_number, pdf_new_stream, pdf_new_string, pdf_ref_obj,
-    pdf_release_obj, pdf_stream_dataptr, pdf_stream_dict, pdf_stream_length, STREAM_COMPRESS,
+    pdf_release_obj, pdf_stream_dataptr, pdf_stream_length, STREAM_COMPRESS,
 };
 use crate::shims::sprintf;
 use crate::{ttstub_input_read};
@@ -400,7 +400,7 @@ pub unsafe extern "C" fn pdf_font_load_type1c(mut font: *mut pdf_font) -> i32 {
                 *fresh1 = 0 as *mut i8
             }
         }
-        if pdf_lookup_dict(fontdict, "ToUnicode").is_none() {
+        if !(*fontdict).as_dict().has("ToUnicode") {
             let tounicode = pdf_create_ToUnicode_CMap(fullname, enc_vec, usedchars);
             if !tounicode.is_null() {
                 pdf_add_dict(fontdict, "ToUnicode", pdf_ref_obj(tounicode));
@@ -894,7 +894,7 @@ pub unsafe extern "C" fn pdf_font_load_type1c(mut font: *mut pdf_font) -> i32 {
      * Write PDF FontFile data.
      */
     let fontfile = pdf_new_stream(STREAM_COMPRESS);
-    let stream_dict = pdf_stream_dict(&mut *fontfile);
+    let stream_dict = (*fontfile).as_stream_mut().get_dict_mut();
     pdf_add_dict(&mut *descriptor, "FontFile3", pdf_ref_obj(fontfile));
     pdf_add_dict(stream_dict, "Subtype", pdf_new_name("Type1C"));
     pdf_add_stream(

--- a/dpx/src/specials/tpic.rs
+++ b/dpx/src/specials/tpic.rs
@@ -49,7 +49,7 @@ use crate::dpx_pdfdraw::{
     pdf_dev_setmiterlimit,
 };
 use crate::dpx_pdfobj::{
-    pdf_add_dict, pdf_foreach_dict, pdf_get_version, pdf_lookup_dict, pdf_name_value,
+    pdf_add_dict, pdf_foreach_dict, pdf_get_version, pdf_name_value,
     pdf_new_boolean, pdf_new_dict, pdf_new_name, pdf_new_number, pdf_new_string, pdf_obj,
     pdf_ref_obj, pdf_release_obj, pdf_string_value,
 };
@@ -112,8 +112,8 @@ unsafe fn check_resourcestatus(category: &str, mut resname: &str) -> i32 {
     if dict1.is_null() {
         return 0i32;
     }
-    if let Some(dict2) = pdf_lookup_dict(&mut *dict1, category) {
-        if (*dict2).is_dict() && pdf_lookup_dict(&mut *dict2, resname).is_some() {
+    if let Some(dict2) = (*dict1).as_dict().get(category) {
+        if dict2.is_dict() && dict2.as_dict().has(resname) {
             return 1i32;
         }
     }


### PR DESCRIPTION
split
`pdf_lookup_dict()` on `.as_dict().has()`, `.as_dict().get()` and `.as_dict().get_mut()`
`pdf_get_array` on `.as_array().get()` and `.as_array().get_mut()`
`stream_dict` on `.as_stream().get_dict()` and `.as_stream().get_dict_mut()`

use `output_xref: Vec<xref_entry>`