### PR TITLE
perf: lazily construct panic message in Cmd::from

### DIFF
--- a/dpx/src/dpx_pdfobj.rs
+++ b/dpx/src/dpx_pdfobj.rs
@@ -2000,7 +2000,6 @@ impl pdf_stream {
     }
 }
 
-
 #[cfg(feature = "libz-sys")]
 mod flate2_libz_helpers {
     // Workaround for https://github.com/rust-lang/libz-sys/issues/55
@@ -2008,7 +2007,7 @@ mod flate2_libz_helpers {
     use libc::c_void;
     use std::{
         alloc::{self, Layout},
-        ptr
+        ptr,
     };
 
     const ALIGN: usize = std::mem::align_of::<usize>();

--- a/engine/src/xetex_consts/cmd.rs
+++ b/engine/src/xetex_consts/cmd.rs
@@ -129,7 +129,7 @@ pub(crate) enum Cmd {
 
 impl From<u16> for Cmd {
     fn from(n: u16) -> Self {
-        Self::n(n as u8).expect(&format!("incorrect command = {}", n))
+        Self::n(n as u8).unwrap_or_else(|| panic!("incorrect command = {}", n))
     }
 }
 


### PR DESCRIPTION
This speeds up the longest `tectonic-on-arXiv` test by 2.25x. The oxidized branch is still quite a bit slower than master though.