### PR TITLE
Rustify pdfobj

### DIFF
--- a/dpx/src/dpx_dpxfile.rs
+++ b/dpx/src/dpx_dpxfile.rs
@@ -129,7 +129,7 @@ unsafe fn ensuresuffix(basename: *const i8, sfx: *const i8) -> *mut i8 {
 /* tmp freed here */
 /* Tectonic-enabled I/O alternatives */
 
-pub unsafe fn dpx_tt_open(
+pub(crate) unsafe fn dpx_tt_open(
     filename: &str,
     suffix: &str,
     format: TTInputFormat,
@@ -150,7 +150,7 @@ pub unsafe fn dpx_tt_open(
  *   dvipdfm  (text file)
  */
 
-pub unsafe fn dpx_open_type1_file(filename: &str) -> Option<InputHandleWrapper> {
+pub(crate) unsafe fn dpx_open_type1_file(filename: &str) -> Option<InputHandleWrapper> {
     let filename_ = CString::new(filename).unwrap();
     let filename = filename_.as_ptr();
     match ttstub_input_open(filename, TTInputFormat::TYPE1, 0) {
@@ -166,7 +166,7 @@ pub unsafe fn dpx_open_type1_file(filename: &str) -> Option<InputHandleWrapper> 
     }
 }
 
-pub unsafe fn dpx_open_truetype_file(filename: &str) -> Option<InputHandleWrapper> {
+pub(crate) unsafe fn dpx_open_truetype_file(filename: &str) -> Option<InputHandleWrapper> {
     let filename_ = CString::new(filename).unwrap();
     let filename = filename_.as_ptr();
     match ttstub_input_open(filename, TTInputFormat::TRUETYPE, 0) {
@@ -182,7 +182,7 @@ pub unsafe fn dpx_open_truetype_file(filename: &str) -> Option<InputHandleWrappe
     }
 }
 
-pub unsafe fn dpx_open_opentype_file(filename: &str) -> Option<InputHandleWrapper> {
+pub(crate) unsafe fn dpx_open_opentype_file(filename: &str) -> Option<InputHandleWrapper> {
     let filename_ = CString::new(filename).unwrap();
     let filename = filename_.as_ptr();
     let q = ensuresuffix(filename, b".otf\x00" as *const u8 as *const i8);
@@ -201,7 +201,7 @@ pub unsafe fn dpx_open_opentype_file(filename: &str) -> Option<InputHandleWrappe
     }
 }
 
-pub unsafe fn dpx_open_dfont_file(filename: &str) -> Option<InputHandleWrapper> {
+pub(crate) unsafe fn dpx_open_dfont_file(filename: &str) -> Option<InputHandleWrapper> {
     let q;
     if filename.len() > 6 && !filename.ends_with(".dfont") {
         // FIXME: we might want to invert this

--- a/dpx/src/dpx_pdfdoc.rs
+++ b/dpx/src/dpx_pdfdoc.rs
@@ -67,10 +67,9 @@ use super::dpx_pngimage::check_for_png;
 use crate::bridge::{ttstub_input_close, ttstub_input_open};
 use crate::dpx_pdfobj::{
     pdf_compare_reference, pdf_deref_obj, pdf_dict, pdf_file, pdf_file_get_catalog, pdf_link_obj,
-    pdf_obj, pdf_obj_typeof, pdf_out_flush, pdf_out_init, pdf_ref_obj, pdf_release_obj,
-    pdf_remove_dict, pdf_set_encrypt, pdf_set_id, pdf_set_info, pdf_set_root, pdf_stream,
-    pdf_stream_length, pdf_string, pdf_string_length, pdf_string_value, IntoObj, PdfObjType,
-    PushObj, STREAM_COMPRESS,
+    pdf_obj, pdf_out_flush, pdf_out_init, pdf_ref_obj, pdf_release_obj, pdf_remove_dict,
+    pdf_set_encrypt, pdf_set_id, pdf_set_info, pdf_set_root, pdf_stream, pdf_stream_length,
+    pdf_string, pdf_string_length, pdf_string_value, IntoObj, PdfObjType, PushObj, STREAM_COMPRESS,
 };
 use libc::{free, memcpy, strcmp, strcpy, strlen, strncmp, strncpy};
 
@@ -1583,7 +1582,7 @@ unsafe fn pdf_doc_add_goto(annot_dict: *mut pdf_obj) {
      */
     let subtype = pdf_deref_obj((*annot_dict).as_dict_mut().get_mut("Subtype"));
     if !subtype.is_null() {
-        if !subtype.is_null() && pdf_obj_typeof(subtype) == PdfObjType::UNDEFINED {
+        if !subtype.is_null() && (&*subtype).typ() == PdfObjType::UNDEFINED {
             return undefined(subtype, A, S, D);
         } else if !(!subtype.is_null() && (*subtype).is_name()) {
             return error(subtype, A, S, D);
@@ -1595,19 +1594,19 @@ unsafe fn pdf_doc_add_goto(annot_dict: *mut pdf_obj) {
     let mut dict = annot_dict;
     let mut key = "Dest";
     D = pdf_deref_obj((*annot_dict).as_dict_mut().get_mut(key));
-    if !D.is_null() && pdf_obj_typeof(D) == PdfObjType::UNDEFINED {
+    if !D.is_null() && (&*D).typ() == PdfObjType::UNDEFINED {
         return undefined(subtype, A, S, D);
     }
 
     A = pdf_deref_obj((*annot_dict).as_dict_mut().get_mut("A"));
     if !A.is_null() {
-        if !A.is_null() && pdf_obj_typeof(A) == PdfObjType::UNDEFINED {
+        if !A.is_null() && (&*A).typ() == PdfObjType::UNDEFINED {
             return undefined(subtype, A, S, D);
         } else if !D.is_null() || !(!A.is_null() && (*A).is_dict()) {
             return error(subtype, A, S, D);
         } else {
             S = pdf_deref_obj((*A).as_dict_mut().get_mut("S"));
-            if !S.is_null() && pdf_obj_typeof(S) == PdfObjType::UNDEFINED {
+            if !S.is_null() && (&*S).typ() == PdfObjType::UNDEFINED {
                 return undefined(subtype, A, S, D);
             } else if !(!S.is_null() && (*S).is_name()) {
                 return error(subtype, A, S, D);
@@ -1628,7 +1627,7 @@ unsafe fn pdf_doc_add_goto(annot_dict: *mut pdf_obj) {
         )
     } else if !D.is_null() && (*D).is_array() {
         return cleanup(subtype, A, S, D);
-    } else if !D.is_null() && pdf_obj_typeof(D) == PdfObjType::UNDEFINED {
+    } else if !D.is_null() && (&*D).typ() == PdfObjType::UNDEFINED {
         return undefined(subtype, A, S, D);
     } else {
         return error(subtype, A, S, D);

--- a/dpx/src/dpx_pdfencoding.rs
+++ b/dpx/src/dpx_pdfencoding.rs
@@ -435,7 +435,7 @@ pub(crate) unsafe fn pdf_close_encodings() {
     enc_cache.clear();
 }
 
-pub unsafe fn pdf_encoding_findresource(enc_name: &str) -> i32 {
+pub(crate) unsafe fn pdf_encoding_findresource(enc_name: &str) -> i32 {
     for (enc_id, encoding) in enc_cache.iter().enumerate() {
         if enc_name == encoding.ident {
             return enc_id as i32;

--- a/dpx/src/dpx_pdffont.rs
+++ b/dpx/src/dpx_pdffont.rs
@@ -63,22 +63,22 @@ use libc::{free, memset, rand, srand};
 /* Options */
 use super::dpx_fontmap::fontmap_rec;
 #[derive(Clone)]
-pub struct pdf_font {
-    pub ident: String,
-    pub subtype: i32,
-    pub map_name: String,
-    pub encoding_id: i32,
-    pub font_id: i32,
-    pub index: i32,
-    pub fontname: String,
-    pub uniqueID: String,
-    pub reference: *mut pdf_obj,
-    pub resource: *mut pdf_obj,
-    pub descriptor: *mut pdf_obj,
-    pub usedchars: *mut i8,
-    pub flags: i32,
-    pub point_size: f64,
-    pub design_size: f64,
+pub(crate) struct pdf_font {
+    pub(crate) ident: String,
+    pub(crate) subtype: i32,
+    pub(crate) map_name: String,
+    pub(crate) encoding_id: i32,
+    pub(crate) font_id: i32,
+    pub(crate) index: i32,
+    pub(crate) fontname: String,
+    pub(crate) uniqueID: String,
+    pub(crate) reference: *mut pdf_obj,
+    pub(crate) resource: *mut pdf_obj,
+    pub(crate) descriptor: *mut pdf_obj,
+    pub(crate) usedchars: *mut i8,
+    pub(crate) flags: i32,
+    pub(crate) point_size: f64,
+    pub(crate) design_size: f64,
     /* _PDFFONT_H_ */
 }
 
@@ -161,7 +161,7 @@ pub(crate) unsafe fn pdf_font_set_deterministic_unique_tags(value: i32) {
     unique_tags_deterministic = value;
 }
 
-pub unsafe fn pdf_font_make_uniqueTag() -> String {
+pub(crate) unsafe fn pdf_font_make_uniqueTag() -> String {
     if unique_tags_deterministic != 0 {
         let tag_str = format!("{:06}", unique_tag_state);
         unique_tag_state += 1;
@@ -259,7 +259,7 @@ unsafe fn pdf_clean_font_struct(mut font: &mut pdf_font) {
 }
 static mut font_cache: Vec<pdf_font> = Vec::new();
 
-pub unsafe fn pdf_init_fonts() {
+pub(crate) unsafe fn pdf_init_fonts() {
     agl_init_map();
     CMap_cache_init();
     pdf_init_encodings();
@@ -267,7 +267,7 @@ pub unsafe fn pdf_init_fonts() {
     font_cache.clear();
 }
 
-pub unsafe fn pdf_get_font_reference(font_id: i32) -> *mut pdf_obj {
+pub(crate) unsafe fn pdf_get_font_reference(font_id: i32) -> *mut pdf_obj {
     if font_id < 0i32 || font_id >= font_cache.len() as _ {
         panic!("Invalid font ID: {}", font_id);
     }
@@ -283,7 +283,7 @@ pub unsafe fn pdf_get_font_reference(font_id: i32) -> *mut pdf_obj {
     pdf_link_obj(font.reference)
 }
 
-pub unsafe fn pdf_get_font_usedchars(font_id: i32) -> *mut i8 {
+pub(crate) unsafe fn pdf_get_font_usedchars(font_id: i32) -> *mut i8 {
     if font_id < 0i32 || font_id >= font_cache.len() as _ {
         panic!("Invalid font ID: {}", font_id);
     }
@@ -305,7 +305,7 @@ pub unsafe fn pdf_get_font_usedchars(font_id: i32) -> *mut i8 {
     };
 }
 
-pub unsafe fn pdf_get_font_wmode(font_id: i32) -> i32 {
+pub(crate) unsafe fn pdf_get_font_wmode(font_id: i32) -> i32 {
     if font_id < 0i32 || font_id >= font_cache.len() as i32 {
         panic!("Invalid font ID: {}", font_id);
     }
@@ -318,7 +318,7 @@ pub unsafe fn pdf_get_font_wmode(font_id: i32) -> i32 {
     };
 }
 
-pub unsafe fn pdf_get_font_subtype(font_id: i32) -> i32 {
+pub(crate) unsafe fn pdf_get_font_subtype(font_id: i32) -> i32 {
     if font_id < 0i32 || font_id >= font_cache.len() as i32 {
         panic!("Invalid font ID: {}", font_id);
     }
@@ -326,7 +326,7 @@ pub unsafe fn pdf_get_font_subtype(font_id: i32) -> i32 {
     font.subtype
 }
 
-pub unsafe fn pdf_get_font_encoding(font_id: i32) -> i32 {
+pub(crate) unsafe fn pdf_get_font_encoding(font_id: i32) -> i32 {
     if font_id < 0i32 || font_id >= font_cache.len() as i32 {
         panic!("Invalid font ID: {}", font_id);
     }
@@ -707,7 +707,7 @@ pub(crate) unsafe fn pdf_font_findresource(
     font_id
 }
 
-pub unsafe fn pdf_font_is_in_use(font: &mut pdf_font) -> bool {
+pub(crate) unsafe fn pdf_font_is_in_use(font: &mut pdf_font) -> bool {
     return if !font.reference.is_null() {
         1i32
     } else {
@@ -715,11 +715,11 @@ pub unsafe fn pdf_font_is_in_use(font: &mut pdf_font) -> bool {
     } != 0;
 }
 
-pub unsafe fn pdf_font_get_index(font: &mut pdf_font) -> i32 {
+pub(crate) unsafe fn pdf_font_get_index(font: &mut pdf_font) -> i32 {
     font.index
 }
 
-pub unsafe fn pdf_font_get_resource(font: &mut pdf_font) -> &mut pdf_obj {
+pub(crate) unsafe fn pdf_font_get_resource(font: &mut pdf_font) -> &mut pdf_obj {
     if font.resource.is_null() {
         font.resource = pdf_dict::new().into_obj();
         (*font.resource).as_dict_mut().set("Type", "Font");
@@ -739,7 +739,7 @@ pub unsafe fn pdf_font_get_resource(font: &mut pdf_font) -> &mut pdf_obj {
     &mut *font.resource
 }
 
-pub unsafe fn pdf_font_get_descriptor(font: &mut pdf_font) -> *mut pdf_obj {
+pub(crate) unsafe fn pdf_font_get_descriptor(font: &mut pdf_font) -> *mut pdf_obj {
     if font.descriptor.is_null() {
         font.descriptor = pdf_dict::new().into_obj();
         (*font.descriptor)
@@ -749,19 +749,19 @@ pub unsafe fn pdf_font_get_descriptor(font: &mut pdf_font) -> *mut pdf_obj {
     font.descriptor
 }
 
-pub unsafe fn pdf_font_get_usedchars(font: &mut pdf_font) -> *mut i8 {
+pub(crate) unsafe fn pdf_font_get_usedchars(font: &mut pdf_font) -> *mut i8 {
     font.usedchars
 }
 
-pub unsafe fn pdf_font_get_encoding(font: &pdf_font) -> i32 {
+pub(crate) unsafe fn pdf_font_get_encoding(font: &pdf_font) -> i32 {
     font.encoding_id
 }
 
-pub unsafe fn pdf_font_get_flag(font: &mut pdf_font, mask: i32) -> i32 {
+pub(crate) unsafe fn pdf_font_get_flag(font: &mut pdf_font, mask: i32) -> i32 {
     return if font.flags & mask != 0 { 1i32 } else { 0i32 };
 }
 
-pub unsafe fn pdf_font_get_param(font: &mut pdf_font, param_type: i32) -> f64 {
+pub(crate) unsafe fn pdf_font_get_param(font: &mut pdf_font, param_type: i32) -> f64 {
     let mut param: f64 = 0.0f64;
     match param_type {
         1 => param = font.design_size,
@@ -771,14 +771,14 @@ pub unsafe fn pdf_font_get_param(font: &mut pdf_font, param_type: i32) -> f64 {
     param
 }
 
-pub unsafe fn pdf_font_get_uniqueTag(font: &mut pdf_font) -> String {
+pub(crate) unsafe fn pdf_font_get_uniqueTag(font: &mut pdf_font) -> String {
     if font.uniqueID == "" {
         font.uniqueID = pdf_font_make_uniqueTag();
     }
     font.uniqueID.clone()
 }
 
-pub unsafe fn pdf_font_set_subtype(mut font: &mut pdf_font, subtype: i32) -> i32 {
+pub(crate) unsafe fn pdf_font_set_subtype(mut font: &mut pdf_font, subtype: i32) -> i32 {
     font.subtype = subtype;
     0i32
 }
@@ -791,7 +791,7 @@ pub unsafe fn pdf_font_set_subtype(mut font: &mut pdf_font, subtype: i32) -> i32
 /* Each font drivers use the followings. */
 /* without unique tag */
 
-pub unsafe fn pdf_font_set_flags(mut font: &mut pdf_font, flags: i32) -> i32 {
+pub(crate) unsafe fn pdf_font_set_flags(mut font: &mut pdf_font, flags: i32) -> i32 {
     font.flags |= flags;
     0i32
 }

--- a/dpx/src/dpx_pdfresource.rs
+++ b/dpx/src/dpx_pdfresource.rs
@@ -175,7 +175,7 @@ unsafe fn get_category(category: *const i8) -> i32 {
     -1i32
 }
 
-pub unsafe fn pdf_defineresource(
+pub(crate) unsafe fn pdf_defineresource(
     category: &str,
     resname: &str,
     object: *mut pdf_obj,
@@ -243,7 +243,7 @@ pub unsafe fn pdf_defineresource(
     cat_id << 16i32 | res_id
 }
 
-pub unsafe fn pdf_findresource(category: &str, resname: &str) -> i32 {
+pub(crate) unsafe fn pdf_findresource(category: &str, resname: &str) -> i32 {
     let category_ = CString::new(category).unwrap();
     let resname_ = CString::new(resname).unwrap();
     let cat_id = get_category(category_.as_ptr());

--- a/dpx/src/dpx_pkfont.rs
+++ b/dpx/src/dpx_pkfont.rs
@@ -109,7 +109,7 @@ unsafe fn dpx_open_pk_font_at(_ident: *const i8, _dpi: u32) -> *mut FILE {
     fp
 }
 
-pub unsafe fn pdf_font_open_pkfont(font: &mut pdf_font) -> i32 {
+pub(crate) unsafe fn pdf_font_open_pkfont(font: &mut pdf_font) -> i32 {
     let point_size = pdf_font_get_param(font, 2i32);
     let encoding_id = pdf_font_get_encoding(font);
     let ident = &*font.ident;
@@ -565,7 +565,7 @@ unsafe fn create_pk_CharProc_stream(
     stream
 }
 
-pub unsafe fn pdf_font_load_pkfont(font: &mut pdf_font) -> i32 {
+pub(crate) unsafe fn pdf_font_load_pkfont(font: &mut pdf_font) -> i32 {
     let mut widths: [f64; 256] = [0.; 256];
     let mut charavail: [i8; 256] = [0; 256];
     /* ENABLE_GLYPHENC */

--- a/dpx/src/dpx_subfont.rs
+++ b/dpx/src/dpx_subfont.rs
@@ -372,7 +372,7 @@ unsafe fn find_sfd_file(sfd_name: &str) -> i32 {
     id
 }
 
-pub unsafe fn sfd_get_subfont_ids(sfd_name: &str, num_ids: *mut i32) -> *mut *mut i8 {
+pub(crate) unsafe fn sfd_get_subfont_ids(sfd_name: &str, num_ids: *mut i32) -> *mut *mut i8 {
     if sfd_name.is_empty() {
         return 0 as *mut *mut i8;
     }
@@ -389,7 +389,7 @@ pub unsafe fn sfd_get_subfont_ids(sfd_name: &str, num_ids: *mut i32) -> *mut *mu
  * Mapping tables are actually read here.
  */
 
-pub unsafe fn sfd_load_record(sfd_name: &str, subfont_id: &str) -> i32 {
+pub(crate) unsafe fn sfd_load_record(sfd_name: &str, subfont_id: &str) -> i32 {
     let mut rec_id: i32 = -1i32;
     if sfd_name.is_empty() || subfont_id.is_empty() {
         return -1i32;

--- a/dpx/src/dpx_type1c.rs
+++ b/dpx/src/dpx_type1c.rs
@@ -131,7 +131,7 @@ use super::dpx_cs_type2::cs_ginfo;
  */
 /* Font info. from OpenType tables */
 
-pub unsafe fn pdf_font_open_type1c(font: &mut pdf_font) -> i32 {
+pub(crate) unsafe fn pdf_font_open_type1c(font: &mut pdf_font) -> i32 {
     let ident = &*(&*font).ident;
     let encoding_id = pdf_font_get_encoding(font);
     let handle = dpx_open_opentype_file(ident);
@@ -285,7 +285,7 @@ unsafe fn add_SimpleMetrics(
     fontdict.set("LastChar", lastchar as f64);
 }
 
-pub unsafe fn pdf_font_load_type1c(font: &mut pdf_font) -> i32 {
+pub(crate) unsafe fn pdf_font_load_type1c(font: &mut pdf_font) -> i32 {
     let mut offset: i32 = 0i32;
     let mut ginfo = cs_ginfo::new();
     let mut widths: [f64; 256] = [0.; 256];

--- a/dpx/src/specials/pdfm.rs
+++ b/dpx/src/specials/pdfm.rs
@@ -63,8 +63,8 @@ use crate::dpx_pdfdoc::{
 };
 use crate::dpx_pdfdraw::{pdf_dev_concat, pdf_dev_grestore, pdf_dev_gsave, pdf_dev_transform};
 use crate::dpx_pdfobj::{
-    pdf_dict, pdf_link_obj, pdf_name, pdf_obj, pdf_obj_typeof, pdf_release_obj, pdf_remove_dict,
-    pdf_stream, pdf_string, pdf_string_value, IntoObj, PdfObjType, STREAM_COMPRESS,
+    pdf_dict, pdf_link_obj, pdf_name, pdf_obj, pdf_release_obj, pdf_remove_dict, pdf_stream,
+    pdf_string, pdf_string_value, IntoObj, PdfObjVariant, STREAM_COMPRESS,
 };
 use crate::dpx_pdfparse::{ParseIdent, ParsePdfObj, SkipWhite};
 use crate::dpx_pdfximage::{pdf_ximage_findresource, pdf_ximage_get_reference};
@@ -305,8 +305,8 @@ unsafe fn spc_handler_pdfm_put(spe: *mut spc_env, ap: *mut spc_arg) -> i32 {
         return -1i32;
     }
     let obj2 = obj2.unwrap();
-    match pdf_obj_typeof(obj1) {
-        PdfObjType::DICT => {
+    match (*obj1).data {
+        PdfObjVariant::DICT(..) => {
             if !(*obj2).is_dict() {
                 spc_warn!(
                     spe,
@@ -330,12 +330,9 @@ unsafe fn spc_handler_pdfm_put(spe: *mut spc_env, ap: *mut spc_arg) -> i32 {
                 (*obj1).as_dict_mut().merge((*obj2).as_dict());
             }
         }
-        PdfObjType::STREAM => {
+        PdfObjVariant::STREAM(obj1) => {
             if (*obj2).is_dict() {
-                (*obj1)
-                    .as_stream_mut()
-                    .get_dict_mut()
-                    .merge((*obj2).as_dict());
+                (*obj1).get_dict_mut().merge((*obj2).as_dict());
             } else if (*obj2).is_stream() {
                 spc_warn!(
                     spe,
@@ -352,12 +349,12 @@ unsafe fn spc_handler_pdfm_put(spe: *mut spc_env, ap: *mut spc_arg) -> i32 {
                 error = -1i32
             }
         }
-        PdfObjType::ARRAY => {
+        PdfObjVariant::ARRAY(obj1) => {
             /* dvipdfm */
-            (*obj1).as_array_mut().push(pdf_link_obj(obj2));
+            (*obj1).push(pdf_link_obj(obj2));
             while !(*ap).cur.is_empty() {
                 if let Some(obj3) = (*ap).cur.parse_pdf_object(ptr::null_mut()) {
-                    (*obj1).as_array_mut().push(obj3);
+                    (*obj1).push(obj3);
                     (*ap).cur.skip_white();
                 } else {
                     break;
@@ -380,12 +377,12 @@ unsafe fn spc_handler_pdfm_put(spe: *mut spc_env, ap: *mut spc_arg) -> i32 {
  * This feature is provided for convenience. TeX can't do
  * input encoding conversion.
  */
-unsafe fn reencodestring(cmap: *mut CMap, instring: *mut pdf_obj) -> i32 {
+unsafe fn reencodestring(cmap: *mut CMap, instring: *mut pdf_string) -> i32 {
     let mut wbuf: [u8; 4096] = [0; 4096];
     if cmap.is_null() || instring.is_null() {
         return 0i32;
     }
-    let slice = (*instring).as_string_mut().to_bytes();
+    let slice = (*instring).to_bytes();
     let mut inbufleft = slice.len() as size_t;
     let mut inbufcur = slice.as_ptr() as *const u8;
     wbuf[0] = 0xfe_u8;
@@ -402,19 +399,17 @@ unsafe fn reencodestring(cmap: *mut CMap, instring: *mut pdf_obj) -> i32 {
     if inbufleft > 0 {
         return -1i32;
     }
-    (*instring)
-        .as_string_mut()
-        .set(&wbuf[..(4096_usize - obufleft as usize)]);
+    (*instring).set(&wbuf[..(4096_usize - obufleft as usize)]);
     0i32
 }
-unsafe fn maybe_reencode_utf8(instring: *mut pdf_obj) -> i32 {
+unsafe fn maybe_reencode_utf8(instring: *mut pdf_string) -> i32 {
     let mut non_ascii: i32 = 0i32;
     let mut cp: *const u8;
     let mut wbuf: [u8; 4096] = [0; 4096];
     if instring.is_null() {
         return 0i32;
     }
-    let slice = (*instring).as_string_mut().as_mut_slice();
+    let slice = (*instring).as_mut_slice();
     let inlen = slice.len() as i32;
     let inbuf = slice.as_mut_ptr() as *mut u8;
     /* check if the input string is strictly ASCII */
@@ -462,7 +457,6 @@ unsafe fn maybe_reencode_utf8(instring: *mut pdf_obj) -> i32 {
         }
     }
     (*instring)
-        .as_string_mut()
         .set(&wbuf[..(op.wrapping_offset_from(wbuf.as_ptr()) as usize)]);
     0i32
 }
@@ -493,11 +487,11 @@ unsafe fn needreencode(kp: &pdf_name, vp: &pdf_string, cd: *mut tounicode) -> i3
 unsafe fn modstrings(kp: &pdf_name, vp: *mut pdf_obj, dp: *mut libc::c_void) -> i32 {
     let mut r: i32 = 0i32;
     let cd: *mut tounicode = dp as *mut tounicode;
-    match pdf_obj_typeof(vp) {
-        PdfObjType::STRING => {
+    match (*vp).data {
+        PdfObjVariant::STRING(vp) => {
             if !cd.is_null() && (*cd).cmap_id >= 0i32 && !(*cd).taintkeys.is_null() {
                 let cmap: *mut CMap = CMap_cache_get((*cd).cmap_id);
-                if needreencode(kp, (*vp).as_string(), cd) != 0 {
+                if needreencode(kp, &*vp, cd) != 0 {
                     r = reencodestring(cmap, vp)
                 }
             } else if is_xdv != 0 && !cd.is_null() && !(*cd).taintkeys.is_null() {
@@ -505,7 +499,7 @@ unsafe fn modstrings(kp: &pdf_name, vp: *mut pdf_obj, dp: *mut libc::c_void) -> 
                  * needreencode() is assumed to do a simple check if given string
                  * object is actually a text string.
                  */
-                if needreencode(kp, (*vp).as_string(), cd) != 0 {
+                if needreencode(kp, &*vp, cd) != 0 {
                     r = maybe_reencode_utf8(vp)
                 }
             }
@@ -514,8 +508,8 @@ unsafe fn modstrings(kp: &pdf_name, vp: *mut pdf_obj, dp: *mut libc::c_void) -> 
                 warn!("Failed to convert input string to UTF16...");
             }
         }
-        PdfObjType::DICT => {
-            r = (*vp).as_dict_mut().foreach(
+        PdfObjVariant::DICT(vp) => {
+            r = (*vp).foreach(
                 Some(
                     modstrings
                         as unsafe fn(_: &pdf_name, _: *mut pdf_obj, _: *mut libc::c_void) -> i32,
@@ -523,8 +517,8 @@ unsafe fn modstrings(kp: &pdf_name, vp: *mut pdf_obj, dp: *mut libc::c_void) -> 
                 dp,
             )
         }
-        PdfObjType::STREAM => {
-            r = (*vp).as_stream_mut().get_dict_mut().foreach(
+        PdfObjVariant::STREAM(vp) => {
+            r = (*vp).get_dict_mut().foreach(
                 Some(
                     modstrings
                         as unsafe fn(_: &pdf_name, _: *mut pdf_obj, _: *mut libc::c_void) -> i32,

--- a/dpx/src/specials/pdfm.rs
+++ b/dpx/src/specials/pdfm.rs
@@ -257,10 +257,8 @@ unsafe fn safeputresdict(kp: &pdf_name, vp: *mut pdf_obj, dp: *mut libc::c_void)
     } else if (*vp).is_dict() {
         if let Some(dict) = dict {
             (*vp).as_dict_mut().foreach(
-                Some(
-                    safeputresdent
-                        as unsafe fn(_: &pdf_name, _: *mut pdf_obj, _: *mut libc::c_void) -> i32,
-                ),
+                safeputresdent
+                    as unsafe fn(_: &pdf_name, _: *mut pdf_obj, _: *mut libc::c_void) -> i32,
                 dict as *mut pdf_obj as *mut libc::c_void,
             );
         } else {
@@ -316,14 +314,8 @@ unsafe fn spc_handler_pdfm_put(spe: *mut spc_env, ap: *mut spc_arg) -> i32 {
                 error = -1i32
             } else if ident.to_bytes() == b"resources" {
                 error = (*obj2).as_dict_mut().foreach(
-                    Some(
-                        safeputresdict
-                            as unsafe fn(
-                                _: &pdf_name,
-                                _: *mut pdf_obj,
-                                _: *mut libc::c_void,
-                            ) -> i32,
-                    ),
+                    safeputresdict
+                        as unsafe fn(_: &pdf_name, _: *mut pdf_obj, _: *mut libc::c_void) -> i32,
                     obj1 as *mut libc::c_void,
                 )
             } else {
@@ -456,8 +448,7 @@ unsafe fn maybe_reencode_utf8(instring: *mut pdf_string) -> i32 {
             return -1i32;
         }
     }
-    (*instring)
-        .set(&wbuf[..(op.wrapping_offset_from(wbuf.as_ptr()) as usize)]);
+    (*instring).set(&wbuf[..(op.wrapping_offset_from(wbuf.as_ptr()) as usize)]);
     0i32
 }
 /* The purpose of this routine is to check if given string object is
@@ -510,19 +501,13 @@ unsafe fn modstrings(kp: &pdf_name, vp: *mut pdf_obj, dp: *mut libc::c_void) -> 
         }
         PdfObjVariant::DICT(vp) => {
             r = (*vp).foreach(
-                Some(
-                    modstrings
-                        as unsafe fn(_: &pdf_name, _: *mut pdf_obj, _: *mut libc::c_void) -> i32,
-                ),
+                modstrings as unsafe fn(_: &pdf_name, _: *mut pdf_obj, _: *mut libc::c_void) -> i32,
                 dp,
             )
         }
         PdfObjVariant::STREAM(vp) => {
             r = (*vp).get_dict_mut().foreach(
-                Some(
-                    modstrings
-                        as unsafe fn(_: &pdf_name, _: *mut pdf_obj, _: *mut libc::c_void) -> i32,
-                ),
+                modstrings as unsafe fn(_: &pdf_name, _: *mut pdf_obj, _: *mut libc::c_void) -> i32,
                 dp,
             )
         }
@@ -550,14 +535,8 @@ impl ParsePdfDictU for &[u8] {
         if let Some(d) = dict {
             unsafe {
                 (*d).as_dict_mut().foreach(
-                    Some(
-                        modstrings
-                            as unsafe fn(
-                                _: &pdf_name,
-                                _: *mut pdf_obj,
-                                _: *mut libc::c_void,
-                            ) -> i32,
-                    ),
+                    modstrings
+                        as unsafe fn(_: &pdf_name, _: *mut pdf_obj, _: *mut libc::c_void) -> i32,
                     cd as *mut libc::c_void,
                 );
             }

--- a/dpx/src/specials/tpic.rs
+++ b/dpx/src/specials/tpic.rs
@@ -19,10 +19,7 @@
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
 */
-#![allow(
-    non_camel_case_types,
-    non_snake_case,
-)]
+#![allow(non_camel_case_types, non_snake_case)]
 
 use crate::bridge::DisplayExt;
 use crate::warn;
@@ -679,10 +676,8 @@ unsafe fn spc_handler_tpic__setopts(spe: *mut spc_env, ap: *mut spc_arg) -> i32 
     let mut tp: *mut spc_tpic_ = &mut _TPIC_STATE;
     if let Some(mut dict) = spc_parse_kvpairs(ap) {
         let error = dict.foreach(
-            Some(
-                tpic_filter_getopts
-                    as unsafe fn(_: &pdf_name, _: *mut pdf_obj, _: *mut libc::c_void) -> i32,
-            ),
+            tpic_filter_getopts
+                as unsafe fn(_: &pdf_name, _: *mut pdf_obj, _: *mut libc::c_void) -> i32,
             tp as *mut libc::c_void,
         );
         if error == 0 {


### PR DESCRIPTION
This removes the scary `*mut void as *mut pdf_...` casts by introducing a `PdfObjVariant` enum that holds the `pdf_obj` data.