### PR TITLE
Rust return types

### DIFF
--- a/dpx/src/dpx_agl.rs
+++ b/dpx/src/dpx_agl.rs
@@ -23,7 +23,7 @@
     mutable_transmutes,
     non_camel_case_types,
     non_snake_case,
-    non_upper_case_globals,
+    non_upper_case_globals
 )]
 
 use crate::DisplayExt;
@@ -385,11 +385,11 @@ pub unsafe fn agl_init_map() {
         &mut aglmap,
         Some(hval_free as unsafe fn(_: *mut libc::c_void) -> ()),
     );
-    agl_load_listfile(b"texglyphlist.txt\x00" as *const u8 as *const i8, 0i32);
-    if agl_load_listfile(b"pdfglyphlist.txt\x00" as *const u8 as *const i8, 1i32) < 0i32 {
+    agl_load_listfile(b"texglyphlist.txt\x00" as *const u8 as *const i8, 0);
+    if agl_load_listfile(b"pdfglyphlist.txt\x00" as *const u8 as *const i8, 1).is_err() {
         warn!("Failed to load AGL file \"{}\"...", "pdfglyphlist.txt");
     }
-    if agl_load_listfile(b"glyphlist.txt\x00" as *const u8 as *const i8, 0i32) < 0i32 {
+    if agl_load_listfile(b"glyphlist.txt\x00" as *const u8 as *const i8, 0).is_err() {
         warn!("Failed to load AGL file \"{}\"...", "glyphlist.txt");
     };
 }
@@ -404,11 +404,11 @@ pub unsafe fn agl_close_map() {
  *  http://partners.adobe.com/asn/tech/type/unicodegn.jsp
  */
 /* Hash */
-unsafe fn agl_load_listfile(filename: *const i8, is_predef: i32) -> i32 {
-    let mut count: i32 = 0i32;
+unsafe fn agl_load_listfile(filename: *const i8, is_predef: i32) -> Result<u32, ()> {
+    let mut count: u32 = 0;
     let mut wbuf: [i8; 1024] = [0; 1024];
     if filename.is_null() {
-        return -1i32;
+        return Err(());
     }
     let handle = dpx_tt_open(
         filename,
@@ -416,7 +416,7 @@ unsafe fn agl_load_listfile(filename: *const i8, is_predef: i32) -> i32 {
         TTInputFormat::FONTMAP,
     );
     if handle.is_none() {
-        return -1i32;
+        return Err(());
     }
     let mut handle = handle.unwrap();
     if verbose != 0 {
@@ -529,7 +529,7 @@ unsafe fn agl_load_listfile(filename: *const i8, is_predef: i32) -> i32 {
     if verbose != 0 {
         info!(">");
     }
-    count
+    Ok(count)
 }
 
 pub unsafe fn agl_lookup_list(glyphname: *const i8) -> *mut agl_name {

--- a/dpx/src/dpx_cff.rs
+++ b/dpx/src/dpx_cff.rs
@@ -23,7 +23,7 @@
     mutable_transmutes,
     non_camel_case_types,
     non_snake_case,
-    non_upper_case_globals,
+    non_upper_case_globals
 )]
 
 use crate::streq_ptr;
@@ -794,12 +794,11 @@ pub unsafe fn cff_open<'a>(
     if cff_dict_known(
         (*cff).topdict,
         b"CharstringType\x00" as *const u8 as *const i8,
-    ) != 0
-        && cff_dict_get(
-            (*cff).topdict,
-            b"CharstringType\x00" as *const u8 as *const i8,
-            0i32,
-        ) != 2i32 as f64
+    ) && cff_dict_get(
+        (*cff).topdict,
+        b"CharstringType\x00" as *const u8 as *const i8,
+        0i32,
+    ) != 2i32 as f64
     {
         warn!("Only Type 2 Charstrings supported...");
         cff_close(cff);
@@ -808,8 +807,7 @@ pub unsafe fn cff_open<'a>(
     if cff_dict_known(
         (*cff).topdict,
         b"SyntheticBase\x00" as *const u8 as *const i8,
-    ) != 0
-    {
+    ) {
         warn!("CFF Synthetic font not supported.");
         cff_close(cff);
         return ptr::null_mut();
@@ -829,13 +827,13 @@ pub unsafe fn cff_open<'a>(
         .unwrap();
     (*cff).num_glyphs = tt_get_unsigned_pair(handle);
     /* Check for font type */
-    if cff_dict_known((*cff).topdict, b"ROS\x00" as *const u8 as *const i8) != 0 {
+    if cff_dict_known((*cff).topdict, b"ROS\x00" as *const u8 as *const i8) {
         (*cff).flag |= 1i32 << 0i32
     } else {
         (*cff).flag |= 1i32 << 1i32
     }
     /* Check for encoding */
-    if cff_dict_known((*cff).topdict, b"Encoding\x00" as *const u8 as *const i8) != 0 {
+    if cff_dict_known((*cff).topdict, b"Encoding\x00" as *const u8 as *const i8) {
         offset = cff_dict_get(
             (*cff).topdict,
             b"Encoding\x00" as *const u8 as *const i8,
@@ -851,7 +849,7 @@ pub unsafe fn cff_open<'a>(
         (*cff).flag |= 1i32 << 3i32
     }
     /* Check for charset */
-    if cff_dict_known((*cff).topdict, b"charset\x00" as *const u8 as *const i8) != 0 {
+    if cff_dict_known((*cff).topdict, b"charset\x00" as *const u8 as *const i8) {
         offset = cff_dict_get(
             (*cff).topdict,
             b"charset\x00" as *const u8 as *const i8,
@@ -1382,7 +1380,7 @@ pub unsafe fn cff_read_encoding(cff: &mut cff_font) -> i32 {
     if cff.topdict.is_null() {
         panic!("Top DICT data not found");
     }
-    if cff_dict_known(cff.topdict, b"Encoding\x00" as *const u8 as *const i8) == 0 {
+    if !cff_dict_known(cff.topdict, b"Encoding\x00" as *const u8 as *const i8) {
         cff.flag |= 1i32 << 3i32;
         cff.encoding = ptr::null_mut();
         return 0i32;
@@ -1587,7 +1585,7 @@ pub unsafe fn cff_read_charsets(cff: &mut cff_font) -> i32 {
     if cff.topdict.is_null() {
         panic!("Top DICT not available");
     }
-    if cff_dict_known(cff.topdict, b"charset\x00" as *const u8 as *const i8) == 0 {
+    if !cff_dict_known(cff.topdict, b"charset\x00" as *const u8 as *const i8) {
         cff.flag |= 1i32 << 5i32;
         cff.charsets = ptr::null_mut();
         return 0i32;
@@ -2130,10 +2128,10 @@ pub unsafe fn cff_read_subrs(cff: &mut cff_font) -> i32 {
     if cff.flag & 1i32 << 0i32 != 0 {
         for i in 0..cff.num_fds as i32 {
             if (*cff.private.offset(i as isize)).is_null()
-                || cff_dict_known(
+                || !cff_dict_known(
                     *cff.private.offset(i as isize),
                     b"Subrs\x00" as *const u8 as *const i8,
-                ) == 0
+                )
             {
                 let ref mut fresh47 = *cff.subrs.offset(i as isize);
                 *fresh47 = ptr::null_mut()
@@ -2160,10 +2158,10 @@ pub unsafe fn cff_read_subrs(cff: &mut cff_font) -> i32 {
             }
         }
     } else if (*cff.private.offset(0)).is_null()
-        || cff_dict_known(
+        || !cff_dict_known(
             *cff.private.offset(0),
             b"Subrs\x00" as *const u8 as *const i8,
-        ) == 0
+        )
     {
         let ref mut fresh49 = *cff.subrs.offset(0);
         *fresh49 = ptr::null_mut()
@@ -2281,7 +2279,7 @@ pub unsafe fn cff_read_private(cff: &mut cff_font) -> i32 {
                 && cff_dict_known(
                     *cff.fdarray.offset(i as isize),
                     b"Private\x00" as *const u8 as *const i8,
-                ) != 0
+                )
                 && {
                     size = cff_dict_get(
                         *cff.fdarray.offset(i as isize),
@@ -2322,7 +2320,7 @@ pub unsafe fn cff_read_private(cff: &mut cff_font) -> i32 {
         cff.private =
             new((1_u64).wrapping_mul(::std::mem::size_of::<*mut cff_dict>() as u64) as u32)
                 as *mut *mut cff_dict;
-        if cff_dict_known(cff.topdict, b"Private\x00" as *const u8 as *const i8) != 0 && {
+        if cff_dict_known(cff.topdict, b"Private\x00" as *const u8 as *const i8) && {
             size = cff_dict_get(cff.topdict, b"Private\x00" as *const u8 as *const i8, 0i32) as i32;
             size > 0i32
         } {

--- a/dpx/src/dpx_cff_dict.rs
+++ b/dpx/src/dpx_cff_dict.rs
@@ -23,7 +23,7 @@
     mutable_transmutes,
     non_camel_case_types,
     non_snake_case,
-    non_upper_case_globals,
+    non_upper_case_globals
 )]
 
 use crate::DisplayExt;
@@ -781,15 +781,15 @@ pub unsafe fn cff_dict_remove(dict: *mut cff_dict, key: *const i8) {
     }
 }
 
-pub unsafe fn cff_dict_known(dict: *mut cff_dict, key: *const i8) -> i32 {
+pub unsafe fn cff_dict_known(dict: *mut cff_dict, key: *const i8) -> bool {
     for i in 0..(*dict).count {
         if streq_ptr(key, (*(*dict).entries.offset(i as isize)).key) as i32 != 0
             && (*(*dict).entries.offset(i as isize)).count > 0i32
         {
-            return 1i32;
+            return true;
         }
     }
-    0i32
+    false
 }
 
 pub unsafe fn cff_dict_get(dict: *mut cff_dict, key: *const i8, idx: i32) -> f64 {

--- a/dpx/src/dpx_cidtype0.rs
+++ b/dpx/src/dpx_cidtype0.rs
@@ -23,7 +23,7 @@
     mutable_transmutes,
     non_camel_case_types,
     non_snake_case,
-    non_upper_case_globals,
+    non_upper_case_globals
 )]
 
 use crate::DisplayExt;
@@ -717,7 +717,7 @@ pub unsafe fn CIDFont_type0_dofont(font: *mut CIDFont) {
         (*(*font).fontdict).as_dict_mut().set("DW", 1000_f64);
     } else {
         let cid_count =
-            if cff_dict_known((*cffont).topdict, b"CIDCount\x00" as *const u8 as *const i8) != 0 {
+            if cff_dict_known((*cffont).topdict, b"CIDCount\x00" as *const u8 as *const i8) {
                 cff_dict_get(
                     (*cffont).topdict,
                     b"CIDCount\x00" as *const u8 as *const i8,
@@ -1217,7 +1217,7 @@ pub unsafe fn CIDFont_type0_t1cdofont(font: *mut CIDFont) {
         && cff_dict_known(
             *cffont.private.offset(0),
             b"StdVW\x00" as *const u8 as *const i8,
-        ) != 0
+        )
     {
         let stemv = cff_dict_get(
             *cffont.private.offset(0),
@@ -1230,8 +1230,7 @@ pub unsafe fn CIDFont_type0_t1cdofont(font: *mut CIDFont) {
         && cff_dict_known(
             *cffont.private.offset(0),
             b"defaultWidthX\x00" as *const u8 as *const i8,
-        ) != 0
-    {
+        ) {
         cff_dict_get(
             *cffont.private.offset(0),
             b"defaultWidthX\x00" as *const u8 as *const i8,
@@ -1244,8 +1243,7 @@ pub unsafe fn CIDFont_type0_t1cdofont(font: *mut CIDFont) {
         && cff_dict_known(
             *cffont.private.offset(0),
             b"nominalWidthX\x00" as *const u8 as *const i8,
-        ) != 0
-    {
+        ) {
         cff_dict_get(
             *cffont.private.offset(0),
             b"nominalWidthX\x00" as *const u8 as *const i8,
@@ -1728,7 +1726,7 @@ unsafe fn get_font_attr(font: *mut CIDFont, cffont: &cff_font) {
     let mut capheight;
     let mut ascent;
     let mut descent;
-    if cff_dict_known(cffont.topdict, b"FontBBox\x00" as *const u8 as *const i8) != 0 {
+    if cff_dict_known(cffont.topdict, b"FontBBox\x00" as *const u8 as *const i8) {
         /* Default values */
         ascent = cff_dict_get(
             cffont.topdict,
@@ -1749,8 +1747,7 @@ unsafe fn get_font_attr(font: *mut CIDFont, cffont: &cff_font) {
     let stemv = if cff_dict_known(
         *cffont.private.offset(0),
         b"StdVW\x00" as *const u8 as *const i8,
-    ) != 0
-    {
+    ) {
         cff_dict_get(
             *cffont.private.offset(0),
             b"StdVW\x00" as *const u8 as *const i8,
@@ -1768,7 +1765,7 @@ unsafe fn get_font_attr(font: *mut CIDFont, cffont: &cff_font) {
          */
         88.
     };
-    if cff_dict_known(cffont.topdict, b"ItalicAngle\x00" as *const u8 as *const i8) != 0 {
+    if cff_dict_known(cffont.topdict, b"ItalicAngle\x00" as *const u8 as *const i8) {
         italicangle = cff_dict_get(
             cffont.topdict,
             b"ItalicAngle\x00" as *const u8 as *const i8,
@@ -1890,24 +1887,22 @@ unsafe fn get_font_attr(font: *mut CIDFont, cffont: &cff_font) {
     if cff_dict_known(
         *cffont.private.offset(0),
         b"ForceBold\x00" as *const u8 as *const i8,
-    ) != 0
-        && cff_dict_get(
-            *cffont.private.offset(0),
-            b"ForceBold\x00" as *const u8 as *const i8,
-            0i32,
-        ) != 0.
+    ) && cff_dict_get(
+        *cffont.private.offset(0),
+        b"ForceBold\x00" as *const u8 as *const i8,
+        0i32,
+    ) != 0.
     {
         flags |= 1i32 << 18i32
     }
     if cff_dict_known(
         *cffont.private.offset(0),
         b"IsFixedPitch\x00" as *const u8 as *const i8,
-    ) != 0
-        && cff_dict_get(
-            *cffont.private.offset(0),
-            b"IsFixedPitch\x00" as *const u8 as *const i8,
-            0i32,
-        ) != 0.
+    ) && cff_dict_get(
+        *cffont.private.offset(0),
+        b"IsFixedPitch\x00" as *const u8 as *const i8,
+        0i32,
+    ) != 0.
     {
         flags |= 1i32 << 0i32
     }
@@ -1944,7 +1939,7 @@ unsafe fn add_metrics(
      * charstrings, to prevent Acrobat 4 from greeking text as
      * much as possible.
      */
-    if cff_dict_known((*cffont).topdict, b"FontBBox\x00" as *const u8 as *const i8) == 0 {
+    if !cff_dict_known((*cffont).topdict, b"FontBBox\x00" as *const u8 as *const i8) {
         panic!("No FontBBox?");
     }
     let mut tmp = vec![];
@@ -2060,8 +2055,7 @@ pub unsafe fn CIDFont_type0_t1dofont(font: *mut CIDFont) {
     let defaultwidth = if cff_dict_known(
         *cffont.private.offset(0),
         b"defaultWidthX\x00" as *const u8 as *const i8,
-    ) != 0
-    {
+    ) {
         cff_dict_get(
             *cffont.private.offset(0),
             b"defaultWidthX\x00" as *const u8 as *const i8,
@@ -2073,8 +2067,7 @@ pub unsafe fn CIDFont_type0_t1dofont(font: *mut CIDFont) {
     let nominalwidth = if cff_dict_known(
         *cffont.private.offset(0),
         b"nominalWidthX\x00" as *const u8 as *const i8,
-    ) != 0
-    {
+    ) {
         cff_dict_get(
             *cffont.private.offset(0),
             b"nominalWidthX\x00" as *const u8 as *const i8,

--- a/dpx/src/dpx_dvi.rs
+++ b/dpx/src/dpx_dvi.rs
@@ -24,7 +24,7 @@
     mutable_transmutes,
     non_camel_case_types,
     non_snake_case,
-    non_upper_case_globals,
+    non_upper_case_globals
 )]
 
 use std::io::{Read, Seek, SeekFrom};
@@ -1036,7 +1036,7 @@ unsafe fn dvi_locate_native_font(
         }
         let ref mut fresh18 = font.cffont;
         *fresh18 = cffont;
-        if cff_dict_known((*cffont).topdict, b"FontBBox\x00" as *const u8 as *const i8) != 0 {
+        if cff_dict_known((*cffont).topdict, b"FontBBox\x00" as *const u8 as *const i8) {
             font.ascent = cff_dict_get(
                 (*cffont).topdict,
                 b"FontBBox\x00" as *const u8 as *const i8,

--- a/dpx/src/dpx_pdfximage.rs
+++ b/dpx/src/dpx_pdfximage.rs
@@ -23,7 +23,7 @@
     mutable_transmutes,
     non_camel_case_types,
     non_snake_case,
-    non_upper_case_globals,
+    non_upper_case_globals
 )]
 
 use euclid::point2;
@@ -226,9 +226,9 @@ unsafe fn source_image_type(handle: &mut InputHandleWrapper) -> i32 {
         1
     } else if check_for_png(handle) != 0 {
         2
-    } else if check_for_bmp(handle) != 0 {
+    } else if check_for_bmp(handle) {
         6
-    } else if check_for_pdf(handle) != false {
+    } else if check_for_pdf(handle) {
         0
     } else if check_for_ps(handle) != 0 {
         5
@@ -316,7 +316,7 @@ unsafe fn load_image(
             if _opts.verbose != 0 {
                 info!("[BMP]");
             }
-            if bmp_include_image(I, &mut handle) < 0 {
+            if bmp_include_image(I, &mut handle).is_err() {
                 pdf_clean_ximage_struct(I);
                 return -1;
             }

--- a/dpx/src/dpx_tt_cmap.rs
+++ b/dpx/src/dpx_tt_cmap.rs
@@ -23,7 +23,7 @@
     mutable_transmutes,
     non_camel_case_types,
     non_snake_case,
-    non_upper_case_globals,
+    non_upper_case_globals
 )]
 
 use super::dpx_sfnt::{
@@ -732,7 +732,7 @@ unsafe fn handle_CIDFont(
         *GIDToCIDMap = ptr::null_mut();
         return 0i32;
     }
-    if cff_dict_known(cffont.topdict, b"ROS\x00" as *const u8 as *const i8) == 0 {
+    if !cff_dict_known(cffont.topdict, b"ROS\x00" as *const u8 as *const i8) {
         panic!("No CIDSystemInfo???");
     } else {
         let reg = cff_dict_get(cffont.topdict, b"ROS\x00" as *const u8 as *const i8, 0i32) as u16;

--- a/dpx/src/dpx_type1.rs
+++ b/dpx/src/dpx_type1.rs
@@ -23,7 +23,7 @@
     mutable_transmutes,
     non_camel_case_types,
     non_snake_case,
-    non_upper_case_globals,
+    non_upper_case_globals
 )]
 
 use crate::mfree;
@@ -190,7 +190,7 @@ unsafe fn get_font_attr(font: *mut pdf_font, cffont: &cff_font) {
     let mut capheight;
     let mut ascent;
     let mut descent;
-    if cff_dict_known(cffont.topdict, b"FontBBox\x00" as *const u8 as *const i8) != 0 {
+    if cff_dict_known(cffont.topdict, b"FontBBox\x00" as *const u8 as *const i8) {
         /* Default values */
         ascent = cff_dict_get(
             cffont.topdict,
@@ -211,8 +211,7 @@ unsafe fn get_font_attr(font: *mut pdf_font, cffont: &cff_font) {
     let stemv = if cff_dict_known(
         *cffont.private.offset(0),
         b"StdVW\x00" as *const u8 as *const i8,
-    ) != 0
-    {
+    ) {
         cff_dict_get(
             *cffont.private.offset(0),
             b"StdVW\x00" as *const u8 as *const i8,
@@ -230,7 +229,7 @@ unsafe fn get_font_attr(font: *mut pdf_font, cffont: &cff_font) {
          */
         88.
     };
-    if cff_dict_known(cffont.topdict, b"ItalicAngle\x00" as *const u8 as *const i8) != 0 {
+    if cff_dict_known(cffont.topdict, b"ItalicAngle\x00" as *const u8 as *const i8) {
         italicangle = cff_dict_get(
             cffont.topdict,
             b"ItalicAngle\x00" as *const u8 as *const i8,
@@ -352,24 +351,22 @@ unsafe fn get_font_attr(font: *mut pdf_font, cffont: &cff_font) {
     if cff_dict_known(
         *cffont.private.offset(0),
         b"ForceBold\x00" as *const u8 as *const i8,
-    ) != 0
-        && cff_dict_get(
-            *cffont.private.offset(0),
-            b"ForceBold\x00" as *const u8 as *const i8,
-            0i32,
-        ) != 0.
+    ) && cff_dict_get(
+        *cffont.private.offset(0),
+        b"ForceBold\x00" as *const u8 as *const i8,
+        0i32,
+    ) != 0.
     {
         flags |= 1i32 << 18i32
     }
     if cff_dict_known(
         *cffont.private.offset(0),
         b"IsFixedPitch\x00" as *const u8 as *const i8,
-    ) != 0
-        && cff_dict_get(
-            *cffont.private.offset(0),
-            b"IsFixedPitch\x00" as *const u8 as *const i8,
-            0i32,
-        ) != 0.
+    ) && cff_dict_get(
+        *cffont.private.offset(0),
+        b"IsFixedPitch\x00" as *const u8 as *const i8,
+        0i32,
+    ) != 0.
     {
         flags |= 1i32 << 0i32
     }
@@ -407,24 +404,23 @@ unsafe fn add_metrics(
      * charstrings, to prevent Acrobat 4 from greeking text as
      * much as possible.
      */
-    if cff_dict_known(cffont.topdict, b"FontBBox\x00" as *const u8 as *const i8) == 0 {
+    if !cff_dict_known(cffont.topdict, b"FontBBox\x00" as *const u8 as *const i8) {
         panic!("No FontBBox?");
     }
     /* The widhts array in the font dictionary must be given relative
      * to the default scaling of 1000:1, not relative to the scaling
      * given by the font matrix.
      */
-    let scaling =
-        if cff_dict_known(cffont.topdict, b"FontMatrix\x00" as *const u8 as *const i8) != 0 {
-            1000.
-                * cff_dict_get(
-                    cffont.topdict,
-                    b"FontMatrix\x00" as *const u8 as *const i8,
-                    0i32,
-                )
-        } else {
-            1.
-        };
+    let scaling = if cff_dict_known(cffont.topdict, b"FontMatrix\x00" as *const u8 as *const i8) {
+        1000.
+            * cff_dict_get(
+                cffont.topdict,
+                b"FontMatrix\x00" as *const u8 as *const i8,
+                0i32,
+            )
+    } else {
+        1.
+    };
     let mut tmp_array = vec![];
     for i in 0..4 {
         let val = cff_dict_get(cffont.topdict, b"FontBBox\x00" as *const u8 as *const i8, i);
@@ -512,21 +508,21 @@ unsafe fn write_fontfile(font: *mut pdf_font, cffont: &cff_font, pdfcharset: &pd
     /*
      * Force existence of Encoding.
      */
-    if cff_dict_known(cffont.topdict, b"CharStrings\x00" as *const u8 as *const i8) == 0 {
+    if !cff_dict_known(cffont.topdict, b"CharStrings\x00" as *const u8 as *const i8) {
         cff_dict_add(
             cffont.topdict,
             b"CharStrings\x00" as *const u8 as *const i8,
             1i32,
         );
     }
-    if cff_dict_known(cffont.topdict, b"charset\x00" as *const u8 as *const i8) == 0 {
+    if !cff_dict_known(cffont.topdict, b"charset\x00" as *const u8 as *const i8) {
         cff_dict_add(
             cffont.topdict,
             b"charset\x00" as *const u8 as *const i8,
             1i32,
         );
     }
-    if cff_dict_known(cffont.topdict, b"Encoding\x00" as *const u8 as *const i8) == 0 {
+    if !cff_dict_known(cffont.topdict, b"Encoding\x00" as *const u8 as *const i8) {
         cff_dict_add(
             cffont.topdict,
             b"Encoding\x00" as *const u8 as *const i8,
@@ -535,7 +531,7 @@ unsafe fn write_fontfile(font: *mut pdf_font, cffont: &cff_font, pdfcharset: &pd
     }
     let mut private_size = cff_dict_pack(*cffont.private.offset(0), &mut wbuf[..]);
     /* Private dict is required (but may have size 0) */
-    if cff_dict_known(cffont.topdict, b"Private\x00" as *const u8 as *const i8) == 0 {
+    if !cff_dict_known(cffont.topdict, b"Private\x00" as *const u8 as *const i8) {
         cff_dict_add(
             cffont.topdict,
             b"Private\x00" as *const u8 as *const i8,
@@ -722,8 +718,7 @@ pub unsafe fn pdf_font_load_type1(font: *mut pdf_font) -> i32 {
     let defaultwidth = if cff_dict_known(
         *cffont.private.offset(0),
         b"defaultWidthX\x00" as *const u8 as *const i8,
-    ) != 0
-    {
+    ) {
         cff_dict_get(
             *cffont.private.offset(0),
             b"defaultWidthX\x00" as *const u8 as *const i8,
@@ -735,8 +730,7 @@ pub unsafe fn pdf_font_load_type1(font: *mut pdf_font) -> i32 {
     let nominalwidth = if cff_dict_known(
         *cffont.private.offset(0),
         b"nominalWidthX\x00" as *const u8 as *const i8,
-    ) != 0
-    {
+    ) {
         cff_dict_get(
             *cffont.private.offset(0),
             b"nominalWidthX\x00" as *const u8 as *const i8,

--- a/dpx/src/dpx_type1c.rs
+++ b/dpx/src/dpx_type1c.rs
@@ -23,7 +23,7 @@
     mutable_transmutes,
     non_camel_case_types,
     non_snake_case,
-    non_upper_case_globals,
+    non_upper_case_globals
 )]
 
 use super::dpx_sfnt::{sfnt_close, sfnt_find_table_pos, sfnt_open, sfnt_read_table_directory};
@@ -219,17 +219,16 @@ unsafe fn add_SimpleMetrics(
      * to the default scaling of 1000:1, not relative to the scaling
      * given by the font matrix.
      */
-    let scaling =
-        if cff_dict_known(cffont.topdict, b"FontMatrix\x00" as *const u8 as *const i8) != 0 {
-            1000i32 as f64
-                * cff_dict_get(
-                    cffont.topdict,
-                    b"FontMatrix\x00" as *const u8 as *const i8,
-                    0i32,
-                )
-        } else {
-            1.
-        };
+    let scaling = if cff_dict_known(cffont.topdict, b"FontMatrix\x00" as *const u8 as *const i8) {
+        1000i32 as f64
+            * cff_dict_get(
+                cffont.topdict,
+                b"FontMatrix\x00" as *const u8 as *const i8,
+                0i32,
+            )
+    } else {
+        1.
+    };
     let mut tmp_array = vec![];
     if num_glyphs as i32 <= 1i32 {
         /* This should be error. */
@@ -465,7 +464,7 @@ pub unsafe fn pdf_font_load_type1c(font: *mut pdf_font) -> i32 {
         && cff_dict_known(
             *cffont.private.offset(0),
             b"StdVW\x00" as *const u8 as *const i8,
-        ) != 0
+        )
     {
         let stemv = cff_dict_get(
             *cffont.private.offset(0),
@@ -481,8 +480,7 @@ pub unsafe fn pdf_font_load_type1c(font: *mut pdf_font) -> i32 {
         && cff_dict_known(
             *cffont.private.offset(0),
             b"defaultWidthX\x00" as *const u8 as *const i8,
-        ) != 0
-    {
+        ) {
         cff_dict_get(
             *cffont.private.offset(0),
             b"defaultWidthX\x00" as *const u8 as *const i8,
@@ -495,8 +493,7 @@ pub unsafe fn pdf_font_load_type1c(font: *mut pdf_font) -> i32 {
         && cff_dict_known(
             *cffont.private.offset(0),
             b"nominalWidthX\x00" as *const u8 as *const i8,
-        ) != 0
-    {
+        ) {
         cff_dict_get(
             *cffont.private.offset(0),
             b"nominalWidthX\x00" as *const u8 as *const i8,
@@ -771,7 +768,7 @@ pub unsafe fn pdf_font_load_type1c(font: *mut pdf_font) -> i32 {
     /*
      * Force existence of Encoding.
      */
-    if cff_dict_known(cffont.topdict, b"Encoding\x00" as *const u8 as *const i8) == 0 {
+    if !cff_dict_known(cffont.topdict, b"Encoding\x00" as *const u8 as *const i8) {
         cff_dict_add(
             cffont.topdict,
             b"Encoding\x00" as *const u8 as *const i8,

--- a/engine/src/xetex_pic.rs
+++ b/engine/src/xetex_pic.rs
@@ -188,7 +188,7 @@ unsafe extern "C" fn get_image_size_in_inches(
             &mut xdensity,
             &mut ydensity,
         )
-    } else if check_for_bmp(handle) != 0 {
+    } else if check_for_bmp(handle) {
         err = bmp_get_bbox(
             handle,
             &mut width_pix,
@@ -196,6 +196,8 @@ unsafe extern "C" fn get_image_size_in_inches(
             &mut xdensity,
             &mut ydensity,
         )
+        .map(|_| 0)
+        .unwrap_or(-1);
     } else if check_for_png(handle) != 0 {
         err = png_get_bbox(
             handle,


### PR DESCRIPTION
Rustify some fuction signatures by making the return types `Result` or `bool`.