### PR TITLE
simplify { let mut init = ...; init }

### DIFF
--- a/dpx/src/dpx_bmpimage.rs
+++ b/dpx/src/dpx_bmpimage.rs
@@ -94,8 +94,7 @@ pub unsafe extern "C" fn bmp_get_bbox(
     mut xdensity: *mut f64,
     mut ydensity: *mut f64,
 ) -> i32 {
-    let mut hdr: hdr_info = {
-        let mut init = hdr_info {
+    let mut hdr: hdr_info = hdr_info {
             offset: 0_u32,
             hsize: 0_u32,
             width: 0_u32,
@@ -106,8 +105,6 @@ pub unsafe extern "C" fn bmp_get_bbox(
             x_pix_per_meter: 0_u32,
             y_pix_per_meter: 0_u32,
         };
-        init
-    };
     handle.seek(SeekFrom::Start(0)).unwrap();
     let r = read_header(handle, &mut hdr);
     *width = hdr.width;
@@ -125,8 +122,7 @@ pub unsafe extern "C" fn bmp_include_image(
     handle: &mut InputHandleWrapper,
 ) -> i32 {
     let mut info = ximage_info::default();
-    let mut hdr: hdr_info = {
-        let mut init = hdr_info {
+    let mut hdr: hdr_info = hdr_info {
             offset: 0_u32,
             hsize: 0_u32,
             width: 0_u32,
@@ -137,8 +133,6 @@ pub unsafe extern "C" fn bmp_include_image(
             x_pix_per_meter: 0_u32,
             y_pix_per_meter: 0_u32,
         };
-        init
-    };
     let num_palette;
     pdf_ximage_init_image_info(&mut info);
     let colorspace;

--- a/dpx/src/dpx_cff_dict.rs
+++ b/dpx/src/dpx_cff_dict.rs
@@ -94,433 +94,250 @@ pub unsafe extern "C" fn cff_release_dict(mut dict: *mut cff_dict) {
 static mut stack_top: i32 = 0i32;
 static mut arg_stack: [f64; 64] = [0.; 64];
 static mut dict_operator: [C2RustUnnamed_2; 61] = [
-    {
-        let mut init = C2RustUnnamed_2 {
+    C2RustUnnamed_2 {
             opname: b"version\x00" as *const u8 as *const i8,
             argtype: 1i32 << 3i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"Notice\x00" as *const u8 as *const i8,
             argtype: 1i32 << 3i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"FullName\x00" as *const u8 as *const i8,
             argtype: 1i32 << 3i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"FamilyName\x00" as *const u8 as *const i8,
             argtype: 1i32 << 3i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"Weight\x00" as *const u8 as *const i8,
             argtype: 1i32 << 3i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"FontBBox\x00" as *const u8 as *const i8,
             argtype: 1i32 << 4i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"BlueValues\x00" as *const u8 as *const i8,
             argtype: 1i32 << 5i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"OtherBlues\x00" as *const u8 as *const i8,
             argtype: 1i32 << 5i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"FamilyBlues\x00" as *const u8 as *const i8,
             argtype: 1i32 << 5i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"FamilyOtherBlues\x00" as *const u8 as *const i8,
             argtype: 1i32 << 5i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"StdHW\x00" as *const u8 as *const i8,
             argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"StdVW\x00" as *const u8 as *const i8,
             argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: 0 as *const i8,
             argtype: -1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"UniqueID\x00" as *const u8 as *const i8,
             argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"XUID\x00" as *const u8 as *const i8,
             argtype: 1i32 << 4i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"charset\x00" as *const u8 as *const i8,
             argtype: 1i32 << 7i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"Encoding\x00" as *const u8 as *const i8,
             argtype: 1i32 << 7i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"CharStrings\x00" as *const u8 as *const i8,
             argtype: 1i32 << 7i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"Private\x00" as *const u8 as *const i8,
             argtype: 1i32 << 8i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"Subrs\x00" as *const u8 as *const i8,
             argtype: 1i32 << 7i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"defaultWidthX\x00" as *const u8 as *const i8,
             argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"nominalWidthX\x00" as *const u8 as *const i8,
             argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"Copyright\x00" as *const u8 as *const i8,
             argtype: 1i32 << 3i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"IsFixedPitch\x00" as *const u8 as *const i8,
             argtype: 1i32 << 2i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"ItalicAngle\x00" as *const u8 as *const i8,
             argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"UnderlinePosition\x00" as *const u8 as *const i8,
             argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"UnderlineThickness\x00" as *const u8 as *const i8,
             argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"PaintType\x00" as *const u8 as *const i8,
             argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"CharstringType\x00" as *const u8 as *const i8,
             argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"FontMatrix\x00" as *const u8 as *const i8,
             argtype: 1i32 << 4i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"StrokeWidth\x00" as *const u8 as *const i8,
             argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"BlueScale\x00" as *const u8 as *const i8,
             argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"BlueShift\x00" as *const u8 as *const i8,
             argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"BlueFuzz\x00" as *const u8 as *const i8,
             argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"StemSnapH\x00" as *const u8 as *const i8,
             argtype: 1i32 << 5i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"StemSnapV\x00" as *const u8 as *const i8,
             argtype: 1i32 << 5i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"ForceBold\x00" as *const u8 as *const i8,
             argtype: 1i32 << 2i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: 0 as *const i8,
             argtype: -1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: 0 as *const i8,
             argtype: -1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"LanguageGroup\x00" as *const u8 as *const i8,
             argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"ExpansionFactor\x00" as *const u8 as *const i8,
             argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"InitialRandomSeed\x00" as *const u8 as *const i8,
             argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"SyntheticBase\x00" as *const u8 as *const i8,
             argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"PostScript\x00" as *const u8 as *const i8,
             argtype: 1i32 << 3i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"BaseFontName\x00" as *const u8 as *const i8,
             argtype: 1i32 << 3i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"BaseFontBlend\x00" as *const u8 as *const i8,
             argtype: 1i32 << 5i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: 0 as *const i8,
             argtype: -1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: 0 as *const i8,
             argtype: -1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: 0 as *const i8,
             argtype: -1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: 0 as *const i8,
             argtype: -1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: 0 as *const i8,
             argtype: -1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: 0 as *const i8,
             argtype: -1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"ROS\x00" as *const u8 as *const i8,
             argtype: 1i32 << 6i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"CIDFontVersion\x00" as *const u8 as *const i8,
             argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"CIDFontRevision\x00" as *const u8 as *const i8,
             argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"CIDFontType\x00" as *const u8 as *const i8,
             argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"CIDCount\x00" as *const u8 as *const i8,
             argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"UIDBase\x00" as *const u8 as *const i8,
             argtype: 1i32 << 0i32 | 1i32 << 1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"FDArray\x00" as *const u8 as *const i8,
             argtype: 1i32 << 7i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"FDSelect\x00" as *const u8 as *const i8,
             argtype: 1i32 << 7i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_2 {
+        },
+    C2RustUnnamed_2 {
             opname: b"FontName\x00" as *const u8 as *const i8,
             argtype: 1i32 << 3i32,
-        };
-        init
-    },
+        },
 ];
 /* Parse DICT data */
 unsafe fn get_integer(mut data: *mut *mut u8, mut endptr: *mut u8, mut status: *mut i32) -> f64 {

--- a/dpx/src/dpx_cid.rs
+++ b/dpx/src/dpx_cid.rs
@@ -154,236 +154,152 @@ pub struct C2RustUnnamed_3 {
    Licensed under the MIT License.
 */
 static mut CIDFont_stdcc_def: [C2RustUnnamed_0; 7] = [
-    {
-        let mut init = C2RustUnnamed_0 {
+    C2RustUnnamed_0 {
             registry: b"Adobe\x00" as *const u8 as *const i8,
             ordering: b"UCS\x00" as *const u8 as *const i8,
             supplement: [
                 -1i32, -1i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0, 0, 0, 0, 0, 0, 0, 0,
             ],
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_0 {
+        },
+    C2RustUnnamed_0 {
             registry: b"Adobe\x00" as *const u8 as *const i8,
             ordering: b"GB1\x00" as *const u8 as *const i8,
             supplement: [
                 -1i32, -1i32, 0i32, 2i32, 4i32, 4i32, 4i32, 4i32, 0, 0, 0, 0, 0, 0, 0, 0,
             ],
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_0 {
+        },
+    C2RustUnnamed_0 {
             registry: b"Adobe\x00" as *const u8 as *const i8,
             ordering: b"CNS1\x00" as *const u8 as *const i8,
             supplement: [
                 -1i32, -1i32, 0i32, 0i32, 3i32, 4i32, 4i32, 4i32, 0, 0, 0, 0, 0, 0, 0, 0,
             ],
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_0 {
+        },
+    C2RustUnnamed_0 {
             registry: b"Adobe\x00" as *const u8 as *const i8,
             ordering: b"Japan1\x00" as *const u8 as *const i8,
             supplement: [
                 -1i32, -1i32, 2i32, 2i32, 4i32, 5i32, 6i32, 6i32, 0, 0, 0, 0, 0, 0, 0, 0,
             ],
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_0 {
+        },
+    C2RustUnnamed_0 {
             registry: b"Adobe\x00" as *const u8 as *const i8,
             ordering: b"Korea1\x00" as *const u8 as *const i8,
             supplement: [
                 -1i32, -1i32, 1i32, 1i32, 2i32, 2i32, 2i32, 2i32, 0, 0, 0, 0, 0, 0, 0, 0,
             ],
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_0 {
+        },
+    C2RustUnnamed_0 {
             registry: b"Adobe\x00" as *const u8 as *const i8,
             ordering: b"Identity\x00" as *const u8 as *const i8,
             supplement: [
                 -1i32, -1i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0, 0, 0, 0, 0, 0, 0, 0,
             ],
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_0 {
+        },
+    C2RustUnnamed_0 {
             registry: 0 as *const i8,
             ordering: 0 as *const i8,
             supplement: [
                 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0i32, 0, 0, 0, 0, 0, 0, 0, 0,
             ],
-        };
-        init
-    },
+        },
 ];
 static mut registry_Adobe: [i8; 6] = [65, 100, 111, 98, 101, 0];
 static mut ordering_Identity: [i8; 9] = [73, 100, 101, 110, 116, 105, 116, 121, 0];
 static mut ordering_UCS: [i8; 4] = [85, 67, 83, 0];
 #[no_mangle]
 pub static mut CSI_IDENTITY: CIDSysInfo = unsafe {
-    {
-        let mut init = CIDSysInfo {
+    CIDSysInfo {
             registry: registry_Adobe.as_ptr() as *mut _,
             ordering: ordering_Identity.as_ptr() as *mut _,
             supplement: 0i32,
-        };
-        init
-    }
+        }
 };
 #[no_mangle]
 pub static mut CSI_UNICODE: CIDSysInfo = unsafe {
-    {
-        let mut init = CIDSysInfo {
+    CIDSysInfo {
             registry: registry_Adobe.as_ptr() as *mut _,
             ordering: ordering_UCS.as_ptr() as *mut _,
             supplement: 0i32,
-        };
-        init
-    }
+        }
 };
 static mut CIDFont_stdcc_alias: [C2RustUnnamed_3; 19] = [
-    {
-        let mut init = C2RustUnnamed_3 {
+    C2RustUnnamed_3 {
             name: b"AU\x00" as *const u8 as *const i8,
             index: 0i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_3 {
+        },
+    C2RustUnnamed_3 {
             name: b"AG1\x00" as *const u8 as *const i8,
             index: 1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_3 {
+        },
+    C2RustUnnamed_3 {
             name: b"AC1\x00" as *const u8 as *const i8,
             index: 2i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_3 {
+        },
+    C2RustUnnamed_3 {
             name: b"AJ1\x00" as *const u8 as *const i8,
             index: 3i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_3 {
+        },
+    C2RustUnnamed_3 {
             name: b"AK1\x00" as *const u8 as *const i8,
             index: 4i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_3 {
+        },
+    C2RustUnnamed_3 {
             name: b"AI\x00" as *const u8 as *const i8,
             index: 5i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_3 {
+        },
+    C2RustUnnamed_3 {
             name: b"UCS\x00" as *const u8 as *const i8,
             index: 0i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_3 {
+        },
+    C2RustUnnamed_3 {
             name: b"GB1\x00" as *const u8 as *const i8,
             index: 1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_3 {
+        },
+    C2RustUnnamed_3 {
             name: b"CNS1\x00" as *const u8 as *const i8,
             index: 2i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_3 {
+        },
+    C2RustUnnamed_3 {
             name: b"Japan1\x00" as *const u8 as *const i8,
             index: 3i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_3 {
+        },
+    C2RustUnnamed_3 {
             name: b"Korea1\x00" as *const u8 as *const i8,
             index: 4i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_3 {
+        },
+    C2RustUnnamed_3 {
             name: b"Identity\x00" as *const u8 as *const i8,
             index: 5i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_3 {
+        },
+    C2RustUnnamed_3 {
             name: b"U\x00" as *const u8 as *const i8,
             index: 0i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_3 {
+        },
+    C2RustUnnamed_3 {
             name: b"G\x00" as *const u8 as *const i8,
             index: 1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_3 {
+        },
+    C2RustUnnamed_3 {
             name: b"C\x00" as *const u8 as *const i8,
             index: 2i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_3 {
+        },
+    C2RustUnnamed_3 {
             name: b"J\x00" as *const u8 as *const i8,
             index: 3i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_3 {
+        },
+    C2RustUnnamed_3 {
             name: b"K\x00" as *const u8 as *const i8,
             index: 4i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_3 {
+        },
+    C2RustUnnamed_3 {
             name: b"I\x00" as *const u8 as *const i8,
             index: 5i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_3 {
+        },
+    C2RustUnnamed_3 {
             name: 0 as *const i8,
             index: 0i32,
-        };
-        init
-    },
+        },
 ];
 static mut __verbose: i32 = 0i32;
 static mut cidoptflags: i32 = 0i32;
@@ -615,9 +531,7 @@ pub unsafe extern "C" fn CIDFont_is_BaseFont(mut font: *mut CIDFont) -> bool {
     (*font).flags & 1i32 << 0i32 != 0
 }
 static mut cid_basefont: [C2RustUnnamed_2; 21] = [
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
+    C2RustUnnamed_2{fontname:
                                  b"Ryumin-Light\x00" as *const u8 as
                                      *const i8,
                              fontdict:
@@ -625,12 +539,9 @@ static mut cid_basefont: [C2RustUnnamed_2; 21] = [
                                      as *const u8 as *const i8,
                              descriptor:
                                  b"<< /CapHeight 709 /Ascent 723 /Descent -241 /StemV 69 /FontBBox [-170 -331 1024 903] /ItalicAngle 0 /Flags 6 /Style << /Panose <010502020300000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+                                     as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
+    C2RustUnnamed_2{fontname:
                                  b"GothicBBB-Medium\x00" as *const u8 as
                                      *const i8,
                              fontdict:
@@ -638,12 +549,9 @@ static mut cid_basefont: [C2RustUnnamed_2; 21] = [
                                      as *const u8 as *const i8,
                              descriptor:
                                  b"<< /CapHeight 737 /Ascent 752 /Descent -271 /StemV 99 /FontBBox [-174 -268 1001 944] /ItalicAngle 0 /Flags 4 /Style << /Panose <0801020b0500000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+                                     as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
+    C2RustUnnamed_2{fontname:
                                  b"MHei-Medium-Acro\x00" as *const u8 as
                                      *const i8,
                              fontdict:
@@ -651,12 +559,9 @@ static mut cid_basefont: [C2RustUnnamed_2; 21] = [
                                      as *const u8 as *const i8,
                              descriptor:
                                  b"<< /Ascent 752 /CapHeight 737 /Descent -271 /StemV 58 /FontBBox [-45 -250 1015 887] /ItalicAngle 0 /Flags 4 /XHeight 553 /Style << /Panose <000001000600000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+                                     as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
+    C2RustUnnamed_2{fontname:
                                  b"MSung-Light-Acro\x00" as *const u8 as
                                      *const i8,
                              fontdict:
@@ -664,12 +569,9 @@ static mut cid_basefont: [C2RustUnnamed_2; 21] = [
                                      as *const u8 as *const i8,
                              descriptor:
                                  b"<< /Ascent 752 /CapHeight 737 /Descent -271 /StemV 58 /FontBBox [-160 -249 1015 888] /ItalicAngle 0 /Flags 6 /XHeight 553 /Style << /Panose <000000000400000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+                                     as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
+    C2RustUnnamed_2{fontname:
                                  b"STSong-Light-Acro\x00" as *const u8 as
                                      *const i8,
                              fontdict:
@@ -677,12 +579,9 @@ static mut cid_basefont: [C2RustUnnamed_2; 21] = [
                                      as *const u8 as *const i8,
                              descriptor:
                                  b"<< /Ascent 752 /CapHeight 737 /Descent -271 /StemV 58 /FontBBox [-25 -254 1000 880] /ItalicAngle 0 /Flags 6 /XHeight 599 /Style << /Panose <000000000400000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+                                     as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
+    C2RustUnnamed_2{fontname:
                                  b"STHeiti-Regular-Acro\x00" as *const u8 as
                                      *const i8,
                              fontdict:
@@ -690,12 +589,9 @@ static mut cid_basefont: [C2RustUnnamed_2; 21] = [
                                      as *const u8 as *const i8,
                              descriptor:
                                  b"<< /Ascent 752 /CapHeight 737 /Descent -271 /StemV 58 /FontBBox [-34 -250 1000 882] /ItalicAngle 0 /Flags 4 /XHeight 599 /Style << /Panose <000001000600000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+                                     as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
+    C2RustUnnamed_2{fontname:
                                  b"HeiseiKakuGo-W5-Acro\x00" as *const u8 as
                                      *const i8,
                              fontdict:
@@ -703,12 +599,9 @@ static mut cid_basefont: [C2RustUnnamed_2; 21] = [
                                      as *const u8 as *const i8,
                              descriptor:
                                  b"<< /Ascent 752 /CapHeight 737 /Descent -221 /StemV 114 /FontBBox [-92 -250 1010 922] /ItalicAngle 0 /Flags 4 /XHeight 553 /Style << /Panose <0801020b0600000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+                                     as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
+    C2RustUnnamed_2{fontname:
                                  b"HeiseiMin-W3-Acro\x00" as *const u8 as
                                      *const i8,
                              fontdict:
@@ -716,12 +609,9 @@ static mut cid_basefont: [C2RustUnnamed_2; 21] = [
                                      as *const u8 as *const i8,
                              descriptor:
                                  b"<< /Ascent 723 /CapHeight 709 /Descent -241 /StemV 69 /FontBBox [-123 -257 1001 910] /ItalicAngle 0 /Flags 6 /XHeight 450 /Style << /Panose <010502020400000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+                                     as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
+    C2RustUnnamed_2{fontname:
                                  b"HYGoThic-Medium-Acro\x00" as *const u8 as
                                      *const i8,
                              fontdict:
@@ -729,12 +619,9 @@ static mut cid_basefont: [C2RustUnnamed_2; 21] = [
                                      as *const u8 as *const i8,
                              descriptor:
                                  b"<< /Ascent 752 /CapHeight 737 /Descent -271 /StemV 58 /FontBBox [-6 -145 1003 880] /ItalicAngle 0 /Flags 4 /XHeight 553 /Style << /Panose <000001000600000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+                                     as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
+    C2RustUnnamed_2{fontname:
                                  b"HYSMyeongJo-Medium-Acro\x00" as *const u8
                                      as *const i8,
                              fontdict:
@@ -742,12 +629,9 @@ static mut cid_basefont: [C2RustUnnamed_2; 21] = [
                                      as *const u8 as *const i8,
                              descriptor:
                                  b"<< /Ascent 752 /CapHeight 737 /Descent -271 /StemV 58 /FontBBox [-0 -148 1001 880] /ItalicAngle 0 /Flags 6 /XHeight 553 /Style << /Panose <000000000600000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+                                     as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
+    C2RustUnnamed_2{fontname:
                                  b"MSungStd-Light-Acro\x00" as *const u8 as
                                      *const i8,
                              fontdict:
@@ -755,12 +639,9 @@ static mut cid_basefont: [C2RustUnnamed_2; 21] = [
                                      as *const u8 as *const i8,
                              descriptor:
                                  b"<< /Ascent 880 /CapHeight 662 /Descent -120 /StemV 54 /FontBBox [-160 -249 1015 1071] /ItalicAngle 0 /Flags 6 /Style << /Panose <000000000400000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+                                     as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
+    C2RustUnnamed_2{fontname:
                                  b"STSongStd-Light-Acro\x00" as *const u8 as
                                      *const i8,
                              fontdict:
@@ -768,12 +649,9 @@ static mut cid_basefont: [C2RustUnnamed_2; 21] = [
                                      as *const u8 as *const i8,
                              descriptor:
                                  b"<< /Ascent 880 /CapHeight 626 /Descent -120 /StemV 44 /FontBBox [-134 -254 1001 905] /ItalicAngle 0 /Flags 6 /Style << /Panose <000000000400000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+                                     as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
+    C2RustUnnamed_2{fontname:
                                  b"HYSMyeongJoStd-Medium-Acro\x00" as
                                      *const u8 as *const i8,
                              fontdict:
@@ -781,12 +659,9 @@ static mut cid_basefont: [C2RustUnnamed_2; 21] = [
                                      as *const u8 as *const i8,
                              descriptor:
                                  b"<< /Ascent 880 /CapHeight 720 /Descent -120 /StemV 60 /FontBBox [-28 -148 1001 880] /ItalicAngle 0 /Flags 6 /Style << /Panose <000000000600000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+                                     as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
+    C2RustUnnamed_2{fontname:
                                  b"AdobeMingStd-Light-Acro\x00" as *const u8
                                      as *const i8,
                              fontdict:
@@ -794,12 +669,9 @@ static mut cid_basefont: [C2RustUnnamed_2; 21] = [
                                      as *const u8 as *const i8,
                              descriptor:
                                  b"<< /Ascent 880 /Descent -120 /StemV 48 /CapHeight 731 /FontBBox [-38 -121 1002 918] /ItalicAngle 0 /Flags 6 /XHeight 466 /Style << /Panose <000002020300000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+                                     as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
+    C2RustUnnamed_2{fontname:
                                  b"AdobeSongStd-Light-Acro\x00" as *const u8
                                      as *const i8,
                              fontdict:
@@ -807,12 +679,9 @@ static mut cid_basefont: [C2RustUnnamed_2; 21] = [
                                      as *const u8 as *const i8,
                              descriptor:
                                  b"<< /Ascent 880 /Descent -120 /StemV 66 /CapHeight 626 /FontBBox [-134 -254 1001 905] /ItalicAngle 0 /Flags 6 /XHeight 416 /Style << /Panose <000002020300000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+                                     as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
+    C2RustUnnamed_2{fontname:
                                  b"KozMinPro-Regular-Acro\x00" as *const u8 as
                                      *const i8,
                              fontdict:
@@ -820,12 +689,9 @@ static mut cid_basefont: [C2RustUnnamed_2; 21] = [
                                      as *const u8 as *const i8,
                              descriptor:
                                  b"<< /Ascent 880 /Descent -120 /StemV 86 /CapHeight 740 /FontBBox [-195 -272 1110 1075] /ItalicAngle 0 /Flags 6 /XHeight 502 /Style << /Panose <000002020400000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+                                     as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
+    C2RustUnnamed_2{fontname:
                                  b"KozGoPro-Medium-Acro\x00" as *const u8 as
                                      *const i8,
                              fontdict:
@@ -833,12 +699,9 @@ static mut cid_basefont: [C2RustUnnamed_2; 21] = [
                                      as *const u8 as *const i8,
                              descriptor:
                                  b"<< /Ascent 880 /Descent -120 /StemV 99 /CapHeight 763 /FontBBox [-149 -374 1254 1008] /ItalicAngle 0 /Flags 4 /XHeight 549 /Style << /Panose <0000020b0700000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+                                     as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
+    C2RustUnnamed_2{fontname:
                                  b"AdobeMyungjoStd-Medium-Acro\x00" as
                                      *const u8 as *const i8,
                              fontdict:
@@ -846,12 +709,9 @@ static mut cid_basefont: [C2RustUnnamed_2; 21] = [
                                      as *const u8 as *const i8,
                              descriptor:
                                  b"<< /Ascent 880 /Descent -120 /StemV 99 /CapHeight 719 /FontBBox [-28 -148 1001 880] /ItalicAngle 0 /Flags 6 /XHeight 478 /Style << /Panose <000002020600000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+                                     as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
+    C2RustUnnamed_2{fontname:
                                  b"KozMinProVI-Regular\x00" as *const u8 as
                                      *const i8,
                              fontdict:
@@ -859,12 +719,9 @@ static mut cid_basefont: [C2RustUnnamed_2; 21] = [
                                      as *const u8 as *const i8,
                              descriptor:
                                  b"<< /Ascent 880 /Descent -120 /StemV 86 /CapHeight 742 /FontBBox [-437 -340 1144 1317] /ItalicAngle 0 /Flags 6 /XHeight 503 /Style <<   /Panose <000002020400000000000000> >>      >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+                                     as *const u8 as *const i8,
     },
-    {
-        let mut init =
-             C2RustUnnamed_2{fontname:
+    C2RustUnnamed_2{fontname:
                                  b"AdobeHeitiStd-Regular\x00" as *const u8 as
                                      *const i8,
                              fontdict:
@@ -872,17 +729,13 @@ static mut cid_basefont: [C2RustUnnamed_2; 21] = [
                                      as *const u8 as *const i8,
                              descriptor:
                                  b"<< /Ascent 880 /Descent -120 /StemV 66 /CapHeight 626 /FontBBox [-134 -254 1001 905] /ItalicAngle 0 /Flags 6 /XHeight 416 /Style << /Panose <000002020300000000000000> >> >>\x00"
-                                     as *const u8 as *const i8,};
-        init
+                                     as *const u8 as *const i8,
     },
-    {
-        let mut init = C2RustUnnamed_2 {
+    C2RustUnnamed_2 {
             fontname: 0 as *const i8,
             fontdict: 0 as *const i8,
             descriptor: 0 as *const i8,
-        };
-        init
-    },
+        },
 ];
 unsafe fn CIDFont_base_open(
     mut font: *mut CIDFont,

--- a/dpx/src/dpx_cidtype2.rs
+++ b/dpx/src/dpx_cidtype2.rs
@@ -202,8 +202,7 @@ unsafe fn validate_name(mut fontname: *mut i8, mut len: i32) {
     };
 }
 static mut known_encodings: [C2RustUnnamed_3; 11] = [
-    {
-        let mut init = C2RustUnnamed_3 {
+    C2RustUnnamed_3 {
             platform: 3_u16,
             encoding: 10_u16,
             pdfnames: [
@@ -213,11 +212,8 @@ static mut known_encodings: [C2RustUnnamed_3; 11] = [
                 b"UCS2\x00" as *const u8 as *const i8,
                 0 as *const i8,
             ],
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_3 {
+        },
+    C2RustUnnamed_3 {
             platform: 3_u16,
             encoding: 1_u16,
             pdfnames: [
@@ -227,11 +223,8 @@ static mut known_encodings: [C2RustUnnamed_3; 11] = [
                 b"UCS2\x00" as *const u8 as *const i8,
                 0 as *const i8,
             ],
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_3 {
+        },
+    C2RustUnnamed_3 {
             platform: 3_u16,
             encoding: 2_u16,
             pdfnames: [
@@ -241,11 +234,8 @@ static mut known_encodings: [C2RustUnnamed_3; 11] = [
                 0 as *const i8,
                 0 as *const i8,
             ],
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_3 {
+        },
+    C2RustUnnamed_3 {
             platform: 3_u16,
             encoding: 3_u16,
             pdfnames: [
@@ -255,11 +245,8 @@ static mut known_encodings: [C2RustUnnamed_3; 11] = [
                 0 as *const i8,
                 0 as *const i8,
             ],
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_3 {
+        },
+    C2RustUnnamed_3 {
             platform: 3_u16,
             encoding: 4_u16,
             pdfnames: [
@@ -269,11 +256,8 @@ static mut known_encodings: [C2RustUnnamed_3; 11] = [
                 0 as *const i8,
                 0 as *const i8,
             ],
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_3 {
+        },
+    C2RustUnnamed_3 {
             platform: 3_u16,
             encoding: 5_u16,
             pdfnames: [
@@ -283,11 +267,8 @@ static mut known_encodings: [C2RustUnnamed_3; 11] = [
                 0 as *const i8,
                 0 as *const i8,
             ],
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_3 {
+        },
+    C2RustUnnamed_3 {
             platform: 1_u16,
             encoding: 1_u16,
             pdfnames: [
@@ -297,11 +278,8 @@ static mut known_encodings: [C2RustUnnamed_3; 11] = [
                 0 as *const i8,
                 0 as *const i8,
             ],
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_3 {
+        },
+    C2RustUnnamed_3 {
             platform: 1_u16,
             encoding: 2_u16,
             pdfnames: [
@@ -311,11 +289,8 @@ static mut known_encodings: [C2RustUnnamed_3; 11] = [
                 0 as *const i8,
                 0 as *const i8,
             ],
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_3 {
+        },
+    C2RustUnnamed_3 {
             platform: 1_u16,
             encoding: 25_u16,
             pdfnames: [
@@ -325,11 +300,8 @@ static mut known_encodings: [C2RustUnnamed_3; 11] = [
                 0 as *const i8,
                 0 as *const i8,
             ],
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_3 {
+        },
+    C2RustUnnamed_3 {
             platform: 1_u16,
             encoding: 3_u16,
             pdfnames: [
@@ -339,11 +311,8 @@ static mut known_encodings: [C2RustUnnamed_3; 11] = [
                 0 as *const i8,
                 0 as *const i8,
             ],
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed_3 {
+        },
+    C2RustUnnamed_3 {
             platform: 0_u16,
             encoding: 0_u16,
             pdfnames: [
@@ -353,9 +322,7 @@ static mut known_encodings: [C2RustUnnamed_3; 11] = [
                 0 as *const i8,
                 0 as *const i8,
             ],
-        };
-        init
-    },
+        },
 ];
 unsafe fn find_tocode_cmap(mut reg: *const i8, mut ord: *const i8, mut select: i32) -> *mut CMap {
     let mut cmap_id: i32 = -1i32;
@@ -572,76 +539,46 @@ unsafe fn add_TTCIDVMetrics(
  */
 unsafe fn fix_CJK_symbols(mut code: u16) -> u16 {
     static mut CJK_Uni_symbols: [C2RustUnnamed_2; 10] = [
-        {
-            let mut init = C2RustUnnamed_2 {
+        C2RustUnnamed_2 {
                 alt1: 0x2014_u16,
                 alt2: 0x2015_u16,
-            };
-            init
-        },
-        {
-            let mut init = C2RustUnnamed_2 {
+            },
+        C2RustUnnamed_2 {
                 alt1: 0x2016_u16,
                 alt2: 0x2225_u16,
-            };
-            init
-        },
-        {
-            let mut init = C2RustUnnamed_2 {
+            },
+        C2RustUnnamed_2 {
                 alt1: 0x203e_u16,
                 alt2: 0xffe3_u16,
-            };
-            init
-        },
-        {
-            let mut init = C2RustUnnamed_2 {
+            },
+        C2RustUnnamed_2 {
                 alt1: 0x2026_u16,
                 alt2: 0x22ef_u16,
-            };
-            init
-        },
-        {
-            let mut init = C2RustUnnamed_2 {
+            },
+        C2RustUnnamed_2 {
                 alt1: 0x2212_u16,
                 alt2: 0xff0d_u16,
-            };
-            init
-        },
-        {
-            let mut init = C2RustUnnamed_2 {
+            },
+        C2RustUnnamed_2 {
                 alt1: 0x301c_u16,
                 alt2: 0xff5e_u16,
-            };
-            init
-        },
-        {
-            let mut init = C2RustUnnamed_2 {
+            },
+        C2RustUnnamed_2 {
                 alt1: 0xffe0_u16,
                 alt2: 0xa2_u16,
-            };
-            init
-        },
-        {
-            let mut init = C2RustUnnamed_2 {
+            },
+        C2RustUnnamed_2 {
                 alt1: 0xffe1_u16,
                 alt2: 0xa3_u16,
-            };
-            init
-        },
-        {
-            let mut init = C2RustUnnamed_2 {
+            },
+        C2RustUnnamed_2 {
                 alt1: 0xffe2_u16,
                 alt2: 0xac_u16,
-            };
-            init
-        },
-        {
-            let mut init = C2RustUnnamed_2 {
+            },
+        C2RustUnnamed_2 {
                 alt1: 0xffff_u16,
                 alt2: 0xffff_u16,
-            };
-            init
-        },
+            },
     ];
     let mut alt_code = code;
     for i in 0..(::std::mem::size_of::<[C2RustUnnamed_2; 10]>() as u64)

--- a/dpx/src/dpx_cmap_read.rs
+++ b/dpx/src/dpx_cmap_read.rs
@@ -523,14 +523,11 @@ unsafe fn do_cidchar(mut cmap: *mut CMap, mut input: *mut ifreader, mut count: i
     check_next_token(input, b"endcidchar\x00" as *const u8 as *const i8)
 }
 unsafe fn do_cidsysteminfo(mut cmap: *mut CMap, mut input: *mut ifreader) -> i32 {
-    let mut csi: CIDSysInfo = {
-        let mut init = CIDSysInfo {
+    let mut csi: CIDSysInfo = CIDSysInfo {
             registry: 0 as *mut i8,
             ordering: 0 as *mut i8,
             supplement: -1i32,
         };
-        init
-    };
     let mut simpledict: i32 = 0i32;
     let mut error: i32 = 0i32;
     ifreader_read(input, (127i32 * 2i32) as size_t);

--- a/dpx/src/dpx_dvi.rs
+++ b/dpx/src/dpx_dvi.rs
@@ -207,8 +207,7 @@ static mut linear: i8 = 0_i8;
 static mut page_loc: *mut u32 = 0 as *const u32 as *mut u32;
 static mut num_pages: u32 = 0_u32;
 static mut dvi_file_size: u32 = 0_u32;
-static mut DVI_INFO: dvi_header = {
-    let mut init = dvi_header {
+static mut DVI_INFO: dvi_header = dvi_header {
         unit_num: 25400000_u32,
         unit_den: 473628672_u32,
         mag: 1000_u32,
@@ -217,8 +216,6 @@ static mut DVI_INFO: dvi_header = {
         stackdepth: 0_u32,
         comment: [0; 257],
     };
-    init
-};
 static mut dev_origin_x: f64 = 72.0f64;
 static mut dev_origin_y: f64 = 770.0f64;
 #[no_mangle]

--- a/dpx/src/dpx_epdf.rs
+++ b/dpx/src/dpx_epdf.rs
@@ -550,279 +550,162 @@ pub unsafe extern "C" fn pdf_include_page(
     0
 }
 /*static mut pdf_operators: [operator; 39] = [
-    {
-        let mut init = operator {
+    operator {
             token: b"SCN\x00" as *const u8 as *const i8,
             opcode: OP_SETCOLOR as i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"b*\x00" as *const u8 as *const i8,
             opcode: OP_CLOSEandCLIP as i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"B*\x00" as *const u8 as *const i8,
             opcode: OP_CLIP as i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"cm\x00" as *const u8 as *const i8,
             opcode: OP_CONCATMATRIX as i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"CS\x00" as *const u8 as *const i8,
             opcode: OP_SETCOLORSPACE as i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"f*\x00" as *const u8 as *const i8,
             opcode: 0i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"gs\x00" as *const u8 as *const i8,
             opcode: -1i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"re\x00" as *const u8 as *const i8,
             opcode: OP_RECTANGLE as i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"rg\x00" as *const u8 as *const i8,
             opcode: -3i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"RG\x00" as *const u8 as *const i8,
             opcode: -3i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"sc\x00" as *const u8 as *const i8,
             opcode: OP_SETCOLOR as i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"SC\x00" as *const u8 as *const i8,
             opcode: OP_SETCOLOR as i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"W*\x00" as *const u8 as *const i8,
             opcode: OP_CLIP as i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"b\x00" as *const u8 as *const i8,
             opcode: OP_CLOSEandCLIP as i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"B\x00" as *const u8 as *const i8,
             opcode: OP_CLIP as i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"c\x00" as *const u8 as *const i8,
             opcode: OP_CURVETO as i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"d\x00" as *const u8 as *const i8,
             opcode: -2i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"f\x00" as *const u8 as *const i8,
             opcode: 0i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"F\x00" as *const u8 as *const i8,
             opcode: 0i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"g\x00" as *const u8 as *const i8,
             opcode: -1i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"G\x00" as *const u8 as *const i8,
             opcode: -1i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"h\x00" as *const u8 as *const i8,
             opcode: OP_CLOSEPATH as i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"i\x00" as *const u8 as *const i8,
             opcode: -1i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"j\x00" as *const u8 as *const i8,
             opcode: -1i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"J\x00" as *const u8 as *const i8,
             opcode: -1i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"k\x00" as *const u8 as *const i8,
             opcode: -4i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"K\x00" as *const u8 as *const i8,
             opcode: -4i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"l\x00" as *const u8 as *const i8,
             opcode: OP_LINETO as i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"m\x00" as *const u8 as *const i8,
             opcode: OP_MOVETO as i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"M\x00" as *const u8 as *const i8,
             opcode: -1i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"n\x00" as *const u8 as *const i8,
             opcode: OP_NOOP as i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"q\x00" as *const u8 as *const i8,
             opcode: OP_GSAVE as i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"Q\x00" as *const u8 as *const i8,
             opcode: OP_GRESTORE as i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"s\x00" as *const u8 as *const i8,
             opcode: OP_CLOSEandCLIP as i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"S\x00" as *const u8 as *const i8,
             opcode: OP_CLIP as i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"v\x00" as *const u8 as *const i8,
             opcode: OP_CURVETO1 as i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"w\x00" as *const u8 as *const i8,
             opcode: -1i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"W\x00" as *const u8 as *const i8,
             opcode: OP_CLIP as i32,
-        };
-        init
-    },
-    {
-        let mut init = operator {
+        },
+    operator {
             token: b"y\x00" as *const u8 as *const i8,
             opcode: OP_CURVETO2 as i32,
-        };
-        init
-    },
+        },
 ];*/
 /* NOWHERE USED
 [no_mangle]

--- a/dpx/src/dpx_pdfcolor.rs
+++ b/dpx/src/dpx_pdfcolor.rs
@@ -1045,14 +1045,11 @@ pub unsafe extern "C" fn iccp_load_profile(
     cspc_id = pdf_colorspace_defineresource(ident, 4i32, cdata, resource);
     cspc_id
 }
-static mut CSPC_CACHE: CspcCache = {
-    let mut init = CspcCache {
+static mut CSPC_CACHE: CspcCache = CspcCache {
         count: 0_u32,
         capacity: 0_u32,
         colorspaces: 0 as *const pdf_colorspace as *mut pdf_colorspace,
     };
-    init
-};
 unsafe fn pdf_colorspace_findresource(
     mut ident: *const i8,
     mut type_0: i32,

--- a/dpx/src/dpx_pdfdev.rs
+++ b/dpx/src/dpx_pdfdev.rs
@@ -347,14 +347,11 @@ pub unsafe extern "C" fn pdf_dev_set_verbose(mut level: i32) {
 pub unsafe extern "C" fn pdf_dev_scale() -> f64 {
     1.0f64
 }
-static mut dev_unit: DevUnit = {
-    let mut init = DevUnit {
+static mut dev_unit: DevUnit = DevUnit {
         dvi2pts: 0.0f64,
         min_bp_val: 658i32,
         precision: 2i32,
     };
-    init
-};
 #[no_mangle]
 pub unsafe extern "C" fn dev_unit_dviunit() -> f64 {
     1.0f64 / dev_unit.dvi2pts
@@ -537,13 +534,10 @@ pub fn pdf_sprint_number(buf: &mut [u8], mut value: f64) -> usize {
     buf[len] = 0;
     len
 }
-static mut dev_param: DevParam = {
-    let mut init = DevParam {
+static mut dev_param: DevParam = DevParam {
         autorotate: 1i32,
         colormode: 1i32,
     };
-    init
-};
 static mut motion_state: MotionState = MotionState::GRAPHICS_MODE;
 static mut format_buffer: [u8; 4096] = [0; 4096];
 static mut text_state: TextState = TextState {

--- a/dpx/src/dpx_pdfdoc.rs
+++ b/dpx/src/dpx_pdfdoc.rs
@@ -231,14 +231,11 @@ pub unsafe extern "C" fn pdf_doc_enable_manual_thumbnails() {
     // warn!("Manual thumbnail is not supported without the libpng library.");
 }
 unsafe fn read_thumbnail(mut thumb_filename: *const i8) -> *mut pdf_obj {
-    let mut options: load_options = {
-        let mut init = load_options {
+    let mut options: load_options = load_options {
             page_no: 1i32,
             bbox_type: 0i32,
             dict: 0 as *mut pdf_obj,
         };
-        init
-    };
     let handle =
         ttstub_input_open(thumb_filename, TTInputFormat::PICT, 0i32);
     if handle.is_none() {
@@ -2720,15 +2717,12 @@ pub unsafe extern "C" fn pdf_doc_end_grabbing(mut attrib: *mut pdf_obj) {
     pdf_dev_reset_color(0i32);
     free(fnode as *mut libc::c_void);
 }
-static mut breaking_state: C2RustUnnamed_4 = {
-    let mut init = C2RustUnnamed_4 {
+static mut breaking_state: C2RustUnnamed_4 = C2RustUnnamed_4 {
         dirty: 0i32,
         broken: 0i32,
         annot_dict: 0 as *const pdf_obj as *mut pdf_obj,
         rect: Rect::zero(),
     };
-    init
-};
 unsafe fn reset_box() {
     breaking_state.rect = Rect::new(
         (core::f64::INFINITY, core::f64::INFINITY),

--- a/dpx/src/dpx_pdfencoding.rs
+++ b/dpx/src/dpx_pdfencoding.rs
@@ -321,14 +321,11 @@ unsafe fn load_encoding_file(mut filename: *const i8) -> i32 {
     }
     enc_id
 }
-static mut enc_cache: C2RustUnnamed = {
-    let mut init = C2RustUnnamed {
+static mut enc_cache: C2RustUnnamed = C2RustUnnamed {
         count: 0i32,
         capacity: 0i32,
         encodings: 0 as *const pdf_encoding as *mut pdf_encoding,
     };
-    init
-};
 #[no_mangle]
 pub unsafe extern "C" fn pdf_init_encodings() {
     enc_cache.count = 0i32;

--- a/dpx/src/dpx_pdffont.rs
+++ b/dpx/src/dpx_pdffont.rs
@@ -293,14 +293,11 @@ unsafe fn pdf_clean_font_struct(mut font: *mut pdf_font) {
         (*font).usedchars = 0 as *mut i8
     };
 }
-static mut font_cache: C2RustUnnamed_0 = {
-    let mut init = C2RustUnnamed_0 {
+static mut font_cache: C2RustUnnamed_0 = C2RustUnnamed_0 {
         count: 0i32,
         capacity: 0i32,
         fonts: 0 as *const pdf_font as *mut pdf_font,
     };
-    init
-};
 #[no_mangle]
 pub unsafe extern "C" fn pdf_init_fonts() {
     assert!(font_cache.fonts.is_null());

--- a/dpx/src/dpx_pdfobj.rs
+++ b/dpx/src/dpx_pdfobj.rs
@@ -3917,8 +3917,7 @@ unsafe extern "C" fn import_dict(
     pdf_add_dict(&mut *copy, pdf_name_value(&*key).to_bytes(), tmp); // TODO: check
     0i32
 }
-static mut loop_marker: pdf_obj = {
-    let mut init = pdf_obj {
+static mut loop_marker: pdf_obj = pdf_obj {
         typ: 0i32,
         label: 0_u32,
         generation: 0_u16,
@@ -3926,8 +3925,6 @@ static mut loop_marker: pdf_obj = {
         flags: 0i32,
         data: 0 as *const libc::c_void as *mut libc::c_void,
     };
-    init
-};
 unsafe fn pdf_import_indirect(mut object: *mut pdf_obj) -> *mut pdf_obj {
     let mut pf: *mut pdf_file = (*((*object).data as *mut pdf_indirect)).pf;
     let mut obj_num: u32 = (*((*object).data as *mut pdf_indirect)).label;

--- a/dpx/src/dpx_pdfresource.rs
+++ b/dpx/src/dpx_pdfresource.rs
@@ -68,69 +68,42 @@ pub struct C2RustUnnamed {
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
 static mut pdf_resource_categories: [C2RustUnnamed; 9] = [
-    {
-        let mut init = C2RustUnnamed {
+    C2RustUnnamed {
             name: b"Font\x00" as *const u8 as *const i8,
             cat_id: 0i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed {
+        },
+    C2RustUnnamed {
             name: b"CIDFont\x00" as *const u8 as *const i8,
             cat_id: 1i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed {
+        },
+    C2RustUnnamed {
             name: b"Encoding\x00" as *const u8 as *const i8,
             cat_id: 2i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed {
+        },
+    C2RustUnnamed {
             name: b"CMap\x00" as *const u8 as *const i8,
             cat_id: 3i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed {
+        },
+    C2RustUnnamed {
             name: b"XObject\x00" as *const u8 as *const i8,
             cat_id: 4i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed {
+        },
+    C2RustUnnamed {
             name: b"ColorSpace\x00" as *const u8 as *const i8,
             cat_id: 5i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed {
+        },
+    C2RustUnnamed {
             name: b"Shading\x00" as *const u8 as *const i8,
             cat_id: 6i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed {
+        },
+    C2RustUnnamed {
             name: b"Pattern\x00" as *const u8 as *const i8,
             cat_id: 7i32,
-        };
-        init
-    },
-    {
-        let mut init = C2RustUnnamed {
+        },
+    C2RustUnnamed {
             name: b"ExtGState\x00" as *const u8 as *const i8,
             cat_id: 8i32,
-        };
-        init
-    },
+        },
 ];
 static mut resources: [res_cache; 9] = [res_cache {
     count: 0,

--- a/dpx/src/dpx_pdfximage.rs
+++ b/dpx/src/dpx_pdfximage.rs
@@ -131,25 +131,19 @@ pub struct ic_ {
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-static mut _opts: opt_ = {
-    let mut init = opt_ {
+static mut _opts: opt_ = opt_ {
         verbose: 0i32,
         cmdtmpl: 0 as *const i8 as *mut i8,
     };
-    init
-};
 #[no_mangle]
 pub unsafe extern "C" fn pdf_ximage_set_verbose(mut level: i32) {
     _opts.verbose = level;
 }
-static mut _ic: ic_ = {
-    let mut init = ic_ {
+static mut _ic: ic_ = ic_ {
         count: 0i32,
         capacity: 0i32,
         ximages: 0 as *const pdf_ximage as *mut pdf_ximage,
     };
-    init
-};
 unsafe fn pdf_init_ximage_struct(mut I: *mut pdf_ximage) {
     (*I).ident = 0 as *mut i8;
     (*I).filename = 0 as *mut i8;

--- a/dpx/src/dpx_tt_cmap.rs
+++ b/dpx/src/dpx_tt_cmap.rs
@@ -1218,41 +1218,26 @@ unsafe fn create_ToUnicode_cmap(
     stream
 }
 static mut cmap_plat_encs: [cmap_plat_enc_rec; 5] = [
-    {
-        let mut init = cmap_plat_enc_rec {
+    cmap_plat_enc_rec {
             platform: 3_i16,
             encoding: 10_i16,
-        };
-        init
-    },
-    {
-        let mut init = cmap_plat_enc_rec {
+        },
+    cmap_plat_enc_rec {
             platform: 0_i16,
             encoding: 3_i16,
-        };
-        init
-    },
-    {
-        let mut init = cmap_plat_enc_rec {
+        },
+    cmap_plat_enc_rec {
             platform: 0_i16,
             encoding: 0_i16,
-        };
-        init
-    },
-    {
-        let mut init = cmap_plat_enc_rec {
+        },
+    cmap_plat_enc_rec {
             platform: 3_i16,
             encoding: 1_i16,
-        };
-        init
-    },
-    {
-        let mut init = cmap_plat_enc_rec {
+        },
+    cmap_plat_enc_rec {
             platform: 0_i16,
             encoding: 1_i16,
-        };
-        init
-    },
+        },
 ];
 #[no_mangle]
 pub unsafe extern "C" fn otf_create_ToUnicode_stream(
@@ -1467,14 +1452,11 @@ pub unsafe extern "C" fn otf_load_Unicode_CMap(
     let cmap_name;
     let mut gsub_vert;
     let gsub_list;
-    let mut csi: CIDSysInfo = {
-        let mut init = CIDSysInfo {
+    let mut csi: CIDSysInfo = CIDSysInfo {
             registry: 0 as *mut i8,
             ordering: 0 as *mut i8,
             supplement: 0i32,
         };
-        init
-    };
     let mut GIDToCIDMap: *mut u8 = 0 as *mut u8;
     if map_name.is_null() {
         return -1i32;

--- a/dpx/src/dpx_type0.rs
+++ b/dpx/src/dpx_type0.rs
@@ -301,14 +301,11 @@ pub unsafe extern "C" fn Type0Font_get_resource(mut font: *mut Type0Font) -> *mu
     }
     pdf_link_obj((*font).indirect)
 }
-static mut __cache: font_cache = {
-    let mut init = font_cache {
+static mut __cache: font_cache = font_cache {
         count: 0i32,
         capacity: 0i32,
         fonts: 0 as *const Type0Font as *mut Type0Font,
     };
-    init
-};
 #[no_mangle]
 pub unsafe extern "C" fn Type0Font_cache_init() {
     if !__cache.fonts.is_null() {

--- a/dpx/src/specials/dvips.rs
+++ b/dpx/src/specials/dvips.rs
@@ -140,14 +140,11 @@ unsafe fn parse_filename(pp: &mut &[u8]) -> Option<CString> {
 /* =filename ... */
 unsafe fn spc_handler_ps_file(mut spe: *mut spc_env, mut args: *mut spc_arg) -> i32 {
     let mut ti = transform_info::new();
-    let mut options: load_options = {
-        let mut init = load_options {
+    let mut options: load_options = load_options {
             page_no: 1i32,
             bbox_type: 0i32,
             dict: 0 as *mut pdf_obj,
         };
-        init
-    };
     assert!(!spe.is_null() && !args.is_null());
     (*args).cur.skip_white();
     if (*args).cur.len() <= 1 || (*args).cur[0] != b'=' {
@@ -180,14 +177,11 @@ unsafe fn spc_handler_ps_file(mut spe: *mut spc_env, mut args: *mut spc_arg) -> 
 unsafe fn spc_handler_ps_plotfile(mut spe: *mut spc_env, mut args: *mut spc_arg) -> i32 {
     let mut error: i32 = 0i32; /* xscale = 1.0, yscale = -1.0 */
     let mut p = transform_info::new();
-    let mut options: load_options = {
-        let mut init = load_options {
+    let mut options: load_options = load_options {
             page_no: 1i32,
             bbox_type: 0i32,
             dict: 0 as *mut pdf_obj,
         };
-        init
-    };
     assert!(!spe.is_null() && !args.is_null());
     spc_warn!(spe, "\"ps: plotfile\" found (not properly implemented)");
     (*args).cur.skip_white();

--- a/dpx/src/specials/html.rs
+++ b/dpx/src/specials/html.rs
@@ -84,18 +84,12 @@ use crate::dpx_pdfdev::Coord;
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-static mut _HTML_STATE: spc_html_ = {
-    let mut init = spc_html_ {
-        opts: {
-            let mut init = C2RustUnnamed_0 { extensions: 0i32 };
-            init
-        },
+static mut _HTML_STATE: spc_html_ = spc_html_ {
+        opts: C2RustUnnamed_0 { extensions: 0i32 },
         link_dict: 0 as *const pdf_obj as *mut pdf_obj,
         baseurl: 0 as *const i8 as *mut i8,
         pending_type: -1i32,
     };
-    init
-};
 /* ENABLE_HTML_SVG_TRANSFORM */
 unsafe fn parse_key_val(
     pp: &mut &[u8],
@@ -531,14 +525,11 @@ unsafe fn check_resourcestatus(category: &str, mut resname: &str) -> i32 {
 /* ENABLE_HTML_SVG_OPACITY */
 unsafe fn spc_html__img_empty(mut spe: *mut spc_env, attr: &pdf_obj) -> i32 {
     let mut ti = transform_info::new();
-    let mut options: load_options = {
-        let mut init = load_options {
+    let mut options: load_options = load_options {
             page_no: 1i32,
             bbox_type: 0i32,
             dict: 0 as *mut pdf_obj,
         };
-        init
-    };
     let mut error: i32 = 0i32;
     let mut alpha: f64 = 1.0f64;
     /* ENABLE_HTML_SVG_OPACITY */

--- a/dpx/src/specials/misc.rs
+++ b/dpx/src/specials/misc.rs
@@ -46,14 +46,11 @@ use crate::dpx_pdfximage::load_options;
 /* quasi-hack to get the primary input */
 unsafe fn spc_handler_postscriptbox(mut spe: *mut spc_env, mut ap: *mut spc_arg) -> i32 {
     let mut ti = transform_info::new();
-    let mut options: load_options = {
-        let mut init = load_options {
+    let mut options: load_options = load_options {
             page_no: 1i32,
             bbox_type: 0i32,
             dict: 0 as *mut pdf_obj,
         };
-        init
-    };
     let mut filename: [i8; 256] = [0; 256];
     let mut buf: [u8; 512] = [0; 512];
     assert!(!spe.is_null() && !ap.is_null());

--- a/dpx/src/specials/pdfm.rs
+++ b/dpx/src/specials/pdfm.rs
@@ -130,22 +130,16 @@ use crate::dpx_pdfdev::Coord;
 /* Note that we explicitly do *not* change this on Windows. For maximum
  * portability, we should probably accept *either* forward or backward slashes
  * as directory separators. */
-static mut _PDF_STAT: spc_pdf_ = {
-    let mut init = spc_pdf_ {
+static mut _PDF_STAT: spc_pdf_ = spc_pdf_ {
         annot_dict: 0 as *const pdf_obj as *mut pdf_obj,
         lowest_level: 255i32,
         resourcemap: 0 as *const ht_table as *mut ht_table,
-        cd: {
-            let mut init = tounicode {
+        cd: tounicode {
                 cmap_id: -1i32,
                 unescape_backslash: 0i32,
                 taintkeys: 0 as *const pdf_obj as *mut pdf_obj,
-            };
-            init
-        },
+            },
     };
-    init
-};
 /* PLEASE REMOVE THIS */
 unsafe extern "C" fn hval_free(mut vp: *mut libc::c_void) {
     free(vp); /* unused */
@@ -980,14 +974,11 @@ unsafe fn spc_handler_pdfm_image(mut spe: *mut spc_env, mut args: *mut spc_arg) 
     let mut sd: *mut spc_pdf_ = &mut _PDF_STAT;
     let mut ident = None;
     let mut ti = transform_info::new();
-    let mut options: load_options = {
-        let mut init = load_options {
+    let mut options: load_options = load_options {
             page_no: 1i32,
             bbox_type: 0i32,
             dict: 0 as *mut pdf_obj,
         };
-        init
-    };
     (*args).cur.skip_white();
     if (*args).cur[0] == b'@' {
         ident = (*args).cur.parse_opt_ident();
@@ -1576,14 +1567,11 @@ unsafe fn spc_handler_pdfm_eform(mut _spe: *mut spc_env, mut args: *mut spc_arg)
 unsafe fn spc_handler_pdfm_uxobj(mut spe: *mut spc_env, mut args: *mut spc_arg) -> i32 {
     let mut sd: *mut spc_pdf_ = &mut _PDF_STAT;
     let mut ti = transform_info::new();
-    let mut options: load_options = {
-        let mut init = load_options {
+    let mut options: load_options = load_options {
             page_no: 1i32,
             bbox_type: 0i32,
             dict: 0 as *mut pdf_obj,
         };
-        init
-    };
     (*args).cur.skip_white();
     if let Some(ident) = (*args).cur.parse_opt_ident() {
         transform_info_clear(&mut ti);

--- a/engine/src/xetex_math.rs
+++ b/engine/src/xetex_math.rs
@@ -6709,15 +6709,12 @@ unsafe extern "C" fn var_delimiter(mut d: i32, mut s: i32, mut v: scaled_t) -> i
     let mut n: i32 = 0;
     let mut u: scaled_t = 0;
     let mut w: scaled_t = 0;
-    let mut q: b16x4 = {
-        let mut init = b16x4_le_t {
+    let mut q: b16x4 = b16x4_le_t {
             s0: 0_u16,
             s1: 0_u16,
             s2: 0_u16,
             s3: 0_u16,
         };
-        init
-    };
     let mut r: b16x4 = b16x4 {
         s0: 0,
         s1: 0,


### PR DESCRIPTION
Note: This was automated with [fastmod](https://github.com/facebookincubator/fastmod).

```bash
fastmod -m -d . --extensions rs \
  "\{\s*?let mut init = (\w+) (.*?);\s*?init\s*?}" \
  "\${1} \${2}"
```