### PR TITLE
replace `FILE*`s with `InputHandleWrapper`s

### DIFF
--- a/bridge/src/lib.rs
+++ b/bridge/src/lib.rs
@@ -60,6 +60,10 @@ impl InputHandleWrapper {
     pub fn as_ptr(&self) -> rust_input_handle_t {
         self.0.as_ptr()
     }
+
+    pub fn close(self) {
+        unsafe { ttstub_input_close(self) }
+    }
 }
 
 impl Read for InputHandleWrapper {
@@ -147,6 +151,7 @@ pub enum TTHistory {
 #[repr(C)]
 #[derive(Clone, Copy, PartialEq)]
 pub enum TTInputFormat {
+    PK = 1,
     TFM = 3,
     AFM = 4,
     BIB = 6,
@@ -394,7 +399,7 @@ pub unsafe fn ttstub_input_ungetc(handle: &mut InputHandleWrapper, mut ch: i32) 
     )
 }
 
-pub unsafe fn ttstub_input_close(mut handle: InputHandleWrapper) -> i32 {
+pub unsafe fn ttstub_input_close(mut handle: InputHandleWrapper) {
     if (*tectonic_global_bridge)
         .input_close
         .expect("non-null function pointer")(
@@ -404,7 +409,6 @@ pub unsafe fn ttstub_input_close(mut handle: InputHandleWrapper) -> i32 {
         // Nonzero return value indicates a serious internal error.
         panic!("ttstub_input_close");
     }
-    0i32
 }
 
 /* TODO: these are needed for the various *_main routines which should

--- a/dpx/src/dpx_fontmap.rs
+++ b/dpx/src/dpx_fontmap.rs
@@ -123,16 +123,6 @@ pub(crate) unsafe fn pdf_init_fontmap_record() -> fontmap_rec {
     }
 }
 
-/* strdup: just returns NULL for NULL */
-unsafe fn mstrdup(s: *const i8) -> *mut i8 {
-    if s.is_null() {
-        return ptr::null_mut();
-    }
-    let r =
-        new((strlen(s).wrapping_add(1)).wrapping_mul(::std::mem::size_of::<i8>()) as _) as *mut i8;
-    strcpy(r, s);
-    r
-}
 unsafe fn pdf_copy_fontmap_record(src: *const fontmap_rec) -> fontmap_rec {
     assert!(!src.is_null());
     fontmap_rec {

--- a/dpx/src/dpx_mfileio.rs
+++ b/dpx/src/dpx_mfileio.rs
@@ -30,43 +30,9 @@ use crate::bridge::{ttstub_input_getc, ttstub_input_ungetc};
 
 use std::ptr;
 
-use libc::{fseek, ftell, rewind, FILE};
-pub(crate) type __off_t = i64;
-pub(crate) type __off64_t = i64;
 use bridge::InputHandleWrapper;
-unsafe fn os_error() {
-    panic!("io:  An OS command failed that should not have.\n");
-}
 
-pub(crate) unsafe fn seek_relative(file: *mut FILE, pos: i32) {
-    if fseek(file, pos as _, 1i32) != 0 {
-        os_error();
-    };
-}
-unsafe fn seek_end(file: *mut FILE) {
-    if fseek(file, 0, 2i32) != 0 {
-        os_error();
-    };
-}
-unsafe fn tell_position(file: *mut FILE) -> i32 {
-    let size = ftell(file);
-    if size < 0 {
-        os_error();
-    }
-    if size as i64 > 0x7fffffffi32 as i64 {
-        panic!("ftell: file size {} exceeds 0x7fffffff.\n", size);
-    }
-    size as i32
-}
-
-pub(crate) unsafe fn file_size(file: *mut FILE) -> i32 {
-    seek_end(file);
-    let size = tell_position(file);
-    rewind(file);
-    size
-}
 /* Note: this is really just a random array used in other files. */
-
 pub(crate) static mut work_buffer: [i8; 1024] = [0; 1024];
 pub(crate) static mut work_buffer_u8: [u8; 1024] = [0; 1024];
 /* Tectonic-enabled versions */

--- a/engine/src/bibtex.rs
+++ b/engine/src/bibtex.rs
@@ -19,8 +19,6 @@ use libc::{free, strcpy, strlen};
 use std::panic;
 use std::ptr;
 
-use bridge::size_t;
-
 use bridge::{TTHistory, TTInputFormat};
 
 use bridge::{InputHandleWrapper, OutputHandleWrapper};
@@ -86,12 +84,9 @@ unsafe fn peekable_open(
         saw_eof: false,
     })
 }
-unsafe fn peekable_close(peekable: Option<peekable_input_t>) -> i32 {
-    let mut _rv: i32 = 0;
+unsafe fn peekable_close(peekable: Option<peekable_input_t>) {
     if let Some(peekable_input_t { handle, .. }) = peekable {
         ttstub_input_close(handle)
-    } else {
-        return 0;
     }
 }
 unsafe fn peekable_getc(peekable: &mut peekable_input_t) -> i32 {

--- a/tests/cached_itarbundle.rs
+++ b/tests/cached_itarbundle.rs
@@ -274,7 +274,7 @@ fn test_full_session() {
             sess_builder.format_cache_path(tempdir.path());
 
             let mut sess = sess_builder.create(&mut status).unwrap();
-            sess.run(&mut status).unwrap();
+            sess.run(&mut status).expect("failed to run session");
         };
 
         // Run tectonic twice


### PR DESCRIPTION
Note: these codepaths are currently all unreachable (?)
because `dpx_open_pk_font_at` has been stubbed to return None.