### PR TITLE
perf improvements

### DIFF
--- a/bridge/src/lib.rs
+++ b/bridge/src/lib.rs
@@ -120,7 +120,11 @@ impl InFile {
 impl Read for InFile {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         unsafe {
-            let res = ttstub_input_read_rust_style(self.0.as_ptr(), buf.as_mut_ptr() as *mut i8, buf.len());
+            let res = ttstub_input_read_rust_style(
+                self.0.as_ptr(),
+                buf.as_mut_ptr() as *mut i8,
+                buf.len(),
+            );
             res.ok_or_else(|| std::io::ErrorKind::UnexpectedEof.into())
         }
     }
@@ -129,7 +133,11 @@ impl Read for InFile {
 impl Read for &InFile {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         unsafe {
-            let res = ttstub_input_read_rust_style(self.0.as_ptr(), buf.as_mut_ptr() as *mut i8, buf.len());
+            let res = ttstub_input_read_rust_style(
+                self.0.as_ptr(),
+                buf.as_mut_ptr() as *mut i8,
+                buf.len(),
+            );
             res.ok_or_else(|| std::io::ErrorKind::UnexpectedEof.into())
         }
     }
@@ -198,7 +206,12 @@ pub struct tt_bridge_api_t {
         ) -> size_t,
     >,
     pub input_read: Option<
-        unsafe fn(_: *mut libc::c_void, _: rust_input_handle_t, _: *mut i8, _: size_t) -> Option<usize>,
+        unsafe fn(
+            _: *mut libc::c_void,
+            _: rust_input_handle_t,
+            _: *mut i8,
+            _: size_t,
+        ) -> Option<usize>,
     >,
     pub input_close: Option<unsafe fn(_: *mut libc::c_void, _: rust_input_handle_t) -> i32>,
 }

--- a/dpx/src/dpx_dvipdfmx.rs
+++ b/dpx/src/dpx_dvipdfmx.rs
@@ -127,7 +127,7 @@ unsafe fn select_paper(paperspec_str: &str) {
         let comma = paperspec
             .iter()
             .position(|&x| x == b',')
-            .expect(&format!("Unrecognized paper format: {}", paperspec_str,));
+            .unwrap_or_else(|| panic!("Unrecognized paper format: {}", paperspec_str));
         if let (Ok(width), Ok(height)) = (
             (&paperspec[..comma]).read_length_no_mag(),
             (&paperspec[comma + 1..]).read_length_no_mag(),

--- a/dpx/src/dpx_fontmap.rs
+++ b/dpx/src/dpx_fontmap.rs
@@ -818,7 +818,9 @@ pub(crate) unsafe fn pdf_load_fontmap_file(filename: &str, mode: i32) -> i32 {
     loop {
         lpos += 1;
         line.clear();
-        bufreader.read_line(&mut line).expect("failed to fill fontmap line");
+        bufreader
+            .read_line(&mut line)
+            .expect("failed to fill fontmap line");
         if line.is_empty() {
             break;
         }
@@ -828,7 +830,8 @@ pub(crate) unsafe fn pdf_load_fontmap_file(filename: &str, mode: i32) -> i32 {
             line.truncate(idx);
         }
 
-        let s = line.trim_start()
+        let s = line
+            .trim_start()
             .trim_end_matches('\n')
             .trim_end_matches('\r');
         if s.is_empty() {

--- a/dpx/src/dpx_pdfencoding.rs
+++ b/dpx/src/dpx_pdfencoding.rs
@@ -225,7 +225,7 @@ unsafe fn load_encoding_file(filename: &str) -> i32 {
     let mut wbuf_0 = vec![0_u8; fsize];
     handle
         .read(&mut wbuf_0[..])
-        .expect(&format!("error reading {}", filename));
+        .unwrap_or_else(|_| panic!("error reading {}", filename));
     let mut p = &wbuf_0[..fsize];
     p.skip_white();
     /*

--- a/dpx/src/dpx_pdfobj.rs
+++ b/dpx/src/dpx_pdfobj.rs
@@ -3483,6 +3483,8 @@ unsafe fn read_xref(pf: &mut pdf_file) -> *mut pdf_obj {
 }
 // HtTable implements defers to a normal std::collections::HashMap
 // but tracks the iteration order of dvipdfmx's ht_table for backwards compat
+// Note: Elements are wrapped in a Box to allow the (highly unsafe!)
+// access pattern of storing .get_mut(x).as_mut_ptr() pointers.
 struct HtTable<T> {
     backing: HashMap<Vec<u8>, Box<T>>,
     compat_iteration_order: HashMap<u32, Vec<Vec<u8>>>,
@@ -3509,7 +3511,7 @@ impl<T> HtTable<T> {
             .wrapping_rem(503)
     }
 
-    fn insert(&mut self, key: Vec<u8>, mut val: Box<T>) {
+    fn insert(&mut self, key: Vec<u8>, val: Box<T>) {
         self.compat_iteration_order
             .entry(Self::hash_key(&key))
             .or_default()

--- a/dpx/src/dpx_pkfont.rs
+++ b/dpx/src/dpx_pkfont.rs
@@ -532,10 +532,12 @@ pub(crate) unsafe fn pdf_font_load_pkfont(font: &mut pdf_font) -> i32 {
     let ident = &*font.ident;
     assert!(!ident.is_empty() && !usedchars.is_null() && point_size > 0.);
     let dpi = truedpi(ident, point_size, base_dpi);
-    let mut fp = dpx_open_pk_font_at(ident, dpi).unwrap_or_else(|| panic!(
-        "Could not find/open PK font file: {} (at {}dpi)",
-        ident, dpi
-    ));
+    let mut fp = dpx_open_pk_font_at(ident, dpi).unwrap_or_else(|| {
+        panic!(
+            "Could not find/open PK font file: {} (at {}dpi)",
+            ident, dpi
+        )
+    });
     memset(charavail.as_mut_ptr() as *mut libc::c_void, 0i32, 256);
     let mut charprocs = pdf_dict::new();
     /* Include bitmap as 72dpi image:

--- a/dpx/src/dpx_pkfont.rs
+++ b/dpx/src/dpx_pkfont.rs
@@ -532,7 +532,7 @@ pub(crate) unsafe fn pdf_font_load_pkfont(font: &mut pdf_font) -> i32 {
     let ident = &*font.ident;
     assert!(!ident.is_empty() && !usedchars.is_null() && point_size > 0.);
     let dpi = truedpi(ident, point_size, base_dpi);
-    let mut fp = dpx_open_pk_font_at(ident, dpi).expect(&format!(
+    let mut fp = dpx_open_pk_font_at(ident, dpi).unwrap_or_else(|| panic!(
         "Could not find/open PK font file: {} (at {}dpi)",
         ident, dpi
     ));

--- a/dpx/src/specials/pdfm.rs
+++ b/dpx/src/specials/pdfm.rs
@@ -1430,11 +1430,7 @@ unsafe fn spc_handler_pdfm_mapline(spe: &mut SpcEnv, ap: &mut SpcArg) -> i32 {
         _ => {
             let s = String::from_utf8(ap.cur.into()).unwrap();
             let mut mrec = pdf_init_fontmap_record();
-            error = pdf_read_fontmap_line(
-                &mut mrec,
-                &s,
-                is_pdfm_mapline(&s),
-            );
+            error = pdf_read_fontmap_line(&mut mrec, &s, is_pdfm_mapline(&s));
             if error != 0 {
                 spc_warn!(spe, "Invalid fontmap line.");
             } else if opchr == b'+' {

--- a/dpx/src/specials/pdfm.rs
+++ b/dpx/src/specials/pdfm.rs
@@ -1428,9 +1428,13 @@ unsafe fn spc_handler_pdfm_mapline(spe: &mut SpcEnv, ap: &mut SpcArg) -> i32 {
             }
         }
         _ => {
-            let buffer = Vec::from(ap.cur);
+            let s = String::from_utf8(ap.cur.into()).unwrap();
             let mut mrec = pdf_init_fontmap_record();
-            error = pdf_read_fontmap_line(&mut mrec, &buffer, is_pdfm_mapline(&buffer));
+            error = pdf_read_fontmap_line(
+                &mut mrec,
+                &s,
+                is_pdfm_mapline(&s),
+            );
             if error != 0 {
                 spc_warn!(spe, "Invalid fontmap line.");
             } else if opchr == b'+' {

--- a/dpx/src/specials/xtx.rs
+++ b/dpx/src/specials/xtx.rs
@@ -209,12 +209,16 @@ unsafe fn spc_handler_xtx_fontmapline(spe: &mut SpcEnv, ap: &mut SpcArg) -> i32 
             }
         }
         _ => {
-            let buffer = Vec::from(ap.cur);
+            let s = String::from_utf8(ap.cur.into()).unwrap();
             let mut mrec = pdf_init_fontmap_record();
-            error = pdf_read_fontmap_line(&mut mrec, &buffer, is_pdfm_mapline(&buffer));
+            error = pdf_read_fontmap_line(
+                &mut mrec,
+                &s,
+                is_pdfm_mapline(&s),
+            );
             if error != 0 {
                 spc_warn!(spe, "Invalid fontmap line.");
-            } else if opchr as i32 == '+' as i32 {
+            } else if opchr == b'+' {
                 pdf_append_fontmap_record(&mrec.map_name, &mrec);
             } else {
                 pdf_insert_fontmap_record(&mrec.map_name, &mrec).ok();

--- a/dpx/src/specials/xtx.rs
+++ b/dpx/src/specials/xtx.rs
@@ -211,11 +211,7 @@ unsafe fn spc_handler_xtx_fontmapline(spe: &mut SpcEnv, ap: &mut SpcArg) -> i32 
         _ => {
             let s = String::from_utf8(ap.cur.into()).unwrap();
             let mut mrec = pdf_init_fontmap_record();
-            error = pdf_read_fontmap_line(
-                &mut mrec,
-                &s,
-                is_pdfm_mapline(&s),
-            );
+            error = pdf_read_fontmap_line(&mut mrec, &s, is_pdfm_mapline(&s));
             if error != 0 {
                 spc_warn!(spe, "Invalid fontmap line.");
             } else if opchr == b'+' {

--- a/engine/src/fmt_file.rs
+++ b/engine/src/fmt_file.rs
@@ -581,24 +581,19 @@ pub(crate) unsafe fn load_fmt_file() -> bool {
 
     yhash = xmalloc_array::<b32x2>((1 + hash_top - hash_offset) as usize);
     hash = yhash.offset(-514);
-    (*hash.offset(HASH_BASE as isize)).s0 = 0;
-    (*hash.offset(HASH_BASE as isize)).s1 = 0;
 
-    x = (HASH_BASE + 1) as i32;
-    while x <= hash_top {
-        *hash.offset(x as isize) = *hash.offset(HASH_BASE as isize);
-        x += 1;
+    for x in HASH_BASE..=(hash_top as usize) {
+        *hash.add(x) = b32x2_le_t { s0: 0, s1: 0 };
     }
 
-    EQTB = vec![EqtbWord::default(); EQTB_TOP + 2];
-    EQTB[UNDEFINED_CONTROL_SEQUENCE as usize].cmd = Cmd::UndefinedCS as _;
-    EQTB[UNDEFINED_CONTROL_SEQUENCE as usize].val = None.tex_int() as _;
-    EQTB[UNDEFINED_CONTROL_SEQUENCE as usize].lvl = LEVEL_ZERO as _;
-
-    x = EQTB_SIZE as i32 + 1;
-    while x <= EQTB_TOP as i32 {
-        EQTB[x as usize] = EQTB[UNDEFINED_CONTROL_SEQUENCE as usize];
-        x += 1;
+    EQTB = Vec::with_capacity(EQTB_TOP+2);
+    unsafe { EQTB.set_len(EQTB_TOP + 2) };
+    for x in EQTB_SIZE..=EQTB_TOP {
+        EQTB[x] = EqtbWord {
+            cmd: Cmd::UndefinedCS as _,
+            val: None.tex_int() as _,
+            lvl: LEVEL_ZERO as _,
+        };
     }
 
     max_reg_num = 32767;
@@ -614,7 +609,10 @@ pub(crate) unsafe fn load_fmt_file() -> bool {
     cur_list.head = CONTRIB_HEAD;
     cur_list.tail = CONTRIB_HEAD;
     page_tail = PAGE_HEAD;
-    MEM = vec![memory_word::default(); MEM_TOP as usize + 2];
+
+
+    MEM = Vec::with_capacity(MEM_TOP+2);
+    unsafe { MEM.set_len(MEM_TOP + 2) };
 
     fmt_in.undump_one(&mut x);
     if x != EQTB_SIZE as i32 {

--- a/engine/src/fmt_file.rs
+++ b/engine/src/fmt_file.rs
@@ -586,7 +586,7 @@ pub(crate) unsafe fn load_fmt_file() -> bool {
         *hash.add(x) = b32x2_le_t { s0: 0, s1: 0 };
     }
 
-    EQTB = Vec::with_capacity(EQTB_TOP+2);
+    EQTB = Vec::with_capacity(EQTB_TOP + 2);
     unsafe { EQTB.set_len(EQTB_TOP + 2) };
     for x in EQTB_SIZE..=EQTB_TOP {
         EQTB[x] = EqtbWord {
@@ -610,8 +610,7 @@ pub(crate) unsafe fn load_fmt_file() -> bool {
     cur_list.tail = CONTRIB_HEAD;
     page_tail = PAGE_HEAD;
 
-
-    MEM = Vec::with_capacity(MEM_TOP+2);
+    MEM = Vec::with_capacity(MEM_TOP + 2);
     unsafe { MEM.set_len(MEM_TOP + 2) };
 
     fmt_in.undump_one(&mut x);

--- a/engine/src/xetex_consts.rs
+++ b/engine/src/xetex_consts.rs
@@ -398,7 +398,7 @@ pub(crate) enum Expr {
 }
 impl From<i32> for Expr {
     fn from(n: i32) -> Self {
-        Self::n(n as i16).expect(&format!("incorrect expression = {}", n))
+        Self::n(n as i16).unwrap_or_else(|| panic!("incorrect expression = {}", n))
     }
 }
 
@@ -631,7 +631,7 @@ pub(crate) enum SaveCmd {
 }
 impl From<u16> for SaveCmd {
     fn from(n: u16) -> Self {
-        Self::n(n as u8).expect(&format!("incorrect save command = {}", n))
+        Self::n(n as u8).unwrap_or_else(|| panic!("incorrect save command = {}", n))
     }
 }
 
@@ -643,7 +643,7 @@ pub(crate) enum BreakType {
 }
 impl From<u16> for BreakType {
     fn from(n: u16) -> Self {
-        Self::n(n).expect(&format!("incorrect break type = {}", n))
+        Self::n(n).unwrap_or_else(|| panic!("incorrect break type = {}", n))
     }
 }
 
@@ -662,7 +662,7 @@ pub(crate) enum ValLevel {
 
 impl From<u8> for ValLevel {
     fn from(n: u8) -> Self {
-        Self::n(n).expect(&format!("incorrect value level = {}", n))
+        Self::n(n).unwrap_or_else(|| panic!("incorrect value level = {}", n))
     }
 }
 
@@ -707,7 +707,7 @@ pub(crate) enum PackMode {
 
 impl From<i32> for PackMode {
     fn from(n: i32) -> Self {
-        Self::n(n as u8).expect(&format!("incorrect PackMode = {}", n))
+        Self::n(n as u8).unwrap_or_else(|| panic!("incorrect PackMode = {}", n))
     }
 }
 
@@ -873,7 +873,7 @@ pub(crate) enum MoveDir {
 }
 impl From<i32> for MoveDir {
     fn from(n: i32) -> Self {
-        Self::n(n).expect(&format!("incorrect move direction = {}", n))
+        Self::n(n).unwrap_or_else(|| panic!("incorrect move direction = {}", n))
     }
 }
 
@@ -897,6 +897,6 @@ pub(crate) enum UnicodeMode {
 }
 impl From<i32> for UnicodeMode {
     fn from(n: i32) -> Self {
-        Self::n(n).expect(&format!("incorrect unicode encoding mode = {}", n))
+        Self::n(n).unwrap_or_else(|| panic!("incorrect unicode encoding mode = {}", n))
     }
 }

--- a/src/engines/mod.rs
+++ b/src/engines/mod.rs
@@ -713,12 +713,12 @@ extern "C" fn input_seek<'a, I: 'a + IoProvider>(
     }
 }
 
-extern "C" fn input_read<'a, I: 'a + IoProvider>(
+fn input_read<'a, I: 'a + IoProvider>(
     es: *mut ExecutionState<'a, I>,
     handle: *mut libc::c_void,
     data: *mut u8,
     len: libc::size_t,
-) -> libc::ssize_t {
+) -> Option<usize> {
     let es = unsafe { &mut *es };
     let rhandle = handle as *mut InputHandle;
     let rdata = unsafe { slice::from_raw_parts_mut(data, len) };
@@ -739,12 +739,12 @@ extern "C" fn input_read<'a, I: 'a + IoProvider>(
         }
     } else {*/
     match es.input_read(rhandle, rdata) {
-        Ok(l) => l as isize,
+        Ok(x) => Some(x),
         Err(e) => {
             if len != 1 {
                 tt_warning!(es.status, "{}-byte read failed", len; e);
             }
-            -1
+            None
         }
     }
     //}

--- a/src/io/cached_itarbundle.rs
+++ b/src/io/cached_itarbundle.rs
@@ -303,7 +303,6 @@ fn load_cache_inner(
 
     let index_path = make_txt_path(index_base, &digest_text);
 
-
     // Let's try to approximate the line count to be able to pre-allocate the hashmap:
     // SourceCodePro-BlackIt.otf 122048 5b5a08844e41c1e639599a32460cc05e74a19829cd38c17ec12ff1cdf072c8ec
     let index_file_size = fs::metadata(&index_path)?.len();


### PR DESCRIPTION
Try to recoup some of the performance lost the C -> Rust conversion. One of the commits introduces uninitialized vectors though so I'll mark this as draft until there's a better solution.
```
  './tectonic-master repro2/1702.05916.tex' ran
    1.02 ± 0.02 times faster than './tectonic-oxidize-post repro2/1702.05916.tex'
    1.23 ± 0.03 times faster than './tectonic-oxidize-pre repro2/1702.05916.tex'
```