### PR TITLE
remode decode_utf16 on BUFFER

### DIFF
--- a/engine/src/xetex_xetex0.rs
+++ b/engine/src/xetex_xetex0.rs
@@ -3773,16 +3773,6 @@ pub(crate) unsafe fn get_next(input: &mut input_state_t) -> (Cmd, i32, i32) {
                 if input.loc <= input.limit {
                     let mut chr = BUFFER[input.loc as usize];
                     input.loc += 1;
-                    if chr >= 0xd800
-                        && chr < 0xdc00
-                        && input.loc <= input.limit
-                        && BUFFER[input.loc as usize] >= 0xdc00
-                        && BUFFER[input.loc as usize] < 0xe000
-                    {
-                        let lower = (BUFFER[input.loc as usize] - 0xdc00) as UTF16_code;
-                        input.loc += 1;
-                        chr = (0x1_0000 + ((chr - 0xd800) * 1024) as i64 + lower as i64) as i32
-                    }
                     'c_65186: loop {
                         ochr = Some(chr);
                         let cmd = Cmd::from(*CAT_CODE(chr as usize) as u16);


### PR DESCRIPTION
cc @pkgw  @crlf0710  @Mrmaxmeier 

I want to discuss with you this part of code.
There is an attempt to convert UTF16 to UTF32 (char).
But `BUFFER` must be array of UTF32 chars. Not UTF16.
So I think this conversion is unneeded and incorrect.

Correct me if I'm wrong.